### PR TITLE
docs: Add initial documentation and examples for DRA driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,66 @@ Kubernetes Device Resource Assignment (DRA) driver for CPU resources.
 
 This repository implements a DRA driver that enables Kubernetes clusters to manage and assign CPU resources to workloads using the DRA framework.
 
+## How it Works
+
+The driver is deployed as a DaemonSet which contains two core components:
+
+- **DRA driver**: This component is responsible for discovering the CPU topology
+  of the node and reporting the available CPUs as allocatable resources to the
+  Kubernetes scheduler by creating `ResourceSlice` objects. When a resource
+  claim is allocated, the driver generates a CDI (Container Device Interface)
+  specification that tells the container runtime to inject an environment
+  variable with the assigned CPU set into the container.
+
+- **NRI Plugin**: This component integrates with the container runtime via the
+  Node Resource Interface (NRI).
+
+  - For containers with **guaranteed CPUs**, the plugin reads the environment
+    variable injected via CDI and pins the container to its exclusive CPU set.
+  - For all other containers, it confines them to a **shared pool** of CPUs that
+    are not exclusively allocated.
+  - It dynamically updates the shared pool as guaranteed containers are created
+    or removed, ensuring efficient use of resources.
+
+## Feature Support
+
+### Currently Supported
+
+- Exclusive CPU Allocation: Guaranteed pods that request CPUs via a
+  ResourceClaim are allocated exclusive cores.
+- Shared CPU Pool Management: All other containers without a ResourceClaim are
+  confined to a shared pool of CPUs that are not reserved for Guaranteed pods.
+- Handle daemonset restart. On restart, the driver synchronizes with all
+  existing pods on the node to rebuild its state of CPU allocations, ensuring
+  accurate CPU allocation for newly scheduled pods.
+
+### Not Supported
+
+- This driver currently only manages CPU resources. Memory allocation and
+  management are not supported.
+
+## Getting Started
+
+### Installation
+
+- Create a kind cluster
+  - `kind create cluster --config kind.yaml`
+- Deploy the driver and all necessary RBAC configurations using the provided
+  manifest
+  - `kubectl apply -f install.yaml`
+
+### Example Usage
+
+- Create a DeviceClass: This tells Kubernetes how to find the resources provided
+  by this driver.
+  - `kubectl apply -f examples/sample_device_class.yaml`
+- Create a ResourceClaim: This requests a specific number of exclusive CPUs from
+  the driver.
+  - `kubectl apply -f examples/sample_cpu_resource_claims.yaml`
+- Create a Pod: Reference the ResourceClaim in your pod spec to receive the
+  allocated CPUs.
+  - `kubectl apply -f examples/sample_pod_with_cpu_resource_claim.yaml`
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).

--- a/examples/sample_cpu_resource_claims.yaml
+++ b/examples/sample_cpu_resource_claims.yaml
@@ -1,0 +1,21 @@
+apiVersion: resource.k8s.io/v1beta1
+kind: ResourceClaim
+metadata:
+  name: cpu-request-4-cpus
+spec:
+  devices:
+    requests:
+    - name: req-dummy
+      deviceClassName: dra.cpu
+      count: 4
+---
+apiVersion: resource.k8s.io/v1beta1
+kind:  ResourceClaim
+metadata:
+  name: cpu-request-6-cpus
+spec:
+  devices:
+    requests:
+    - name: req-dummy-2
+      deviceClassName: dra.cpu
+      count: 6

--- a/examples/sample_device_class.yaml
+++ b/examples/sample_device_class.yaml
@@ -1,0 +1,8 @@
+apiVersion: resource.k8s.io/v1beta1
+kind: DeviceClass
+metadata:
+  name: dra.cpu
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "dra.cpu"

--- a/examples/sample_pod_with_cpu_resource_claim.yaml
+++ b/examples/sample_pod_with_cpu_resource_claim.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-app-with-dra-cpu
+spec:
+  containers:
+    - name: container1
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        requests:
+          cpu: "4"
+        limits:
+          cpu: "4"
+        claims:
+          - name: "container1-claim"
+    - name: container2
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        requests:
+          cpu: "6"
+        limits:
+          cpu: "6"
+        claims:
+          - name: "container2-claim"
+  resourceClaims:
+    - name: "container1-claim"
+      resourceClaimName: cpu-request-4-cpus
+    - name: "container2-claim"
+      resourceClaimName: cpu-request-6-cpus

--- a/install.yaml
+++ b/install.yaml
@@ -1,0 +1,189 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dracpu
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceslices
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims
+      - deviceclasses
+    verbs:
+      - get
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dracpu
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dracpu
+subjects:
+- kind: ServiceAccount
+  name: dracpu
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dracpu
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dracpu
+  namespace: kube-system
+  labels:
+    tier: node
+    app: dracpu
+    k8s-app: dracpu
+spec:
+  selector:
+    matchLabels:
+      app: dracpu
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: dracpu
+        k8s-app: dracpu
+    spec:
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: dracpu
+      hostPID: true
+      initContainers:
+      - name: enable-nri
+        image: busybox:stable
+        volumeMounts:
+        - mountPath: /etc
+          name: etc
+        securityContext:
+          privileged: true
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -o errexit
+          set -o pipefail
+          set -o nounset
+          set -x
+          if grep -q "io.containerd.nri.v1.nri" /etc/containerd/config.toml
+          then
+             echo "containerd config contains NRI reference already; taking no action"
+          else
+             echo "containerd config does not mention NRI, thus enabling it";
+             printf '%s\n' "[plugins.\"io.containerd.nri.v1.nri\"]" "  disable = false" "  disable_connections = false" "  plugin_config_path = \"/etc/nri/conf.d\"" "  plugin_path = \"/opt/nri/plugins\"" "  plugin_registration_timeout = \"5s\"" "  plugin_request_timeout = \"5s\"" "  socket_path = \"/var/run/nri/nri.sock\"" >> /etc/containerd/config.toml
+             echo "restarting containerd"
+             nsenter -t 1 -m -u -i -n -p -- systemctl restart containerd
+          fi
+      containers:
+      - name: dracpu
+        args:
+        - /dracpu
+        - --v=4
+        image: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "SYS_ADMIN"]
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/plugins
+        - name: plugin-registry
+          mountPath: /var/lib/kubelet/plugins_registry
+        - name: nri-plugin
+          mountPath: /var/run/nri
+        - name: pod-resources-socket
+          mountPath: /var/lib/kubelet/pod-resources
+          readOnly: true
+        - name: cdi-dir
+          mountPath: /var/run/cdi
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/plugins
+      - name: plugin-registry
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+      - name: nri-plugin
+        hostPath:
+          path: /var/run/nri
+      - name: netns
+        hostPath:
+          path: /var/run/netns
+      - name: infiniband
+        hostPath:
+          path: /dev/infiniband
+      - name: etc
+        hostPath:
+          path: /etc
+      - name: pod-resources-socket
+        hostPath:
+          path: /var/lib/kubelet/pod-resources
+      - name: cdi-dir
+        hostPath:
+          path: /var/run/cdi
+          type: DirectoryOrCreate
+---
+apiVersion: resource.k8s.io/v1beta1
+kind: DeviceClass
+metadata:
+  name: dra.cpu
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "dra.cpu"

--- a/kind.yaml
+++ b/kind.yaml
@@ -1,0 +1,56 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.33.1
+  kubeadmConfigPatches:
+  # Enable the corresponding version of the resource.k8s.io API
+  - |
+    kind: ClusterConfiguration
+    scheduler:
+        extraArgs:
+          v: "5"
+          vmodule: "allocator=6,dynamicresources=6" # structured/allocator.go, DRA scheduler plugin
+    controllerManager:
+        extraArgs:
+          v: "5"
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"
+- role: worker
+  image: kindest/node:v1.33.1
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"
+- role: worker
+  image: kindest/node:v1.33.1
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"
+featureGates:
+  # Enable the corresponding DRA feature gates
+  DynamicResourceAllocation: true
+  DRAResourceClaimDeviceStatus: true
+runtimeConfig:
+  api/beta : true


### PR DESCRIPTION
  This PR adds documentation and example usage for the DRA CPU driver.

   - Updates README.md with "How it Works", "Feature Support", and "Getting Started" sections.
   - Adds example manifests for DeviceClass, ResourceClaim, and a sample Pod.
   - Includes install.yaml for deployment and kind.yaml for setting up a test environment.