### PR TITLE
bugfix: cdi: write the CDI spec atomically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/containerd/nri v0.9.0
 	github.com/go-logr/logr v1.4.2
+	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.22.1
 	github.com/onsi/gomega v1.36.2
 	github.com/prometheus/client_golang v1.22.0
@@ -35,7 +36,6 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/driver/cdi_test.go
+++ b/pkg/driver/cdi_test.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	cdiSpec "tags.cncf.io/container-device-interface/specs-go"
+)
+
+type testdevice struct {
+	name string
+	env  string
+}
+
+func TestAddDevice(t *testing.T) {
+	type testcase struct {
+		name         string
+		devices      []testdevice
+		expectedSpec *cdiSpec.Spec
+	}
+
+	testcases := []testcase{
+		{
+			name: "empty",
+			expectedSpec: &cdiSpec.Spec{
+				Version: cdiSpecVersion,
+				Kind:    cdiVendor + "/" + cdiClass,
+				Devices: []cdiSpec.Device{},
+			},
+		},
+		{
+			name: "simple device",
+			devices: []testdevice{
+				{
+					name: "foodev",
+					env:  "FOO=42",
+				},
+			},
+			expectedSpec: &cdiSpec.Spec{
+				Version: cdiSpecVersion,
+				Kind:    cdiVendor + "/" + cdiClass,
+				Devices: []cdiSpec.Device{
+					{
+						Name: "foodev",
+						ContainerEdits: cdiSpec.ContainerEdits{
+							Env: []string{
+								"FOO=42",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			saveCDIDir := cdiSpecDir
+			t.Cleanup(func() {
+				cdiSpecDir = saveCDIDir
+			})
+			cdiSpecDir = t.TempDir()
+
+			mgr, err := NewCdiManager(testDriverName)
+			require.NoError(t, err)
+
+			_, err = os.Stat(filepath.Join(cdiSpecDir, testDriverName+".json"))
+			require.NoError(t, err)
+
+			for _, dev := range tcase.devices {
+				err = mgr.AddDevice(dev.name, dev.env)
+				require.NoError(t, err)
+			}
+
+			got, err := mgr.GetSpec()
+			require.NoError(t, err)
+			if diff := cmp.Diff(got, tcase.expectedSpec); diff != "" {
+				t.Errorf("unexpected spec from empty: %v", diff)
+			}
+		})
+	}
+}
+
+func TestRemoveDevice(t *testing.T) {
+	type testcase struct {
+		name         string
+		initial      []testdevice
+		toRemove     []testdevice
+		expectedSpec *cdiSpec.Spec
+	}
+
+	testcases := []testcase{
+		{
+			name: "multi device",
+			initial: []testdevice{
+				{
+					name: "foodev",
+					env:  "FOO=42",
+				},
+				{
+					name: "bardev",
+					env:  "GO=1",
+				},
+				{
+					name: "fizzbuzzdev",
+					env:  "SEQ=3,5,15",
+				},
+			},
+			toRemove: []testdevice{
+				{
+					name: "fizzbuzzdev",
+				},
+			},
+			expectedSpec: &cdiSpec.Spec{
+				Version: cdiSpecVersion,
+				Kind:    cdiVendor + "/" + cdiClass,
+				Devices: []cdiSpec.Device{
+					{
+						Name: "foodev",
+						ContainerEdits: cdiSpec.ContainerEdits{
+							Env: []string{
+								"FOO=42",
+							},
+						},
+					},
+					{
+						Name: "bardev",
+						ContainerEdits: cdiSpec.ContainerEdits{
+							Env: []string{
+								"GO=1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			saveCDIDir := cdiSpecDir
+			t.Cleanup(func() {
+				cdiSpecDir = saveCDIDir
+			})
+			cdiSpecDir = t.TempDir()
+
+			mgr, err := NewCdiManager(testDriverName)
+			require.NoError(t, err)
+			for _, dev := range tcase.initial {
+				err = mgr.AddDevice(dev.name, dev.env)
+				require.NoError(t, err)
+			}
+			for _, dev := range tcase.toRemove {
+				err = mgr.RemoveDevice(dev.name)
+				require.NoError(t, err)
+			}
+
+			got, err := mgr.GetSpec()
+			require.NoError(t, err)
+			if diff := cmp.Diff(got, tcase.expectedSpec); diff != "" {
+				t.Errorf("unexpected spec from empty: %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The recommended way in unix environments to atomically write a file is to write a temporary file and then use rename(2) which is atomic.
This avoids entirely any possibility of hving a half-written file.

In the future, we may want to look into
```
tags.cncf.io/container-device-interface/pkg/cdi
tags.cncf.io/container-device-interface/pkg/parser
```

to replace out cdi handling code entirely. For the short term, the low hanging fruit is to fix the bug and carry on while the other features mature. We can pivot to the CDI packages after we hit the first milestone