### PR TITLE
e2e: test for exclusive CPU assignment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,15 +19,13 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.24'
-    - name: Build container image
-      run: make build-image
     - name: Kind version check
       run: kind version
     - name: Create and setup K8S kind cluster
-      run: make kind-cluster kind-load-image ci-kind-load-image
-    - name: Prepare CI manifests
-      run: make ci-manifests
-    - name: Deploy DRA CPU Driver plugin
-      run: make ci-kind-install
-    - name: run E2E tests
+      run: make ci-kind-setup
+    - name: Run E2E tests
       run: KUBECONFIG=${HOME}/.kube/config make test-e2e-base
+    - name: Show logs on failure
+      if: ${{ failure() }}
+      run: |
+        kubectl get pods -A -o wide

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
         go-version: '1.24'
 
     - name: Build
-      run: go build -v ./...
+      run: make build
 
     - name: Test
-      run: go test -v ./...
+      run: make test-unit

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ go.work.sum
 # .idea/
 # .vscode/
 
-hack/ci/*.yaml
+# CI Manifests
+#  Partial files needed to regenerate the CI install file
+hack/ci/*.part.yaml
+#  The CI install files itself is gonna change at every PR (hash change)
+hack/ci/install-ci.yaml

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean: ## clean
 	rm -rf "$(OUT_DIR)/"
 
 test-unit: ## run tests
-	CGO_ENABLED=1 go test -v -race -count 1 ./pkg/...
+	CGO_ENABLED=1 go test -v -race -count 1 -coverprofile=coverage.out ./pkg/...
 
 update: ## runs go mod tidy
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,10 @@ default: build ## Default builds
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-23s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-
-build: build-dracpu ## build dracpu
+build: build-dracpu build-test-dracpuinfo build-test-dracputester ## build all the binaries
 
 build-dracpu: ## build dracpu
 	go build -v -o "$(OUT_DIR)/dracpu" ./cmd/dracpu
-
 
 clean: ## clean
 	rm -rf "$(OUT_DIR)/"
@@ -149,10 +147,10 @@ build-test-image: ## build tests image
 		--tag="${IMAGE_TEST}" \
 		--load
 
-test-dracputester: ## build helper to serve as entry point and report cpu allocation
+build-test-dracputester: ## build helper to serve as entry point and report cpu allocation
 	go build -v -o "$(OUT_DIR)/dracputester" ./test/image/dracputester
 
-test-dracpuinfo: ## build helper to expose hardware info in the internal dracpu format
+build-test-dracpuinfo: ## build helper to expose hardware info in the internal dracpu format
 	go build -v -o "$(OUT_DIR)/dracpuinfo" ./test/image/dracpuinfo
 
 test-e2e-base: ## run e2e test base suite

--- a/hack/ci/kind-ci.yaml
+++ b/hack/ci/kind-ci.yaml
@@ -1,0 +1,45 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  DynamicResourceAllocation: true
+  DRAResourceClaimDeviceStatus: true
+  DRAConsumableCapacity: true
+nodes:
+- role: control-plane
+  image: kindest/node:v1.34.0
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    scheduler:
+        extraArgs:
+          v: "5"
+          vmodule: "allocator=6,dynamicresources=6" # structured/allocator.go, DRA scheduler plugin
+    controllerManager:
+        extraArgs:
+          v: "5"
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"
+- role: worker
+  image: kindest/node:v1.34.0
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -28,3 +28,8 @@ While considering extending the testsuite, adding tests, cases or sub-suites, pl
   If this variable is set, it should be the `hostname` of a valid worker node in
   the cluster against which the tests run.
   If it is not set, the suit will pick a random node among the workers.
+- `DRACPU_E2E_RESERVED_CPUS`: (optional) if set, it is meant to mirror the driver `--reserved-cpus`
+  setting. The value must be a linux cpuset string. The tests will ensure no containers
+  consume these CPUs.
+  NOTE: at the moment is not easy to autodetect this setting from the driver configuration.
+  Future version may autodetect it.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -21,7 +21,10 @@ While considering extending the testsuite, adding tests, cases or sub-suites, pl
 
 ## configure using environment variables
 
-- `DRACPU_E2E_TARGET_NODE`: the CPU-related tests don't need any specific node.
+- `DRACPU_E2E_TEST_IMAGE`: (mandatory) the full pullSpec of the test image the suite should
+  use as container image to run test containers. The default CI configuration sets this
+  value automatically.
+- `DRACPU_E2E_TARGET_NODE`: (optional) the CPU-related tests don't need any specific node.
   If this variable is set, it should be the `hostname` of a valid worker node in
   the cluster against which the tests run.
   If it is not set, the suit will pick a random node among the workers.

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -19,7 +19,9 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
@@ -28,9 +30,16 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/cpuset"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	minCPUCountForExclusiveAllocation = 4
 )
 
 /*
@@ -53,6 +62,7 @@ var _ = ginkgo.Describe("CPU Assignment", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 	var rootFxt *fixture.Fixture
 	var targetNode *v1.Node
 	var targetNodeCPUInfo discovery.DRACPUInfo
+	var availableCPUs cpuset.CPUSet
 	var dracpuTesterImage string
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
@@ -79,55 +89,202 @@ var _ = ginkgo.Describe("CPU Assignment", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 		}
 		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
 
-		infoPod, err := e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, makeDiscoveryPod(infraFxt.Namespace.Name, dracpuTesterImage))
+		infoPod := makeDiscoveryPod(infraFxt.Namespace.Name, dracpuTesterImage)
+		infoPod = pinPodToNode(infoPod, targetNode.Name)
+		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create discovery pod: %v", err)
 		data, err := e2epod.GetLogs(infraFxt.K8SClientset, ctx, infoPod.Namespace, infoPod.Name, infoPod.Spec.Containers[0].Name)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from discovery pod: %v", err)
 		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
-		rootFxt.Log.Info("checking worker node", "coreCount", len(targetNodeCPUInfo.CPUs))
 
+		availableCPUs = makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
+		rootFxt.Log.Info("checking worker node", "coreCount", len(targetNodeCPUInfo.CPUs), "availableCPUs", availableCPUs.String(), "nodeName", infoPod.Spec.NodeName)
 	})
 
-	ginkgo.When("not setting resource claims", func() {
+	ginkgo.When("setting resource claims", func() {
 		var fxt *fixture.Fixture
+		var exclCPUClaim *resourcev1.ResourceClaim
 
-		ginkgo.JustBeforeEach(func(ctx context.Context) {
-			fxt = rootFxt.WithPrefix("no-res-claims")
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			fxt = rootFxt.WithPrefix("with-claims")
 			gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
 		})
 
-		ginkgo.JustAfterEach(func(ctx context.Context) {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			gomega.Expect(fxt.Teardown(ctx)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("should grant best-effort pods access to all system CPUs", func(ctx context.Context) {
-			pod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create tester pod: %v", err)
+		ginkgo.Context("for exclusive CPU allocation", func() {
+			// TODO: check and ensure cpumanager configuration?
 
-			cpus, err := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, pod)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get the CPUs allocated to tester pod %s/%s", pod.Namespace, pod.Name)
-			gomega.Expect(cpus.Size()).To(gomega.Equal(len(targetNodeCPUInfo.CPUs)))
+			ginkgo.JustBeforeEach(func(ctx context.Context) {
+				ginkgo.By(fmt.Sprintf("checking the target nodes has at least %d allocatable cpus", minCPUCountForExclusiveAllocation))
+				if len(targetNodeCPUInfo.CPUs) < minCPUCountForExclusiveAllocation {
+					ginkgo.Skip(fmt.Sprintf("exclusive allocation tests require at least %d cpus in the worker node", minCPUCountForExclusiveAllocation))
+				}
+
+				cpuCount := 2
+				ginkgo.By(fmt.Sprintf("creating a resource claim for %d cpus", cpuCount))
+
+				claim := resourcev1.ResourceClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cpu-request-2-exclusive",
+					},
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{
+								{
+									Name: "request-cpus",
+									Exactly: &resourcev1.ExactDeviceRequest{
+										DeviceClassName: "dra.cpu",
+										Count:           int64(cpuCount),
+									},
+								},
+							},
+						},
+					},
+				}
+
+				var err error
+				exclCPUClaim, err = fxt.K8SClientset.ResourceV1().ResourceClaims(fxt.Namespace.Name).Create(ctx, &claim, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				gomega.Expect(exclCPUClaim).ToNot(gomega.BeNil())
+			})
+
+			ginkgo.It("should allocate exclusive CPUs and remove from the shared pool", func(ctx context.Context) {
+				ginkgo.By("creating a best-effort reference pod")
+
+				var err error
+				sharedPodPre := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
+				sharedPodPre = pinPodToNode(sharedPodPre, targetNode.Name)
+				sharedPodPre, err = e2epod.CreateSync(ctx, fxt.K8SClientset, sharedPodPre)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create tester pod: %v", err)
+
+				ginkgo.By("checking the best-effort reference pod has access to all the node CPUs through the shared pool")
+				sharedAllocPre := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPodPre)
+				rootFxt.Log.Info("checking shared allocation", "pod", identifyPod(sharedPodPre), "cpuAllocated", sharedAllocPre.CPUAssigned.String())
+				unallocatedCPUs := availableCPUs.Difference(sharedAllocPre.CPUAssigned)
+				gomega.Expect(unallocatedCPUs.Size()).To(gomega.BeZero(), "available CPUs not in the shared pool: %v", unallocatedCPUs.String())
+
+				ginkgo.By("creating a guaranteed pod getting exclusive CPUs from the resource claim")
+				exclPod := makeTesterPodWithExclusiveCPUClaim(fxt.Namespace.Name, dracpuTesterImage, exclCPUClaim)
+				exclPod = pinPodToNode(exclPod, targetNode.Name)
+				exclPod, err = e2epod.CreateSync(ctx, fxt.K8SClientset, exclPod)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create tester pod: %v", err)
+
+				ginkgo.By("checking the pod with exclusive CPUs has access to amount of CPUs requested in the claim")
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get the CPUs allocated to tester pod %s/%s", exclPod.Namespace, exclPod.Name)
+				exclusiveAlloc := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, exclPod)
+				gomega.Expect(int64(exclusiveAlloc.CPUAssigned.Size())).To(gomega.Equal(exclCPUClaim.Spec.Devices.Requests[0].Exactly.Count))
+				rootFxt.Log.Info("checking exclusive allocation", "pod", identifyPod(exclPod), "cpus", exclusiveAlloc.CPUAssigned.String())
+
+				ginkgo.By("checking the shared pool does not include anymore the exclusively allocated CPUs")
+				expectedSharedCPUs := availableCPUs.Difference(exclusiveAlloc.CPUAssigned)
+
+				ginkgo.By("creating a second best-effort reference pod")
+				sharedPodPost := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
+				sharedPodPost = pinPodToNode(sharedPodPost, targetNode.Name)
+				sharedPodPost, err = e2epod.CreateSync(ctx, fxt.K8SClientset, sharedPodPost)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create the second tester pod: %v", err)
+
+				ginkgo.By("checking the second best-effort pod has access to all the non-exclusively-allocated node CPUs through the shared pool")
+				sharedAllocPost := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPodPost)
+				rootFxt.Log.Info("checking shared allocation", "pod", identifyPod(sharedPodPost), "cpuAllocated", sharedAllocPost.CPUAssigned.String())
+				gomega.Expect(expectedSharedCPUs.Equals(sharedAllocPost.CPUAssigned)).To(gomega.BeTrue(), "the second best-effort tester pod does not have the expected shared CPUs: %v got: %v", expectedSharedCPUs.String(), sharedAllocPost.CPUAssigned.String())
+
+				ginkgo.By("checking the CPU pool of the best-effort pod created before the pod with CPU resource claims")
+				gomega.Eventually(func() error {
+					sharedAllocPreUpdated := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPodPre)
+					rootFxt.Log.Info("checking shared allocation", "pod", identifyPod(sharedPodPre), "cpuAllocated", sharedAllocPreUpdated.CPUAssigned.String())
+					if !expectedSharedCPUs.Equals(sharedAllocPreUpdated.CPUAssigned) {
+						return fmt.Errorf("shared CPUs mismatch: expected %v got %v", expectedSharedCPUs.String(), sharedAllocPreUpdated.CPUAssigned.String())
+					}
+					return nil
+				}).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(gomega.Succeed(), "the first, pre-existing best-effort tester pod does not have access to the exclusively allocated CPUs")
+			})
 		})
 	})
 })
 
-func getTesterPodCPUAllocation(cs kubernetes.Interface, ctx context.Context, pod *v1.Pod) (cpuset.CPUSet, error) {
+func makeCPUSetFromDiscoveredCPUInfo(cpuInfo discovery.DRACPUInfo) cpuset.CPUSet {
+	coreIDs := make([]int, len(cpuInfo.CPUs))
+	for idx, cpu := range cpuInfo.CPUs {
+		coreIDs[idx] = cpu.CpuID
+	}
+	return cpuset.New(coreIDs...)
+}
+
+type CPUAllocation struct {
+	CPUAssigned cpuset.CPUSet
+	CPUAffinity cpuset.CPUSet
+}
+
+func getTesterPodCPUAllocation(cs kubernetes.Interface, ctx context.Context, pod *v1.Pod) CPUAllocation {
+	ginkgo.GinkgoHelper()
+
 	data, err := e2epod.GetLogs(cs, ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
-	if err != nil {
-		return cpuset.CPUSet{}, err
-	}
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs for %s/%s/%s", pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
+
 	testerInfo := discovery.DRACPUTester{}
-	err = json.Unmarshal([]byte(data), &testerInfo)
-	if err != nil {
-		return cpuset.CPUSet{}, err
+	gomega.Expect(json.Unmarshal([]byte(data), &testerInfo)).To(gomega.Succeed())
+
+	ret := CPUAllocation{}
+	ret.CPUAssigned, err = cpuset.Parse(testerInfo.Allocation.CPUs)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse assigned cpuset: %q", testerInfo.Allocation.CPUs)
+	ret.CPUAffinity, err = cpuset.Parse(testerInfo.Runtimeinfo.CPUAffinity)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse affinity cpuset: %q", testerInfo.Runtimeinfo.CPUAffinity)
+	return ret
+}
+
+func makeTesterPodWithExclusiveCPUClaim(ns, image string, cpuClaim *resourcev1.ResourceClaim) *v1.Pod {
+	ginkgo.GinkgoHelper()
+	cpuQty := resource.NewQuantity(cpuClaim.Spec.Devices.Requests[0].Exactly.Count, resource.DecimalSI)
+	memQty, err := resource.ParseQuantity("256Mi") // random "low enough" value
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "tester-pod-excl-cpu-claim-",
+			Namespace:    ns,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "tester-container-1",
+					Image:   image,
+					Command: []string{"/dracputester"},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    *cpuQty,
+							v1.ResourceMemory: memQty,
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    *cpuQty,
+							v1.ResourceMemory: memQty,
+						},
+						Claims: []v1.ResourceClaim{
+							{
+								Name: "tester-container-1-claim",
+							},
+						},
+					},
+				},
+			},
+			ResourceClaims: []v1.PodResourceClaim{
+				{
+					Name:              "tester-container-1-claim",
+					ResourceClaimName: ptr.To(cpuClaim.Name),
+				},
+			},
+			RestartPolicy: v1.RestartPolicyAlways,
+		},
 	}
-	return cpuset.Parse(testerInfo.Allocation.CPUs)
 }
 
 func makeTesterPodBestEffort(ns, image string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "tester-pod-",
+			GenerateName: "tester-pod-be-",
 			Namespace:    ns,
 		},
 		Spec: v1.PodSpec{
@@ -136,6 +293,14 @@ func makeTesterPodBestEffort(ns, image string) *v1.Pod {
 					Name:    "tester-container",
 					Image:   image,
 					Command: []string{"/dracputester"},
+					// at the moment we depend on pod logs to learn the cpu allocation.
+					// Therefore, the pod without resource claims, best-effort,
+					// will restart periodically to provide the up to date information.
+					// NOTE: restarting always ensuring there's the minimal and easiest
+					// amount of logs to process. The other option would be to periodically
+					// log the data, but then the client side will need to read and discard
+					// all but the latest update, which is wasteful. This approach is the simplest.
+					Args: []string{"-run-for", "1s"},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyAlways,
@@ -161,4 +326,15 @@ func makeDiscoveryPod(ns, image string) *v1.Pod {
 			RestartPolicy: v1.RestartPolicyNever,
 		},
 	}
+}
+
+func pinPodToNode(pod *v1.Pod, nodeName string) *v1.Pod {
+	pod.Spec.NodeSelector = map[string]string{
+		"kubernetes.io/hostname": nodeName,
+	}
+	return pod
+}
+
+func identifyPod(pod *v1.Pod) string {
+	return pod.Namespace + "/" + pod.Name + "@" + pod.Spec.NodeName
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"os"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -25,10 +24,6 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	/* TODO temporary workaround */
-	if _, ok := os.LookupEnv("KUBECONFIG"); !ok {
-		return
-	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "DRA CPU Driver E2E Suite")
 }

--- a/test/pkg/discovery/types.go
+++ b/test/pkg/discovery/types.go
@@ -32,14 +32,19 @@ type DRACPUAllocation struct {
 	CPUs string `json:"cpus"`
 }
 
+type DRACPURuntimeinfo struct {
+	CPUAffinity string `json:"affinity"`
+}
+
 type DRACPUInfo struct {
 	Buildinfo DRACPUBuildinfo   `json:"buildinfo"`
 	CPUs      []cpuinfo.CPUInfo `json:"cpus"`
 }
 
 type DRACPUTester struct {
-	Buildinfo  DRACPUBuildinfo  `json:"buildinfo"`
-	Allocation DRACPUAllocation `json:"allocation"`
+	Buildinfo   DRACPUBuildinfo   `json:"buildinfo"`
+	Allocation  DRACPUAllocation  `json:"allocation"`
+	Runtimeinfo DRACPURuntimeinfo `json:"runtimeinfo"`
 }
 
 func NewBuildinfo() DRACPUBuildinfo {

--- a/test/pkg/fixture/fixture.go
+++ b/test/pkg/fixture/fixture.go
@@ -31,6 +31,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+func By(format string, args ...any) {
+	ginkgo.By(fmt.Sprintf(format, args...))
+}
+
 type Fixture struct {
 	Prefix       string
 	K8SClientset kubernetes.Interface


### PR DESCRIPTION
add initial test to automatically validate the exclusive cpu assignment.

Notes for reviewers:
- we intentionally use a bogus image pullSpec to be sure we either use the freshly-built image from current sources or fail loudly
- we fetch the cgroup settings from the test pods using logs, so we let the containers be continuously restarted to refresh the information; see the commit messages for details.