### PR TITLE
Fix/optimize Resolve the performance overhead of calling large clusters

### DIFF
--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -64,6 +64,10 @@ func (d CPUDetails) CPUsInNUMANodes(ids ...int) cpuset.CPUSet {
 
 // CPUsInCores returns all of the logical CPU IDs associated with the given
 // core IDs in this CPUDetails.
+// TODO: CoreID is only unique within a socket. On multi-socket systems where CoreIDs repeat
+// across sockets, this method may return CPUs from multiple sockets for the same CoreID.
+// Consider refactoring core-level methods to use CoreKey{SocketID, CoreID} for correct
+// disambiguation, similar to CPUTopology.CPUsByCore.
 func (d CPUDetails) CPUsInCores(ids ...int) cpuset.CPUSet {
 	var cpuIDs []int
 	for _, id := range ids {

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -31,6 +31,7 @@ type CPUAllocation struct {
 	availableCPUs            cpuset.CPUSet
 	reservedCPUs             cpuset.CPUSet
 	resourceClaimAllocations map[types.UID]cpuset.CPUSet
+	allocatedCPUs            cpuset.CPUSet
 }
 
 // NewCPUAllocation creates a new CPUAllocation.
@@ -46,15 +47,16 @@ func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUS
 		availableCPUs:            availableCPUs,
 		reservedCPUs:             reservedCPUs,
 		resourceClaimAllocations: make(map[types.UID]cpuset.CPUSet),
+		allocatedCPUs:            cpuset.New(),
 	}
 }
 
 // AddResourceClaimAllocation adds a new resource claim allocation to the store.
-// TODO(pravk03): Keep track of all allocated CPUs here so that GetSharedCPUs() can return in O(1).
 func (s *CPUAllocation) AddResourceClaimAllocation(claimUID types.UID, cpus cpuset.CPUSet) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.resourceClaimAllocations[claimUID] = cpus
+	s.allocatedCPUs = s.allocatedCPUs.Union(cpus)
 	klog.Infof("Added allocation for resource claim %s: CPUs %s", claimUID, cpus.String())
 }
 
@@ -62,22 +64,18 @@ func (s *CPUAllocation) AddResourceClaimAllocation(claimUID types.UID, cpus cpus
 func (s *CPUAllocation) RemoveResourceClaimAllocation(claimUID types.UID) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.resourceClaimAllocations[claimUID]; ok {
+	if cpus, ok := s.resourceClaimAllocations[claimUID]; ok {
 		delete(s.resourceClaimAllocations, claimUID)
+		s.allocatedCPUs = s.allocatedCPUs.Difference(cpus)
 		klog.Infof("Removed allocation for resource claim %s", claimUID)
 	}
 }
 
-// GetSharedCPUs calculates and returns the set of CPUs not reserved by any resource claim.
+// GetSharedCPUs returns the set of CPUs not reserved by any resource claim.
 func (s *CPUAllocation) GetSharedCPUs() cpuset.CPUSet {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	allocatedCPUs := cpuset.New()
-	for _, cpus := range s.resourceClaimAllocations {
-		allocatedCPUs = allocatedCPUs.Union(cpus)
-	}
-	return s.availableCPUs.Difference(allocatedCPUs)
+	return s.availableCPUs.Difference(s.allocatedCPUs)
 }
 
 // GetResourceClaimAllocation returns the cpuset for a given resource claim.

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
@@ -111,4 +112,85 @@ func TestCPUAllocationGetSharedCPUs(t *testing.T) {
 	store.AddResourceClaimAllocation(claimUID2, cpus2)
 	expectedShared = expectedShared.Difference(cpus2)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
+}
+
+func TestCPUAllocationStoreCacheConsistency(t *testing.T) {
+	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+	store := newTestCPUAllocation(allCPUs, cpuset.New())
+
+	store.AddResourceClaimAllocation("claim-1", cpuset.New(0, 1))
+	store.AddResourceClaimAllocation("claim-2", cpuset.New(2, 3))
+	store.AddResourceClaimAllocation("claim-3", cpuset.New(4, 5))
+
+	expectedShared := cpuset.New(6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
+
+	store.RemoveResourceClaimAllocation("claim-2")
+	expectedShared = cpuset.New(2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
+
+	store.RemoveResourceClaimAllocation("claim-1")
+	expectedShared = cpuset.New(0, 1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
+
+	store.RemoveResourceClaimAllocation("claim-3")
+	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
+}
+
+func getSharedCPUsNaive(availableCPUs cpuset.CPUSet, allocations map[types.UID]cpuset.CPUSet) cpuset.CPUSet {
+	allocated := cpuset.New()
+	for _, cpus := range allocations {
+		allocated = allocated.Union(cpus)
+	}
+	return availableCPUs.Difference(allocated)
+}
+
+func BenchmarkGetSharedCPUs(b *testing.B) {
+	testCases := []struct {
+		name           string
+		numCPUs        int
+		numAllocations int
+	}{
+		{"10_allocations", 128, 10},
+		{"100_allocations", 128, 100},
+		{"500_allocations", 1024, 500},
+	}
+
+	for _, tc := range testCases {
+		var infos []cpuinfo.CPUInfo
+		for i := 0; i < tc.numCPUs; i++ {
+			infos = append(infos, cpuinfo.CPUInfo{CpuID: i, CoreID: i, SocketID: 0, NUMANodeID: 0})
+		}
+		mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: infos}
+		topo, _ := mockProvider.GetCPUTopology()
+
+		allocations := make(map[types.UID]cpuset.CPUSet)
+		for i := 0; i < tc.numAllocations && i*2+1 < tc.numCPUs; i++ {
+			allocations[types.UID(fmt.Sprintf("claim-%d", i))] = cpuset.New(i*2, i*2+1)
+		}
+
+		cpuIDs := make([]int, 0, tc.numCPUs)
+		for i := 0; i < tc.numCPUs; i++ {
+			cpuIDs = append(cpuIDs, i)
+		}
+		availableCPUs := cpuset.New(cpuIDs...)
+
+		b.Run(tc.name+"/naive", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = getSharedCPUsNaive(availableCPUs, allocations)
+			}
+		})
+
+		b.Run(tc.name+"/optimized", func(b *testing.B) {
+			store := NewCPUAllocation(topo, cpuset.New())
+			for claimUID, cpus := range allocations {
+				store.AddResourceClaimAllocation(claimUID, cpus)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = store.GetSharedCPUs()
+			}
+		})
+	}
 }

--- a/pkg/store/pod_config.go
+++ b/pkg/store/pod_config.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // ContainerState holds the allocation type and all claim assignments for a container.
@@ -45,14 +46,16 @@ type PodCPUAssignments map[string]*ContainerState
 
 // PodConfig maps a Pod's UID directly to its container-level assignments.
 type PodConfig struct {
-	mu      sync.RWMutex
-	configs map[types.UID]PodCPUAssignments
+	mu                  sync.RWMutex
+	configs             map[types.UID]PodCPUAssignments
+	sharedCPUContainers sets.Set[types.UID]
 }
 
 // NewPodConfig creates a new PodConfig.
 func NewPodConfig() *PodConfig {
 	return &PodConfig{
-		configs: make(map[types.UID]PodCPUAssignments),
+		configs:             make(map[types.UID]PodCPUAssignments),
+		sharedCPUContainers: sets.New[types.UID](),
 	}
 }
 
@@ -61,10 +64,23 @@ func (s *PodConfig) SetContainerState(podUID types.UID, state *ContainerState) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Check if there's an existing state for this container that we need to clean up from cache.
+	if podAssignments, ok := s.configs[podUID]; ok {
+		if oldState, exists := podAssignments[state.containerName]; exists {
+			// Remove old container from sharedCPUContainers cache if it was there.
+			s.sharedCPUContainers.Delete(oldState.containerUID)
+		}
+	}
+
 	if _, ok := s.configs[podUID]; !ok {
 		s.configs[podUID] = make(PodCPUAssignments)
 	}
 	s.configs[podUID][state.containerName] = state
+
+	// Update sharedCPUContainers cache based on new state.
+	if !state.HasExclusiveCPUAllocation() {
+		s.sharedCPUContainers.Insert(state.containerUID)
+	}
 }
 
 // GetContainerState retrieves a container's state.
@@ -98,6 +114,9 @@ func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string)
 		claimUIDs = []types.UID{}
 	}
 
+	// Remove from sharedCPUContainers cache.
+	s.sharedCPUContainers.Delete(cs.containerUID)
+
 	delete(podAssignments, containerName)
 	if len(podAssignments) == 0 {
 		delete(s.configs, podUID)
@@ -107,23 +126,19 @@ func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string)
 }
 
 // GetContainersWithSharedCPUs returns a list of container UIDs that have shared CPU allocation.
-// TODO(pravk03): Cache this and return from this function in O(1)
 func (s *PodConfig) GetContainersWithSharedCPUs() []types.UID {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	sharedCPUContainers := []types.UID{}
-	for _, podAssignments := range s.configs {
-		for _, state := range podAssignments {
-			if len(state.resourceClaimUIDs) == 0 {
-				sharedCPUContainers = append(sharedCPUContainers, state.containerUID)
-			}
-		}
-	}
-	return sharedCPUContainers
+	return s.sharedCPUContainers.UnsortedList()
 }
 
 func (s *PodConfig) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.configs)
+}
+
+// HasExclusiveCPUAllocation returns true if the container has associated resource claims.
+func (cs *ContainerState) HasExclusiveCPUAllocation() bool {
+	return len(cs.resourceClaimUIDs) > 0
 }

--- a/pkg/store/pod_config_test.go
+++ b/pkg/store/pod_config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -106,6 +107,115 @@ func TestGetSharedCPUContainerUIDs(t *testing.T) {
 			tc.setup(store)
 			gotUIDs := store.GetContainersWithSharedCPUs()
 			require.ElementsMatch(t, tc.wantUIDs, gotUIDs)
+		})
+	}
+}
+
+func TestSharedCPUContainersCacheConsistency(t *testing.T) {
+	store := NewPodConfig()
+
+	store.SetContainerState("pod1", NewContainerState("c1", "id1"))
+	store.SetContainerState("pod1", NewContainerState("c2", "id2"))
+	store.SetContainerState("pod2", NewContainerState("c3", "id3"))
+
+	sharedUIDs := store.GetContainersWithSharedCPUs()
+	require.Len(t, sharedUIDs, 3)
+
+	store.SetContainerState("pod3", NewContainerState("c4", "id4", "claim-1"))
+	sharedUIDs = store.GetContainersWithSharedCPUs()
+	require.Len(t, sharedUIDs, 3)
+
+	store.SetContainerState("pod1", NewContainerState("c1", "id1", "claim-2"))
+	sharedUIDs = store.GetContainersWithSharedCPUs()
+	require.Len(t, sharedUIDs, 2)
+	require.NotContains(t, sharedUIDs, types.UID("id1"))
+
+	store.RemoveContainerState("pod1", "c2")
+	sharedUIDs = store.GetContainersWithSharedCPUs()
+	require.Len(t, sharedUIDs, 1)
+	require.ElementsMatch(t, []types.UID{"id3"}, sharedUIDs)
+
+	store.RemoveContainerState("pod2", "c3")
+	sharedUIDs = store.GetContainersWithSharedCPUs()
+	require.Len(t, sharedUIDs, 0)
+}
+
+func TestSetContainerState_ContainerRestart(t *testing.T) {
+	store := NewPodConfig()
+	podUID := types.UID("pod1")
+
+	// Initial container with shared CPUs.
+	store.SetContainerState(podUID, NewContainerState("ctr", "old-uid"))
+	require.ElementsMatch(t, []types.UID{"old-uid"}, store.GetContainersWithSharedCPUs())
+
+	// Container restarts: same name, new UID.
+	store.SetContainerState(podUID, NewContainerState("ctr", "new-uid"))
+	sharedUIDs := store.GetContainersWithSharedCPUs()
+	require.Len(t, sharedUIDs, 1)
+	require.NotContains(t, sharedUIDs, types.UID("old-uid"), "stale UID should be removed")
+	require.Contains(t, sharedUIDs, types.UID("new-uid"))
+}
+
+func getContainersWithSharedCPUsNaive(configs map[types.UID]map[string]*ContainerState) []types.UID {
+	var result []types.UID
+	for _, containers := range configs {
+		for _, state := range containers {
+			if len(state.resourceClaimUIDs) == 0 {
+				result = append(result, state.containerUID)
+			}
+		}
+	}
+	return result
+}
+
+func BenchmarkGetContainersWithSharedCPUs(b *testing.B) {
+	testCases := []struct {
+		name          string
+		numPods       int
+		ctrsPerPod    int
+		sharedPercent int
+	}{
+		{"10_pods_50pct_shared", 10, 2, 50},
+		{"100_pods_50pct_shared", 100, 2, 50},
+		{"500_pods_50pct_shared", 500, 2, 50},
+		{"500_pods_90pct_shared", 500, 2, 90},
+	}
+
+	for _, tc := range testCases {
+		configs := make(map[types.UID]map[string]*ContainerState)
+		store := NewPodConfig()
+
+		ctrIndex := 0
+		for i := 0; i < tc.numPods; i++ {
+			podUID := types.UID(fmt.Sprintf("pod-%d", i))
+			configs[podUID] = make(map[string]*ContainerState)
+
+			for j := 0; j < tc.ctrsPerPod; j++ {
+				ctrName := fmt.Sprintf("ctr-%d", j)
+				ctrUID := types.UID(fmt.Sprintf("ctr-uid-%d", ctrIndex))
+
+				var state *ContainerState
+				if (ctrIndex*100)/(tc.numPods*tc.ctrsPerPod) < tc.sharedPercent {
+					state = NewContainerState(ctrName, ctrUID)
+				} else {
+					state = NewContainerState(ctrName, ctrUID, types.UID(fmt.Sprintf("claim-%d", ctrIndex)))
+				}
+				configs[podUID][ctrName] = state
+				store.SetContainerState(podUID, state)
+				ctrIndex++
+			}
+		}
+
+		b.Run(tc.name+"/naive", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = getContainersWithSharedCPUsNaive(configs)
+			}
+		})
+
+		b.Run(tc.name+"/optimized", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = store.GetContainersWithSharedCPUs()
+			}
 		})
 	}
 }


### PR DESCRIPTION
Resolve the performance overhead of calling large clusters

Note: RemoveResourceClaimAllocate() requires rebuilding the cache during deletion, with a complexity of O (n). This is because cpuset does not support efficient differencing operations (one claim may have allocated CPUs that overlap with other claims). However, due to relatively few deletion operations, and the use of Get Shared CPUs ()
Very frequent calls (called every time a container is created/deleted)


Fixes:https://github.com/kubernetes-sigs/dra-driver-cpu/issues/53