### PR TITLE
feat: Add support for excluding certain CPUs from ResourceSlice

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The driver is deployed as a DaemonSet which contains two core components:
 
 The driver can be configured with the following command-line flag:
 
-- `--reserved-cpus`: Specifies a set of CPUs to be reserved for system and kubelet processes. These CPUs will not be allocatable by the DRA driver. The value is a cpuset, e.g., `0-1`.
+- `--reserved-cpus`: Specifies a set of CPUs to be reserved for system and kubelet processes. These CPUs will not be allocatable by the DRA driver and would be excluded from the `ResourceSlice`. The value is a cpuset, e.g., `0-1`. This semantic is the same as the one the kubelet applies with its `static` CPU Manager policy and enabling [`strict-cpu-reservation`](https://kubernetes.io/blog/2024/12/16/cpumanager-strict-cpu-reservation/) flag and specifying the CPUs with the [`reservedSystemCPUs`](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list) to be reserved for system daemons. For correct CPU accounting, the number of CPUs reserved with this flag should match the sum of the kubelet's `kubeReserved` and `systemReserved` settings. This ensures the kubelet subtracts the correct number of CPUs from `Node.Status.Allocatable`.
 
 ## Feature Support
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The driver is deployed as a DaemonSet which contains two core components:
   - It dynamically updates the shared pool as guaranteed containers are created
     or removed, ensuring efficient use of resources.
 
+## Configuration
+
+The driver can be configured with the following command-line flag:
+
+- `--reserved-cpus`: Specifies a set of CPUs to be reserved for system and kubelet processes. These CPUs will not be allocatable by the DRA driver. The value is a cpuset, e.g., `0-1`.
+
 ## Feature Support
 
 ### Currently Supported

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -52,7 +52,7 @@ var (
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&hostnameOverride, "hostname-override", "", "If non-empty, will be used as the name of the Node that kube-network-policies is running on. If unset, the node name is assumed to be the same as the node's hostname.")
-	flag.StringVar(&reservedCPUs, "reserved-cpus", "", "cpuset of CPUs to reserve. These CPUs are excluded from the ResourceSlice and will not be allocated to workloads. This configuration serves the same purpose as `kubeReserved` and `systemReserved` flags in Kubelet to reserve CPUs for system daemons (https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved). In order for CPU accounting to work correctly, the number of CPUs being reserved with this flag should match the kubelet settings (`kubeReserved` + `systemReserved`).")
+	flag.StringVar(&reservedCPUs, "reserved-cpus", "", "cpuset of CPUs to be excluded from ResourceSlice.")
 }
 
 func main() {
@@ -132,7 +132,12 @@ func main() {
 	}()
 	signal.Notify(signalCh, os.Interrupt, unix.SIGINT)
 
-	dracpu, err := driver.Start(ctx, driverName, clientset, nodeName, reservedCPUSet)
+	driverConfig := &driver.Config{
+		DriverName:   driverName,
+		NodeName:     nodeName,
+		ReservedCPUs: reservedCPUSet,
+	}
+	dracpu, err := driver.Start(ctx, clientset, driverConfig)
 	if err != nil {
 		klog.Fatalf("driver failed to start: %v", err)
 	}

--- a/pkg/driver/cpu_allocation_store.go
+++ b/pkg/driver/cpu_allocation_store.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/cpuset"
+)
+
+// CPUAllocationStore is the single source of truth for CPU allocations.
+type CPUAllocationStore struct {
+	mu                       sync.RWMutex
+	allCPUs                  cpuset.CPUSet
+	resourceClaimAllocations map[types.UID]cpuset.CPUSet
+}
+
+// NewCPUAllocationStore creates a new CPUAllocationStore.
+func NewCPUAllocationStore(provider CPUInfoProvider) *CPUAllocationStore {
+	cpuIDs := []int{}
+	cpuInfo, err := provider.GetCPUInfos()
+	if err != nil {
+		klog.Fatalf("Fatal error getting CPU topology: %v", err)
+	}
+	for _, cpu := range cpuInfo {
+		cpuIDs = append(cpuIDs, cpu.CpuID)
+	}
+	allCPUs := cpuset.New(cpuIDs...)
+	return &CPUAllocationStore{
+		allCPUs:                  allCPUs,
+		resourceClaimAllocations: make(map[types.UID]cpuset.CPUSet),
+	}
+}
+
+// AddResourceClaimAllocation adds a new resource claim allocation to the store.
+func (s *CPUAllocationStore) AddResourceClaimAllocation(claimUID types.UID, cpus cpuset.CPUSet) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resourceClaimAllocations[claimUID] = cpus
+	klog.Infof("Added allocation for resource claim %s: CPUs %s", claimUID, cpus.String())
+}
+
+// RemoveResourceClaimAllocation removes a resource claim allocation from the store.
+func (s *CPUAllocationStore) RemoveResourceClaimAllocation(claimUID types.UID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.resourceClaimAllocations[claimUID]; ok {
+		delete(s.resourceClaimAllocations, claimUID)
+		klog.Infof("Removed allocation for resource claim %s", claimUID)
+	}
+}
+
+// GetSharedCPUs calculates and returns the set of CPUs not reserved by any resource claim.
+func (s *CPUAllocationStore) GetSharedCPUs() cpuset.CPUSet {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	allocatedCPUs := cpuset.New()
+	for _, cpus := range s.resourceClaimAllocations {
+		allocatedCPUs = allocatedCPUs.Union(cpus)
+	}
+	return s.allCPUs.Difference(allocatedCPUs)
+}

--- a/pkg/driver/cpu_allocation_store.go
+++ b/pkg/driver/cpu_allocation_store.go
@@ -53,6 +53,7 @@ func NewCPUAllocationStore(provider CPUInfoProvider, reservedCPUs cpuset.CPUSet)
 }
 
 // AddResourceClaimAllocation adds a new resource claim allocation to the store.
+// TODO(pravk03): Keep track of all allocated CPUs here so that GetSharedCPUs() can return in O(1).
 func (s *CPUAllocationStore) AddResourceClaimAllocation(claimUID types.UID, cpus cpuset.CPUSet) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -80,4 +81,12 @@ func (s *CPUAllocationStore) GetSharedCPUs() cpuset.CPUSet {
 		allocatedCPUs = allocatedCPUs.Union(cpus)
 	}
 	return s.availableCPUs.Difference(allocatedCPUs)
+}
+
+// GetResourceClaimAllocation returns the cpuset for a given resource claim.
+func (s *CPUAllocationStore) GetResourceClaimAllocation(claimUID types.UID) (cpuset.CPUSet, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cpus, ok := s.resourceClaimAllocations[claimUID]
+	return cpus, ok
 }

--- a/pkg/driver/cpu_allocation_store_test.go
+++ b/pkg/driver/cpu_allocation_store_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/cpuset"
+)
+
+func newTestCPUAllocationStore() (*CPUAllocationStore, cpuset.CPUSet) {
+	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
+	var infos []cpuinfo.CPUInfo
+	for _, cpuID := range allCPUs.UnsortedList() {
+		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NumaNode: 0})
+	}
+	mockProvider := &mockCPUInfoProvider{cpuInfos: infos}
+	return NewCPUAllocationStore(mockProvider), allCPUs
+}
+
+func TestCPUAllocationStoreResourceClaimAllocation(t *testing.T) {
+	store, _ := newTestCPUAllocationStore()
+	claimUID := types.UID("claim-uid-1")
+	cpus := cpuset.New(0, 1)
+
+	// Add allocation
+	store.AddResourceClaimAllocation(claimUID, cpus)
+	require.Contains(t, store.resourceClaimAllocations, claimUID)
+	require.True(t, store.resourceClaimAllocations[claimUID].Equals(cpus))
+
+	// Remove allocation
+	store.RemoveResourceClaimAllocation(claimUID)
+	require.NotContains(t, store.resourceClaimAllocations, claimUID)
+
+	// Remove non-existent allocation
+	store.RemoveResourceClaimAllocation(types.UID("non-existent"))
+}
+
+func TestCPUAllocationStoreGetSharedCPUs(t *testing.T) {
+	store, allCPUs := newTestCPUAllocationStore()
+
+	// No allocations
+	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
+
+	// With allocations
+	claimUID1 := types.UID("claim-uid-1")
+	cpus1 := cpuset.New(1, 2)
+	store.AddResourceClaimAllocation(claimUID1, cpus1)
+	expectedShared := allCPUs.Difference(cpus1)
+	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
+
+	claimUID2 := types.UID("claim-uid-2")
+	cpus2 := cpuset.New(3, 4)
+	store.AddResourceClaimAllocation(claimUID2, cpus2)
+	expectedShared = expectedShared.Difference(cpus2)
+	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -56,16 +56,17 @@ type CPUInfoProvider interface {
 
 // CPUDriver is the structure that holds all the driver runtime information.
 type CPUDriver struct {
-	driverName        string
-	nodeName          string
-	kubeClient        kubernetes.Interface
-	draPlugin         KubeletPlugin
-	nriPlugin         stub.Stub
-	podConfigStore    *PodConfigStore
-	cdiMgr            cdiManager
-	cpuIDToDeviceName map[int]string
-	deviceNameToCPUID map[string]int
-	cpuInfoProvider   CPUInfoProvider
+	driverName         string
+	nodeName           string
+	kubeClient         kubernetes.Interface
+	draPlugin          KubeletPlugin
+	nriPlugin          stub.Stub
+	podConfigStore     *PodConfigStore
+	cdiMgr             cdiManager
+	cpuIDToDeviceName  map[int]string
+	deviceNameToCPUID  map[string]int
+	cpuInfoProvider    CPUInfoProvider
+	cpuAllocationStore *CPUAllocationStore
 }
 
 // Start creates and starts a new CPUDriver.
@@ -78,7 +79,8 @@ func Start(ctx context.Context, driverName string, kubeClient kubernetes.Interfa
 		deviceNameToCPUID: make(map[string]int),
 		cpuInfoProvider:   cpuinfo.NewSystemCPUInfo(),
 	}
-	plugin.podConfigStore = NewPodConfigStore(plugin.cpuInfoProvider)
+	plugin.cpuAllocationStore = NewCPUAllocationStore(plugin.cpuInfoProvider)
+	plugin.podConfigStore = NewPodConfigStore()
 
 	driverPluginPath := filepath.Join(kubeletPluginPath, driverName)
 	if err := os.MkdirAll(driverPluginPath, 0750); err != nil {

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -38,7 +38,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	klog.Infof("Synchronized state with the runtime (%d pods, %d containers)...",
 		len(pods), len(containers))
 
-	cpuAllocationStore := NewCPUAllocationStore(cp.cpuInfoProvider)
+	cpuAllocationStore := NewCPUAllocationStore(cp.cpuInfoProvider, cp.reservedCPUs)
 	podConfigStore := NewPodConfigStore()
 
 	for _, pod := range pods {

--- a/pkg/driver/pod_store.go
+++ b/pkg/driver/pod_store.go
@@ -19,96 +19,53 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
-	"k8s.io/utils/cpuset"
 )
 
-// CPUType defines whether the CPU allocation is for a Guaranteed or BestEffort container.
-type CPUType string
-
-const (
-	// CPUTypeGuaranteed is for containers with guaranteed CPU allocation.
-	CPUTypeGuaranteed CPUType = "Guaranteed"
-	// CPUTypeShared is for containers with shared CPU allocation.
-	CPUTypeShared CPUType = "Shared"
-)
-
-// ContainerCPUState holds the CPU allocation type and all claim assignments for a container.
-type ContainerCPUState struct {
-	cpuType       CPUType
-	containerName string
-	containerUID  types.UID
-	// updated if cpuType is CPUTypeGuaranteed
-	guaranteedCPUs cpuset.CPUSet
+// ContainerState holds the allocation type and all claim assignments for a container.
+type ContainerState struct {
+	containerName     string
+	containerUID      types.UID
+	resourceClaimUIDs []types.UID
 }
 
-// NewContainerCPUState creates a new ContainerCPUState.
-func NewContainerCPUState(cpuType CPUType, containerName string, containerUID types.UID, guaranteedCPUs cpuset.CPUSet) *ContainerCPUState {
-	return &ContainerCPUState{
-		cpuType:        cpuType,
-		containerName:  containerName,
-		containerUID:   containerUID,
-		guaranteedCPUs: guaranteedCPUs,
+// NewContainerState creates a new ContainerState.
+func NewContainerState(containerName string, containerUID types.UID, claimUIDs []types.UID) *ContainerState {
+	return &ContainerState{
+		containerName:     containerName,
+		containerUID:      containerUID,
+		resourceClaimUIDs: claimUIDs,
 	}
 }
 
-// PodCPUAssignments maps a container name to its CPU state.
-type PodCPUAssignments map[string]*ContainerCPUState
+// PodCPUAssignments maps a container name to its state.
+type PodCPUAssignments map[string]*ContainerState
 
-// PodConfigStore maps a Pod's UID directly to its container-level CPU assignments.
+// PodConfigStore maps a Pod's UID directly to its container-level assignments.
 type PodConfigStore struct {
-	mu         sync.RWMutex
-	configs    map[types.UID]PodCPUAssignments
-	allCPUs    cpuset.CPUSet
-	publicCPUs cpuset.CPUSet
+	mu      sync.RWMutex
+	configs map[types.UID]PodCPUAssignments
 }
 
 // NewPodConfigStore creates a new PodConfigStore.
-func NewPodConfigStore(provider CPUInfoProvider) *PodConfigStore {
-	cpuIDs := []int{}
-	cpuInfo, err := provider.GetCPUInfos()
-	if err != nil {
-		klog.Fatalf("Fatal error getting CPU topology: %v", err)
-	}
-	for _, cpu := range cpuInfo {
-		cpuIDs = append(cpuIDs, cpu.CpuID)
-	}
-
-	allCPUsSet := cpuset.New(cpuIDs...)
-
+func NewPodConfigStore() *PodConfigStore {
 	return &PodConfigStore{
-		configs:    make(map[types.UID]PodCPUAssignments),
-		allCPUs:    allCPUsSet,
-		publicCPUs: allCPUsSet.Clone(),
+		configs: make(map[types.UID]PodCPUAssignments),
 	}
 }
 
-// SetContainerState records or updates a container's CPU allocation using a state object.
-func (s *PodConfigStore) SetContainerState(podUID types.UID, state *ContainerCPUState) {
+// SetContainerState records or updates a container's allocation using a state object.
+func (s *PodConfigStore) SetContainerState(podUID types.UID, state *ContainerState) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if _, ok := s.configs[podUID]; !ok {
 		s.configs[podUID] = make(PodCPUAssignments)
 	}
-
-	// Use the container name from the state object as the map key.
 	s.configs[podUID][state.containerName] = state
-
-	if state.cpuType == CPUTypeGuaranteed {
-		// Recalculate public CPUs after any change that could affect guaranteed CPUs.
-		s.recalculatePublicCPUs()
-	}
-
-	if state.cpuType == CPUTypeGuaranteed {
-		klog.Infof("Set Guaranteed CPUs for PodUID:%v Container:%s guaranteedCPUs:%v", podUID, state.containerName, state.guaranteedCPUs.String())
-	} else {
-		klog.Infof("Set PodUID:%v Container:%s to Shared", podUID, state.containerName)
-	}
 }
 
-// GetContainerState retrieves a container's CPU state.
-func (s *PodConfigStore) GetContainerState(podUID types.UID, containerName string) *ContainerCPUState {
+// GetContainerState retrieves a container's state.
+func (s *PodConfigStore) GetContainerState(podUID types.UID, containerName string) *ContainerState {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -128,35 +85,29 @@ func (s *PodConfigStore) RemoveContainerState(podUID types.UID, containerName st
 		return
 	}
 
-	state, ok := podAssignments[containerName]
-	if !ok {
-		return
-	}
-
-	klog.Infof("Removing container state for %s from PodUID %v", containerName, podUID)
 	delete(podAssignments, containerName)
 
-	// If this was the last container for the pod, clean up the pod entry itself.
 	if len(podAssignments) == 0 {
 		delete(s.configs, podUID)
 	}
-
-	// If a guaranteed container was removed, its CPUs must be returned to the public pool.
-	if state.cpuType == CPUTypeGuaranteed {
-		s.recalculatePublicCPUs()
-		klog.Infof("Recalculated public CPUs after removing guaranteed container.")
-	}
 }
 
-// GetContainersWithSharedCPUs returns a list of container UIDs that have shared CPU allocation.
-// TODO(pravk03): Cache this and return in O(1).
-func (s *PodConfigStore) GetContainersWithSharedCPUs() []types.UID {
+// DeletePodState removes a pod's state from the store.
+func (s *PodConfigStore) DeletePodState(podUID types.UID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.configs, podUID)
+}
+
+// GetSharedCPUContainerUIDs returns a list of container UIDs that have shared CPU allocation.
+// TODO(pravk03): Cache this and return from this function in O(1)
+func (s *PodConfigStore) GetSharedCPUContainerUIDs() []types.UID {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	sharedCPUContainers := []types.UID{}
 	for _, podAssignments := range s.configs {
 		for _, state := range podAssignments {
-			if state.cpuType == CPUTypeShared {
+			if !state.IsGuaranteed() {
 				sharedCPUContainers = append(sharedCPUContainers, state.containerUID)
 			}
 		}
@@ -164,78 +115,21 @@ func (s *PodConfigStore) GetContainersWithSharedCPUs() []types.UID {
 	return sharedCPUContainers
 }
 
-// IsContainerGuaranteed checks if the container has a guaranteed CPU allocation.
-func (s *PodConfigStore) IsContainerGuaranteed(podUID types.UID, containerName string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	podAssignments, ok := s.configs[podUID]
-	if !ok {
-		klog.Warningf("Pod with UID %v not found in PodConfigStore", podUID)
-		return false
-	}
-
-	containerState, ok := podAssignments[containerName]
-	if !ok {
-		klog.Warningf("Container %s not found in Pod %v in PodConfigStore", containerName, podUID)
-		return false
-	}
-	return containerState.cpuType == CPUTypeGuaranteed
+// IsGuaranteed returns true if the container has a guaranteed CPU allocation.
+func (cs *ContainerState) IsGuaranteed() bool {
+	return len(cs.resourceClaimUIDs) > 0
 }
 
-// IsPodGuaranteed checks if any container in the pod has a guaranteed CPU allocation.
+// IsPodGuaranteed returns true if any container in the pod has a guaranteed CPU allocation.
 func (s *PodConfigStore) IsPodGuaranteed(podUID types.UID) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	podAssignments, ok := s.configs[podUID]
-	if !ok {
-		klog.Warningf("Pod with UID %v not found in PodConfigStore", podUID)
-		return false
-	}
-
-	for _, state := range podAssignments {
-		if state.cpuType == CPUTypeGuaranteed {
-			return true
-		}
-	}
-	return false
-}
-
-// GetPublicCPUs calculates and returns the list of CPUs not reserved by any Guaranteed containers.
-// This is the pool available for Shared containers.
-func (s *PodConfigStore) GetPublicCPUs() cpuset.CPUSet {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.publicCPUs
-}
-
-func (s *PodConfigStore) recalculatePublicCPUs() {
-	guaranteedCPUs := cpuset.New()
-	for _, podAssignments := range s.configs {
+	if podAssignments, ok := s.configs[podUID]; ok {
 		for _, state := range podAssignments {
-			if state.cpuType == CPUTypeGuaranteed {
-				guaranteedCPUs = guaranteedCPUs.Union(state.guaranteedCPUs)
+			if state.IsGuaranteed() {
+				return true
 			}
 		}
 	}
-	s.publicCPUs = s.allCPUs.Difference(guaranteedCPUs)
-}
-
-// DeletePodState removes a pod's state from the store.
-func (s *PodConfigStore) DeletePodState(podUID types.UID) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.configs[podUID]; !ok {
-		return
-	}
-	recalculatePublicCPUs := false
-	for _, state := range s.configs[podUID] {
-		if state.cpuType == CPUTypeGuaranteed {
-			recalculatePublicCPUs = true
-			break
-		}
-	}
-	delete(s.configs, podUID)
-	if recalculatePublicCPUs {
-		s.recalculatePublicCPUs()
-	}
+	return false
 }

--- a/pkg/driver/pod_store_test.go
+++ b/pkg/driver/pod_store_test.go
@@ -19,31 +19,15 @@ package driver
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/cpuset"
 )
 
-func newPodConfigStore(t *testing.T) (*PodConfigStore, cpuset.CPUSet) {
-	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
-	var infos []cpuinfo.CPUInfo
-	for _, cpuID := range allCPUs.UnsortedList() {
-		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NumaNode: 0})
-	}
-	mockProvider := &mockCPUInfoProvider{cpuInfos: infos}
-	store := NewPodConfigStore(mockProvider)
-	require.NotNil(t, store)
-	require.True(t, store.allCPUs.Equals(allCPUs))
-	require.True(t, store.publicCPUs.Equals(allCPUs))
-	return store, allCPUs
-}
-
-func TestContainerState(t *testing.T) {
-	store, _ := newPodConfigStore(t)
+func TestSetAndGetContainerState(t *testing.T) {
+	store := NewPodConfigStore()
 	podUID := types.UID("pod-uid-1")
 	ctrName := "ctr-name-1"
-	state := NewContainerCPUState(CPUTypeGuaranteed, ctrName, "ctr-id-1", cpuset.New(0, 1))
+	state := NewContainerState(ctrName, "ctr-uid-1", []types.UID{"claim-uid-1"})
 
 	// Get non-existent state
 	require.Nil(t, store.GetContainerState(podUID, ctrName))
@@ -55,37 +39,41 @@ func TestContainerState(t *testing.T) {
 }
 
 func TestRemoveContainerState(t *testing.T) {
-	store, allCPUs := newPodConfigStore(t)
+	store := NewPodConfigStore()
 	podUID := types.UID("pod-uid-1")
-	ctrName := "ctr-name-1"
-	guaranteedCPUs := cpuset.New(0, 1)
-	guaranteedState := NewContainerCPUState(CPUTypeGuaranteed, ctrName, "ctr-id-1", guaranteedCPUs)
+	ctrName1 := "ctr-name-1"
+	ctrName2 := "ctr-name-2"
+	state1 := NewContainerState(ctrName1, "ctr-uid-1", []types.UID{"claim-uid-1"})
+	state2 := NewContainerState(ctrName2, "ctr-uid-2", nil)
 
-	// Setup: add a container
-	store.SetContainerState(podUID, guaranteedState)
-	publicCPUs := store.GetPublicCPUs()
-	require.False(t, publicCPUs.Equals(allCPUs), "Public CPUs should be reduced")
-	require.True(t, publicCPUs.Equals(allCPUs.Difference(guaranteedCPUs)), "Public CPUs should exclude guaranteed CPUs")
+	// Setup: add a pod with two containers
+	store.SetContainerState(podUID, state1)
+	store.SetContainerState(podUID, state2)
+	require.NotNil(t, store.GetContainerState(podUID, ctrName1))
+	require.NotNil(t, store.GetContainerState(podUID, ctrName2))
 
-	// Remove container
-	store.RemoveContainerState(podUID, ctrName)
-	require.Nil(t, store.GetContainerState(podUID, ctrName))
-	require.True(t, store.GetPublicCPUs().Equals(allCPUs), "Public CPUs should be restored")
+	// Remove one container
+	store.RemoveContainerState(podUID, ctrName1)
+	require.Nil(t, store.GetContainerState(podUID, ctrName1))
+	require.NotNil(t, store.GetContainerState(podUID, ctrName2), "other container should still exist")
+
+	// Remove the second container, which should remove the pod entry
+	store.RemoveContainerState(podUID, ctrName2)
+	require.Nil(t, store.GetContainerState(podUID, ctrName2))
+	_, podExists := store.configs[podUID]
+	require.False(t, podExists, "pod entry should be gone after last container is removed")
 
 	// Remove non-existent container, should not panic
 	store.RemoveContainerState(podUID, "non-existent-ctr")
-	require.True(t, store.GetPublicCPUs().Equals(allCPUs))
 }
 
 func TestDeletePodState(t *testing.T) {
-	store, allCPUs := newPodConfigStore(t)
+	store := NewPodConfigStore()
 	podUID := types.UID("pod-uid-1")
-	guaranteedState := NewContainerCPUState(CPUTypeGuaranteed, "ctr-1", "id-1", cpuset.New(0, 1))
-	sharedState := NewContainerCPUState(CPUTypeShared, "ctr-2", "id-2", cpuset.New())
+	state := NewContainerState("ctr-1", "id-1", []types.UID{"claim-uid-1"})
 
-	// Setup: add a pod with two containers
-	store.SetContainerState(podUID, guaranteedState)
-	store.SetContainerState(podUID, sharedState)
+	// Setup: add a pod
+	store.SetContainerState(podUID, state)
 	_, podExists := store.configs[podUID]
 	require.True(t, podExists)
 
@@ -93,16 +81,15 @@ func TestDeletePodState(t *testing.T) {
 	store.DeletePodState(podUID)
 	_, podExists = store.configs[podUID]
 	require.False(t, podExists)
-	require.True(t, store.GetPublicCPUs().Equals(allCPUs), "Public CPUs should be restored")
 
 	// Deleting non-existent pod should be a no-op
 	store.DeletePodState(podUID)
 }
 
-func TestGetContainersWithSharedCPUs(t *testing.T) {
-	sharedState1 := NewContainerCPUState(CPUTypeShared, "c1", "id1", cpuset.New())
-	sharedState2 := NewContainerCPUState(CPUTypeShared, "c2", "id2", cpuset.New())
-	guaranteedState := NewContainerCPUState(CPUTypeGuaranteed, "c3", "id3", cpuset.New(2, 3))
+func TestGetSharedCPUContainerUIDs(t *testing.T) {
+	sharedState1 := NewContainerState("c1", "id1", nil)
+	sharedState2 := NewContainerState("c2", "id2", nil)
+	guaranteedState := NewContainerState("c3", "id3", []types.UID{"claim-uid-1"})
 
 	testCases := []struct {
 		name     string
@@ -134,46 +121,72 @@ func TestGetContainersWithSharedCPUs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			store, _ := newPodConfigStore(t)
+			store := NewPodConfigStore()
 			tc.setup(store)
-			gotUIDs := store.GetContainersWithSharedCPUs()
+			gotUIDs := store.GetSharedCPUContainerUIDs()
 			require.ElementsMatch(t, tc.wantUIDs, gotUIDs)
 		})
 	}
 }
 
-func TestIsContainerGuaranteed(t *testing.T) {
-	store, _ := newPodConfigStore(t)
-	podUID := types.UID("pod-uid-1")
-	guaranteedCtr := "guaranteed-ctr"
-	sharedCtr := "shared-ctr"
-	store.SetContainerState(podUID, NewContainerCPUState(CPUTypeGuaranteed, guaranteedCtr, "id1", cpuset.New(0, 1)))
-	store.SetContainerState(podUID, NewContainerCPUState(CPUTypeShared, sharedCtr, "id2", cpuset.New()))
-
-	require.True(t, store.IsContainerGuaranteed(podUID, guaranteedCtr))
-	require.False(t, store.IsContainerGuaranteed(podUID, sharedCtr))
-	require.False(t, store.IsContainerGuaranteed(podUID, "non-existent-ctr"))
-	require.False(t, store.IsContainerGuaranteed("non-existent-pod", guaranteedCtr))
-}
-
 func TestIsPodGuaranteed(t *testing.T) {
-	store, _ := newPodConfigStore(t)
-	guaranteedPod := types.UID("guaranteed-pod")
-	sharedPod := types.UID("shared-pod")
-	mixedPod := types.UID("mixed-pod")
+	guaranteedState := NewContainerState("guaranteed-ctr", "gid1", []types.UID{"claim-uid-1"})
+	sharedState := NewContainerState("shared-ctr", "sid1", nil)
 
-	// Pod with only guaranteed containers
-	store.SetContainerState(guaranteedPod, NewContainerCPUState(CPUTypeGuaranteed, "c1", "id1", cpuset.New(0, 1)))
+	testCases := []struct {
+		name           string
+		podUID         types.UID
+		setup          func(s *PodConfigStore)
+		wantGuaranteed bool
+	}{
+		{
+			name:           "pod not in store",
+			podUID:         "non-existent-pod",
+			setup:          func(s *PodConfigStore) {},
+			wantGuaranteed: false,
+		},
+		{
+			name:   "pod with only shared containers",
+			podUID: "pod1",
+			setup: func(s *PodConfigStore) {
+				s.SetContainerState("pod1", sharedState)
+			},
+			wantGuaranteed: false,
+		},
+		{
+			name:   "pod with only guaranteed containers",
+			podUID: "pod1",
+			setup: func(s *PodConfigStore) {
+				s.SetContainerState("pod1", guaranteedState)
+			},
+			wantGuaranteed: true,
+		},
+		{
+			name:   "pod with mixed containers",
+			podUID: "pod1",
+			setup: func(s *PodConfigStore) {
+				s.SetContainerState("pod1", sharedState)
+				s.SetContainerState("pod1", guaranteedState)
+			},
+			wantGuaranteed: true,
+		},
+		{
+			name:   "pod with multiple shared containers",
+			podUID: "pod1",
+			setup: func(s *PodConfigStore) {
+				s.SetContainerState("pod1", NewContainerState("c1", "id1", nil))
+				s.SetContainerState("pod1", NewContainerState("c2", "id2", nil))
+			},
+			wantGuaranteed: false,
+		},
+	}
 
-	// Pod with only shared containers
-	store.SetContainerState(sharedPod, NewContainerCPUState(CPUTypeShared, "c2", "id2", cpuset.New()))
-
-	// Pod with both guaranteed and shared containers
-	store.SetContainerState(mixedPod, NewContainerCPUState(CPUTypeGuaranteed, "c3", "id3", cpuset.New(2, 3)))
-	store.SetContainerState(mixedPod, NewContainerCPUState(CPUTypeShared, "c4", "id4", cpuset.New()))
-
-	// A pod is considered guaranteed if it has at least one guaranteed container.
-	require.True(t, store.IsPodGuaranteed(guaranteedPod))
-	require.False(t, store.IsPodGuaranteed(sharedPod))
-	require.True(t, store.IsPodGuaranteed(mixedPod))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewPodConfigStore()
+			tc.setup(store)
+			gotGuaranteed := store.IsPodGuaranteed(tc.podUID)
+			require.Equal(t, tc.wantGuaranteed, gotGuaranteed)
+		})
+	}
 }

--- a/pkg/driver/pod_store_test.go
+++ b/pkg/driver/pod_store_test.go
@@ -123,13 +123,13 @@ func TestGetSharedCPUContainerUIDs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			store := NewPodConfigStore()
 			tc.setup(store)
-			gotUIDs := store.GetSharedCPUContainerUIDs()
+			gotUIDs := store.GetContainersWithSharedCPUs()
 			require.ElementsMatch(t, tc.wantUIDs, gotUIDs)
 		})
 	}
 }
 
-func TestIsPodGuaranteed(t *testing.T) {
+func TestPodHasExclusiveCPUAllocation(t *testing.T) {
 	guaranteedState := NewContainerState("guaranteed-ctr", "gid1", []types.UID{"claim-uid-1"})
 	sharedState := NewContainerState("shared-ctr", "sid1", nil)
 
@@ -185,7 +185,7 @@ func TestIsPodGuaranteed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			store := NewPodConfigStore()
 			tc.setup(store)
-			gotGuaranteed := store.IsPodGuaranteed(tc.podUID)
+			gotGuaranteed := store.PodHasExclusiveCPUAllocation(tc.podUID)
 			require.Equal(t, tc.wantGuaranteed, gotGuaranteed)
 		})
 	}


### PR DESCRIPTION
This PR introduces the `--reserved-cpus` command-line flag, allowing administrators to prevent specific CPUs from being advertised for allocation by the DRA driver. This is useful for isolating CPUs for system processes or other critical workloads similar to what we have in kubelet - https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#kube-reserved.

A CPUAllocationStore has been added to track CPU allocations and coordinate with the NRI plugin to manage shared CPU pools.

Fixes: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/8