### PR TITLE
manifests: update to resourceapi v1

### DIFF
--- a/hack/examples/sample_cpu_resource_claims.yaml
+++ b/hack/examples/sample_cpu_resource_claims.yaml
@@ -6,8 +6,9 @@ spec:
   devices:
     requests:
     - name: req-dummy
-      deviceClassName: dra.cpu
-      count: 4
+      exactly:
+        deviceClassName: dra.cpu
+        count: 4
 ---
 apiVersion: resource.k8s.io/v1
 kind:  ResourceClaim
@@ -17,5 +18,6 @@ spec:
   devices:
     requests:
     - name: req-dummy-2
-      deviceClassName: dra.cpu
-      count: 6
+      exactly:
+        deviceClassName: dra.cpu
+        count: 6


### PR DESCRIPTION
the API actually changed between v1beta1 and v1beta2 Now the manifests work out of the box against kube 1.34 (w/ kind 0.30).

complements: #17 