### PR TITLE
daemonset: cleanup and set priority

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -110,6 +110,10 @@ spec:
           name: etc
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
set pod priority for the dracpu daemonset. This way we decouple the resource requests, which we haven't figured out yet, from the actual pod priority for eviction and preemption.
For more details: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#interactions-of-pod-priority-and-qos

Note 

The collateral question is if we should bump resource requirements and if we should opt in the guaranteed QOS class.
We don't know yet the resource required in normal operations, so we don't change unless we have more data.

Opting in the Guaranteed QOS class would mean set upper hard limit to the resources. This goes against the scalability requirements (if nothing else, bigger clusters means more kubernetes objects to observe) and is even harder to do without data to drive our changes.

For all these reasons, we abstain for now from changing resource requirements till we have real world data.


Fixes: #4 