### PR TITLE
Refactor CPU Topology Representation for Asymmetric/Heterogeneous Systems

### DIFF
--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -197,7 +197,7 @@ func (d CPUDetails) CoresInNUMANodes(ids ...int) cpuset.CPUSet {
 // CoresNeededInUncoreCache returns either the full list of all available unique core IDs associated with the given
 // UnCoreCache IDs in this CPUDetails or subset that matches the ask.
 func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpuset.CPUSet {
-	coreIDs := d.coresInUncoreCache(ids...)
+	coreIDs := d.CoresInUncoreCache(ids...)
 	if coreIDs.Size() <= numCoresNeeded {
 		return coreIDs
 	}
@@ -205,8 +205,8 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 	return cpuset.New(tmpCoreIDs[:numCoresNeeded]...)
 }
 
-// Helper function that just gets the cores
-func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
+// CoresInUncoreCache returns the set of unique core IDs associated with the given UnCoreCache IDs.
+func (d CPUDetails) CoresInUncoreCache(ids ...int) cpuset.CPUSet {
 	var coreIDs []int
 	for _, id := range ids {
 		for _, info := range d {

--- a/pkg/cpuinfo/cpuinfo_utils_test.go
+++ b/pkg/cpuinfo/cpuinfo_utils_test.go
@@ -151,7 +151,7 @@ func TestCoresNeededInUncoreCache(t *testing.T) {
 }
 
 func TestCoresInUncoreCache(t *testing.T) {
-	assert.True(t, cpuset.New(0, 1).Equals(testCPUDetails.coresInUncoreCache(0)))
-	assert.True(t, cpuset.New(2, 3).Equals(testCPUDetails.coresInUncoreCache(1)))
-	assert.True(t, cpuset.New().Equals(testCPUDetails.coresInUncoreCache(2)))
+	assert.True(t, cpuset.New(0, 1).Equals(testCPUDetails.CoresInUncoreCache(0)))
+	assert.True(t, cpuset.New(2, 3).Equals(testCPUDetails.CoresInUncoreCache(1)))
+	assert.True(t, cpuset.New().Equals(testCPUDetails.CoresInUncoreCache(2)))
 }

--- a/pkg/cpumanager/test_topology.go
+++ b/pkg/cpumanager/test_topology.go
@@ -29,6 +29,7 @@ var (
 		NumCPUs:    8,
 		NumSockets: 1,
 		NumCores:   4,
+		SMTEnabled: true,
 		CPUDetails: map[int]topology.CPUInfo{
 			0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
 			1: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
@@ -46,6 +47,7 @@ var (
 		NumSockets:     2,
 		NumCores:       6,
 		NumUncoreCache: 1,
+		SMTEnabled:     true,
 		CPUDetails: map[int]topology.CPUInfo{
 			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
 			1:  {CoreID: 1, SocketID: 1, NUMANodeID: 1},
@@ -117,6 +119,7 @@ var (
 		NumSockets:     1,
 		NumCores:       8,
 		NumUncoreCache: 2,
+		SMTEnabled:     true,
 		CPUDetails: map[int]topology.CPUInfo{
 			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
 			1:  {CoreID: 1, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
@@ -184,6 +187,7 @@ var (
 		NumCPUs:    18,
 		NumSockets: 3,
 		NumCores:   9,
+		SMTEnabled: true,
 		CPUDetails: map[int]topology.CPUInfo{
 			0:  {CoreID: 0, SocketID: 1, NUMANodeID: 1},
 			1:  {CoreID: 0, SocketID: 1, NUMANodeID: 1},
@@ -224,6 +228,7 @@ var (
 		NumSockets:   2,
 		NumCores:     40,
 		NumNUMANodes: 4,
+		SMTEnabled:   true,
 		CPUDetails: map[int]topology.CPUInfo{
 			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
 			1:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
@@ -319,6 +324,7 @@ var (
 		NumSockets:   4,
 		NumCores:     40,
 		NumNUMANodes: 2,
+		SMTEnabled:   true,
 		CPUDetails: map[int]topology.CPUInfo{
 			0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
 			1:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
@@ -425,6 +431,7 @@ var (
 		NumSockets:   2,
 		NumCores:     128,
 		NumNUMANodes: 8,
+		SMTEnabled:   true,
 		CPUDetails: map[int]topology.CPUInfo{
 			0:   {CoreID: 0, SocketID: 0, NUMANodeID: 0},
 			1:   {CoreID: 1, SocketID: 0, NUMANodeID: 0},


### PR DESCRIPTION
Refactor CPU topology representation to eliminate symmetric/uniform assumptions in CPU allocation logic, as discussed in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/16#discussion_r2588301122.
 
Motivation
The previous CPUTopology methods (CPUsPerCore, CPUsPerSocket, CPUsPerUncore) computed global averages via simple division (e.g., NumCPUs / NumCores). This is incorrect when CPUsare offlined asymmetrically or on heterogeneous systems — all the math goes haywire as
 
Not fully resolved：
1. takePartialUncore still uses an average within the uncore cache scope. The cpusPerCore calculation (cpusInUncore.Size() / numCores, rounded up) is a per-uncore-cache average rather than the old global average. This is significantly more accurate, but still an approximation,However, this scenario is extremely rare in actual hardware - inside the uncore cache Core is usually symmetrical.