### PR TITLE
yaml: drop podresources socket mounts

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -169,9 +169,6 @@ spec:
           mountPath: /var/lib/kubelet/plugins_registry
         - name: nri-plugin
           mountPath: /var/run/nri
-        - name: pod-resources-socket
-          mountPath: /var/lib/kubelet/pod-resources
-          readOnly: true
         - name: cdi-dir
           mountPath: /var/run/cdi
       volumes:
@@ -193,9 +190,6 @@ spec:
       - name: etc
         hostPath:
           path: /etc
-      - name: pod-resources-socket
-        hostPath:
-          path: /var/lib/kubelet/pod-resources
       - name: cdi-dir
         hostPath:
           path: /var/run/cdi


### PR DESCRIPTION
we don't use them and it seems there are no plans to use them, so let's simplify the YAMLs and reduce the plugin surface.