### PR TITLE
DNM: demonstrate CI failure using multiple workers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,15 +19,13 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.24'
-    - name: Build container image
-      run: make build-image
     - name: Kind version check
       run: kind version
     - name: Create and setup K8S kind cluster
-      run: make kind-cluster kind-load-image ci-kind-load-image
-    - name: Prepare CI manifests
-      run: make ci-manifests
-    - name: Deploy DRA CPU Driver plugin
-      run: make ci-kind-install
-    - name: run E2E tests
+      run: make ci-kind-setup
+    - name: Run E2E tests
       run: KUBECONFIG=${HOME}/.kube/config make test-e2e-base
+    - name: Show logs on failure
+      if: ${{ failure() }}
+      run: |
+        kubectl get pods -A -o wide

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ go.work.sum
 # .idea/
 # .vscode/
 
-hack/ci/*.yaml
+# CI Manifests
+#  Partial files needed to regenerate the CI install file
+hack/ci/*.part.yaml
+#  The CI install files itself is gonna change at every PR (hash change)
+hack/ci/install-ci.yaml

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ STAGING_REPO_NAME=dra-driver-cpu
 IMAGE_NAME=dra-driver-cpu
 # docker image registry, default to upstream
 REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images
+# this is an intentionally non-existent registry to be used only by local CI using the local image loading
+REGISTRY_CI := dev.kind.local/ci
 STAGING_IMAGE_NAME := ${REGISTRY}/${STAGING_REPO_NAME}/${IMAGE_NAME}
 TESTING_IMAGE_NAME := ${REGISTRY}/${IMAGE_NAME}-test
 # tag based on date-sha
@@ -61,7 +63,8 @@ TAG ?= $(GIT_VERSION)
 # the full image tag
 IMAGE_LATEST?=$(STAGING_IMAGE_NAME):latest
 IMAGE := ${STAGING_IMAGE_NAME}:${TAG}
-IMAGE_TESTING := "${TESTING_IMAGE_NAME}:${TAG}"
+IMAGE_CI := ${REGISTRY_CI}/${IMAGE_NAME}:${TAG}
+IMAGE_TEST := ${REGISTRY_CI}/${IMAGE_NAME}-test:${TAG}
 PLATFORMS?=linux/amd64
 
 # required to enable buildx
@@ -74,8 +77,11 @@ build-image: ## build image
 		--platform="${PLATFORMS}" \
 		--tag="${IMAGE}" \
 		--tag="${IMAGE_LATEST}" \
+		--tag="${IMAGE_CI}" \
 		--load
 
+# no need to push the test image
+# never push the CI image! it intentionally refers to a non-existing registry
 push-image: build-image ## build and push image
 	docker push ${IMAGE}
 	docker push ${IMAGE_LATEST}
@@ -95,33 +101,33 @@ kind-install-cpu-dra: kind-uninstall-cpu-dra build-image kind-load-image ## inst
 delete-kind-cluster: ## delete kind cluster
 	kind delete cluster --name ${CLUSTER_NAME}
 
-ci-kind-install: kind-uninstall-cpu-dra build-image kind-load-image ## install on CI cluster
-	kubectl create -f hack/ci/install-ci.yaml
+ci-kind-setup: ci-manifests build-image build-test-image ## setup a CI cluster from scratch
+	kind create cluster --name ${CLUSTER_NAME} --config hack/ci/kind-ci.yaml
 	kubectl label node ${CLUSTER_NAME}-worker node-role.kubernetes.io/worker=''
+	kind load docker-image --name ${CLUSTER_NAME} ${IMAGE_CI} ${IMAGE_TEST}
+	kubectl create -f hack/ci/install-ci.yaml
 	hack/ci/wait-resourcelices.sh
 
-ci-kind-load-image: build-test-image  ## load the testing container image into kind
-	kind load docker-image ${IMAGE_TESTING} --name ${CLUSTER_NAME}
-
 ci-manifests: install.yaml install-yq ## create the CI install manifests
-	@cd hack/ci && ../../bin/yq e -s '"_" + (.kind | downcase) + "-" + .metadata.name + ".yaml"' ../../install.yaml
+	@cd hack/ci && ../../bin/yq e -s '(.kind | downcase) + "-" + .metadata.name + ".part.yaml"' ../../install.yaml
 	@# need to make kind load docker-image working as expected: see https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
-	@bin/yq -i '.spec.template.spec.containers[0].imagePullPolicy = "IfNotPresent"' hack/ci/_daemonset-dracpu.yaml
-	@bin/yq -i '.spec.template.spec.containers[0].image = "${IMAGE}"' hack/ci/_daemonset-dracpu.yaml
-	@bin/yq -i '.spec.template.metadata.labels["build"] = "${GIT_VERSION}"' hack/ci/_daemonset-dracpu.yaml
+	@bin/yq -i '.spec.template.spec.containers[0].imagePullPolicy = "IfNotPresent"' hack/ci/daemonset-dracpu.part.yaml
+	@bin/yq -i '.spec.template.spec.containers[0].image = "${IMAGE_CI}"' hack/ci/daemonset-dracpu.part.yaml
+	@bin/yq -i '.spec.template.metadata.labels["build"] = "${GIT_VERSION}"' hack/ci/daemonset-dracpu.part.yaml
 	@bin/yq '.' \
-		hack/ci/_clusterrole-dracpu.yaml \
-		hack/ci/_serviceaccount-dracpu.yaml \
-		hack/ci/_clusterrolebinding-dracpu.yaml \
-		hack/ci/_daemonset-dracpu.yaml \
-		hack/ci/_deviceclass-dra.cpu.yaml \
+		hack/ci/clusterrole-dracpu.part.yaml \
+		hack/ci/serviceaccount-dracpu.part.yaml \
+		hack/ci/clusterrolebinding-dracpu.part.yaml \
+		hack/ci/daemonset-dracpu.part.yaml \
+		hack/ci/deviceclass-dra.cpu.part.yaml \
 		> hack/ci/install-ci.yaml
+	@rm hack/ci/*.part.yaml
 
 build-test-image: ## build tests image
 	docker buildx build . \
 		--file test/image/Dockerfile \
 		--platform="${PLATFORMS}" \
-		--tag="${REGISTRY}/${IMAGE_NAME}-test:${TAG}" \
+		--tag="${IMAGE_TEST}" \
 		--load
 
 test-dracputester: ## build helper to serve as entry point and report cpu allocation
@@ -131,7 +137,7 @@ test-dracpuinfo: ## build helper to expose hardware info in the internal dracpu 
 	go build -v -o "$(OUT_DIR)/dracpuinfo" ./test/image/dracpuinfo
 
 test-e2e-base: ## run e2e test base suite
-	env DRACPU_E2E_TEST_IMAGE=$(IMAGE_TESTING) go test -v ./test/e2e/ --ginkgo.v
+	env DRACPU_E2E_TEST_IMAGE=$(IMAGE_TEST) go test -v ./test/e2e/ --ginkgo.v
 
 # dependencies
 .PHONY:

--- a/hack/ci/kind-ci.yaml
+++ b/hack/ci/kind-ci.yaml
@@ -1,0 +1,45 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  DynamicResourceAllocation: true
+  DRAResourceClaimDeviceStatus: true
+  DRAConsumableCapacity: true
+nodes:
+- role: control-plane
+  image: kindest/node:v1.34.0
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    scheduler:
+        extraArgs:
+          v: "5"
+          vmodule: "allocator=6,dynamicresources=6" # structured/allocator.go, DRA scheduler plugin
+    controllerManager:
+        extraArgs:
+          v: "5"
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"
+- role: worker
+  image: kindest/node:v1.34.0
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"

--- a/hack/ci/kind-ci.yaml
+++ b/hack/ci/kind-ci.yaml
@@ -43,3 +43,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         v: "5"
+- role: worker
+  image: kindest/node:v1.34.0
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -19,7 +19,9 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
@@ -28,9 +30,16 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/cpuset"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	minCPUCountForExclusiveAllocation = 4
 )
 
 /*
@@ -53,6 +62,7 @@ var _ = ginkgo.Describe("CPU Assignment", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 	var rootFxt *fixture.Fixture
 	var targetNode *v1.Node
 	var targetNodeCPUInfo discovery.DRACPUInfo
+	var availableCPUs cpuset.CPUSet
 	var dracpuTesterImage string
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
@@ -79,55 +89,202 @@ var _ = ginkgo.Describe("CPU Assignment", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 		}
 		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
 
-		infoPod, err := e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, makeDiscoveryPod(infraFxt.Namespace.Name, dracpuTesterImage))
+		infoPod := makeDiscoveryPod(infraFxt.Namespace.Name, dracpuTesterImage)
+		infoPod = pinPodToNode(infoPod, targetNode.Name)
+		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create discovery pod: %v", err)
 		data, err := e2epod.GetLogs(infraFxt.K8SClientset, ctx, infoPod.Namespace, infoPod.Name, infoPod.Spec.Containers[0].Name)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from discovery pod: %v", err)
 		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
-		rootFxt.Log.Info("checking worker node", "coreCount", len(targetNodeCPUInfo.CPUs))
 
+		availableCPUs = makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
+		rootFxt.Log.Info("checking worker node", "coreCount", len(targetNodeCPUInfo.CPUs), "availableCPUs", availableCPUs.String(), "nodeName", infoPod.Spec.NodeName)
 	})
 
-	ginkgo.When("not setting resource claims", func() {
+	ginkgo.When("setting resource claims", func() {
 		var fxt *fixture.Fixture
+		var exclCPUClaim *resourcev1.ResourceClaim
 
-		ginkgo.JustBeforeEach(func(ctx context.Context) {
-			fxt = rootFxt.WithPrefix("no-res-claims")
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			fxt = rootFxt.WithPrefix("res-claims")
 			gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
 		})
 
-		ginkgo.JustAfterEach(func(ctx context.Context) {
+		ginkgo.AfterEach(func(ctx context.Context) {
 			gomega.Expect(fxt.Teardown(ctx)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("should grant best-effort pods access to all system CPUs", func(ctx context.Context) {
-			pod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create tester pod: %v", err)
+		ginkgo.Context("for exclusive CPU allocation", func() {
+			// TODO: check and ensure cpumanager configuration?
 
-			cpus, err := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, pod)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get the CPUs allocated to tester pod %s/%s", pod.Namespace, pod.Name)
-			gomega.Expect(cpus.Size()).To(gomega.Equal(len(targetNodeCPUInfo.CPUs)))
+			ginkgo.JustBeforeEach(func(ctx context.Context) {
+				ginkgo.By(fmt.Sprintf("checking the target nodes has at least %d allocatable cpus", minCPUCountForExclusiveAllocation))
+				if len(targetNodeCPUInfo.CPUs) < minCPUCountForExclusiveAllocation {
+					ginkgo.Skip(fmt.Sprintf("exclusive allocation tests require at least %d cpus in the worker node", minCPUCountForExclusiveAllocation))
+				}
+
+				cpuCount := 2
+				ginkgo.By(fmt.Sprintf("creating a resource claim for %d cpus", cpuCount))
+
+				claim := resourcev1.ResourceClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cpu-request-2-exclusive",
+					},
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{
+								{
+									Name: "request-cpus",
+									Exactly: &resourcev1.ExactDeviceRequest{
+										DeviceClassName: "dra.cpu",
+										Count:           int64(cpuCount),
+									},
+								},
+							},
+						},
+					},
+				}
+
+				var err error
+				exclCPUClaim, err = fxt.K8SClientset.ResourceV1().ResourceClaims(fxt.Namespace.Name).Create(ctx, &claim, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				gomega.Expect(exclCPUClaim).ToNot(gomega.BeNil())
+			})
+
+			ginkgo.It("should allocate exclusive CPUs and remove from the shared pool", func(ctx context.Context) {
+				ginkgo.By("creating a best-effort reference pod")
+
+				var err error
+				sharedPodPre := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
+				sharedPodPre = pinPodToNode(sharedPodPre, targetNode.Name)
+				sharedPodPre, err = e2epod.CreateSync(ctx, fxt.K8SClientset, sharedPodPre)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create tester pod: %v", err)
+
+				ginkgo.By("checking the best-effort reference pod has access to all the node CPUs through the shared pool")
+				sharedAllocPre := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPodPre)
+				rootFxt.Log.Info("checking shared allocation", "pod", identifyPod(sharedPodPre), "cpuAllocated", sharedAllocPre.CPUAssigned.String(), "cpuAffinity", sharedAllocPre.CPUAffinity.String())
+				unallocatedCPUs := availableCPUs.Difference(sharedAllocPre.CPUAssigned)
+				gomega.Expect(unallocatedCPUs.Size()).To(gomega.BeZero(), "available CPUs not in the shared pool: %v", unallocatedCPUs.String())
+
+				ginkgo.By("creating a guaranteed pod getting exclusive CPUs from the resource claim")
+				exclPod := makeTesterPodWithExclusiveCPUClaim(fxt.Namespace.Name, dracpuTesterImage, exclCPUClaim)
+				exclPod = pinPodToNode(exclPod, targetNode.Name)
+				exclPod, err = e2epod.CreateSync(ctx, fxt.K8SClientset, exclPod)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create tester pod: %v", err)
+
+				ginkgo.By("checking the pod with exclusive CPUs has access to amount of CPUs requested in the claim")
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get the CPUs allocated to tester pod %s/%s", exclPod.Namespace, exclPod.Name)
+				exclusiveAlloc := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, exclPod)
+				gomega.Expect(int64(exclusiveAlloc.CPUAssigned.Size())).To(gomega.Equal(exclCPUClaim.Spec.Devices.Requests[0].Exactly.Count))
+				rootFxt.Log.Info("checking exclusive allocation", "pod", identifyPod(exclPod), "cpus", exclusiveAlloc.CPUAssigned.String(), "sharedPool", sharedAllocPre.CPUAssigned.String(), "unallocated", unallocatedCPUs.String())
+
+				ginkgo.By("checking the shared pool does not include anymore the exclusively allocated CPUs")
+				expectedSharedCPUs := availableCPUs.Difference(exclusiveAlloc.CPUAssigned)
+
+				ginkgo.By("creating a second best-effort reference pod")
+				sharedPodPost := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
+				sharedPodPost = pinPodToNode(sharedPodPost, targetNode.Name)
+				sharedPodPost, err = e2epod.CreateSync(ctx, fxt.K8SClientset, sharedPodPost)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create the second tester pod: %v", err)
+
+				ginkgo.By("checking the second best-effort pod has access to all the non-exclusively-allocated node CPUs through the shared pool")
+				sharedAllocPost := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPodPost)
+				rootFxt.Log.Info("checking shared allocation", "pod", identifyPod(sharedPodPost), "cpuAllocated", sharedAllocPost.CPUAssigned.String(), "cpuAffinity", sharedAllocPost.CPUAffinity.String())
+				gomega.Expect(expectedSharedCPUs.Equals(sharedAllocPost.CPUAssigned)).To(gomega.BeTrue(), "the second, post-created best-effort tester pod does not have access to the exclusively allocated CPUs, expected: %v got: %v", expectedSharedCPUs.String(), sharedAllocPost.CPUAssigned.String())
+
+				ginkgo.By("checking the CPU pool of the best-effort pod created before the pod with CPU resource claims")
+				gomega.Eventually(func() error {
+					sharedAllocPreUpdated := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPodPre)
+					rootFxt.Log.Info("checking shared allocation", "pod", identifyPod(sharedPodPre), "cpuAllocated", sharedAllocPreUpdated.CPUAssigned.String(), "cpuAffinity", sharedAllocPreUpdated.CPUAffinity.String())
+					if !expectedSharedCPUs.Equals(sharedAllocPreUpdated.CPUAssigned) {
+						return fmt.Errorf("shared CPUs mismatch: expected %v got %v", expectedSharedCPUs.String(), sharedAllocPreUpdated.CPUAssigned.String())
+					}
+					return nil
+				}).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(gomega.Succeed(), "the first, pre-existing best-effort tester pod does not have access to the exclusively allocated CPUs")
+			})
 		})
 	})
 })
 
-func getTesterPodCPUAllocation(cs kubernetes.Interface, ctx context.Context, pod *v1.Pod) (cpuset.CPUSet, error) {
+func makeCPUSetFromDiscoveredCPUInfo(cpuInfo discovery.DRACPUInfo) cpuset.CPUSet {
+	coreIDs := make([]int, len(cpuInfo.CPUs))
+	for idx, cpu := range cpuInfo.CPUs {
+		coreIDs[idx] = cpu.CpuID
+	}
+	return cpuset.New(coreIDs...)
+}
+
+type CPUAllocation struct {
+	CPUAssigned cpuset.CPUSet
+	CPUAffinity cpuset.CPUSet
+}
+
+func getTesterPodCPUAllocation(cs kubernetes.Interface, ctx context.Context, pod *v1.Pod) CPUAllocation {
+	ginkgo.GinkgoHelper()
+
 	data, err := e2epod.GetLogs(cs, ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
-	if err != nil {
-		return cpuset.CPUSet{}, err
-	}
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs for %s/%s/%s", pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
+
 	testerInfo := discovery.DRACPUTester{}
-	err = json.Unmarshal([]byte(data), &testerInfo)
-	if err != nil {
-		return cpuset.CPUSet{}, err
+	gomega.Expect(json.Unmarshal([]byte(data), &testerInfo)).To(gomega.Succeed())
+
+	ret := CPUAllocation{}
+	ret.CPUAssigned, err = cpuset.Parse(testerInfo.Allocation.CPUs)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse assigned cpuset: %q", testerInfo.Allocation.CPUs)
+	ret.CPUAffinity, err = cpuset.Parse(testerInfo.Runtimeinfo.CPUAffinity)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse affinity cpuset: %q", testerInfo.Runtimeinfo.CPUAffinity)
+	return ret
+}
+
+func makeTesterPodWithExclusiveCPUClaim(ns, image string, cpuClaim *resourcev1.ResourceClaim) *v1.Pod {
+	ginkgo.GinkgoHelper()
+	cpuQty := resource.NewQuantity(cpuClaim.Spec.Devices.Requests[0].Exactly.Count, resource.DecimalSI)
+	memQty, err := resource.ParseQuantity("256Mi") // random "low enough" value
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "tester-pod-excl-cpu-claim-",
+			Namespace:    ns,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "tester-container-1",
+					Image:   image,
+					Command: []string{"/dracputester"},
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    *cpuQty,
+							v1.ResourceMemory: memQty,
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    *cpuQty,
+							v1.ResourceMemory: memQty,
+						},
+						Claims: []v1.ResourceClaim{
+							{
+								Name: "tester-container-1-claim",
+							},
+						},
+					},
+				},
+			},
+			ResourceClaims: []v1.PodResourceClaim{
+				{
+					Name:              "tester-container-1-claim",
+					ResourceClaimName: ptr.To(cpuClaim.Name),
+				},
+			},
+			RestartPolicy: v1.RestartPolicyAlways,
+		},
 	}
-	return cpuset.Parse(testerInfo.Allocation.CPUs)
 }
 
 func makeTesterPodBestEffort(ns, image string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "tester-pod-",
+			GenerateName: "tester-pod-be-",
 			Namespace:    ns,
 		},
 		Spec: v1.PodSpec{
@@ -136,6 +293,10 @@ func makeTesterPodBestEffort(ns, image string) *v1.Pod {
 					Name:    "tester-container",
 					Image:   image,
 					Command: []string{"/dracputester"},
+					// at the moment we depend on pod logs to learn the cpu allocation.
+					// Therefore, the pod without resource claims, best-effort,
+					// will restart periodically to provide the up to date information.
+					Args: []string{"-run-for", "1s"},
 				},
 			},
 			RestartPolicy: v1.RestartPolicyAlways,
@@ -161,4 +322,15 @@ func makeDiscoveryPod(ns, image string) *v1.Pod {
 			RestartPolicy: v1.RestartPolicyNever,
 		},
 	}
+}
+
+func pinPodToNode(pod *v1.Pod, nodeName string) *v1.Pod {
+	pod.Spec.NodeSelector = map[string]string{
+		"kubernetes.io/hostname": nodeName,
+	}
+	return pod
+}
+
+func identifyPod(pod *v1.Pod) string {
+	return pod.Namespace + "/" + pod.Name + "@" + pod.Spec.NodeName
 }

--- a/test/pkg/discovery/types.go
+++ b/test/pkg/discovery/types.go
@@ -32,14 +32,19 @@ type DRACPUAllocation struct {
 	CPUs string `json:"cpus"`
 }
 
+type DRACPURuntimeinfo struct {
+	CPUAffinity string `json:"affinity"`
+}
+
 type DRACPUInfo struct {
 	Buildinfo DRACPUBuildinfo   `json:"buildinfo"`
 	CPUs      []cpuinfo.CPUInfo `json:"cpus"`
 }
 
 type DRACPUTester struct {
-	Buildinfo  DRACPUBuildinfo  `json:"buildinfo"`
-	Allocation DRACPUAllocation `json:"allocation"`
+	Buildinfo   DRACPUBuildinfo   `json:"buildinfo"`
+	Allocation  DRACPUAllocation  `json:"allocation"`
+	Runtimeinfo DRACPURuntimeinfo `json:"runtimeinfo"`
 }
 
 func NewBuildinfo() DRACPUBuildinfo {


### PR DESCRIPTION
this is #22 but with 2 worker nodes in the kind CI clusters. It seems that in this specific configuration the runtime fail to set the shared CPUs.
It is an interesting issue, but should not be too big of a concern because in any scenario resembling real world we will have independent workers (e.g. not running on kind)