### PR TITLE
dra: codeorg: simplify device attributes

### DIFF
--- a/pkg/device/attributes.go
+++ b/pkg/device/attributes.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package device
+
+import (
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/utils/ptr"
+)
+
+// SetCompatibilityAttributes add attributes to enable compatibility (e.g. alignment) with other
+// DRA resource drivers leveraging attributes which are not kubernetes standard.
+// This is the "staging area" which enables attribute sharing until (or before) they become standard.
+func SetCompatibilityAttributes(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaID int64) {
+	attrs["dra.net/numaNode"] = resourceapi.DeviceAttribute{IntValue: ptr.To(numaID)}
+}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpumanager"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,15 +57,13 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices() [][]resourceapi.Device {
 	var devices []resourceapi.Device
 
 	topo := cp.cpuTopology
-	smtEnabled := topo.SMTEnabled
 
 	switch cp.cpuDeviceGroupBy {
 	case GROUP_BY_SOCKET:
 		socketIDs := topo.CPUDetails.Sockets().List()
-		for _, socketIDInt := range socketIDs {
-			socketID := int64(socketIDInt)
-			deviceName := fmt.Sprintf("%s%03d", cpuDeviceSocketGroupedPrefix, socketIDInt)
-			socketCPUSet := topo.CPUDetails.CPUsInSockets(socketIDInt)
+		for _, socketID := range socketIDs {
+			deviceName := fmt.Sprintf("%s%03d", cpuDeviceSocketGroupedPrefix, socketID)
+			socketCPUSet := topo.CPUDetails.CPUsInSockets(socketID)
 			allocatableCPUs := socketCPUSet.Difference(cp.reservedCPUs)
 			availableCPUsInSocket := int64(allocatableCPUs.Size())
 
@@ -76,25 +75,26 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices() [][]resourceapi.Device {
 				cpuResourceQualifiedName: {Value: *resource.NewQuantity(availableCPUsInSocket, resource.DecimalSI)},
 			}
 
-			cp.deviceNameToSocketID[deviceName] = socketIDInt
+			cp.deviceNameToSocketID[deviceName] = socketID
+
+			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				"dra.cpu/socketID":   {IntValue: ptr.To(int64(socketID))},
+				"dra.cpu/numCPUs":    {IntValue: ptr.To(availableCPUsInSocket)},
+				"dra.cpu/smtEnabled": {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
+			}
 
 			devices = append(devices, resourceapi.Device{
-				Name: deviceName,
-				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-					"dra.cpu/socketID":   {IntValue: &socketID},
-					"dra.cpu/numCPUs":    {IntValue: &availableCPUsInSocket},
-					"dra.cpu/smtEnabled": {BoolValue: &smtEnabled},
-				},
+				Name:                     deviceName,
+				Attributes:               deviceAttrs,
 				Capacity:                 deviceCapacity,
 				AllowMultipleAllocations: ptr.To(true),
 			})
 		}
 	case GROUP_BY_NUMA_NODE:
 		numaNodeIDs := topo.CPUDetails.NUMANodes().List()
-		for _, numaIDInt := range numaNodeIDs {
-			numaID := int64(numaIDInt)
-			deviceName := fmt.Sprintf("%s%03d", cpuDeviceNUMAGroupedPrefix, numaIDInt)
-			numaNodeCPUSet := topo.CPUDetails.CPUsInNUMANodes(numaIDInt)
+		for _, numaID := range numaNodeIDs {
+			deviceName := fmt.Sprintf("%s%03d", cpuDeviceNUMAGroupedPrefix, numaID)
+			numaNodeCPUSet := topo.CPUDetails.CPUsInNUMANodes(numaID)
 			allocatableCPUs := numaNodeCPUSet.Difference(cp.reservedCPUs)
 			availableCPUsInNUMANode := int64(allocatableCPUs.Size())
 
@@ -110,18 +110,19 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices() [][]resourceapi.Device {
 				cpuResourceQualifiedName: {Value: *resource.NewQuantity(availableCPUsInNUMANode, resource.DecimalSI)},
 			}
 
-			cp.deviceNameToNUMANodeID[deviceName] = numaIDInt
+			cp.deviceNameToNUMANodeID[deviceName] = numaID
+
+			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				"dra.cpu/numaNodeID": {IntValue: ptr.To(int64(numaID))},
+				"dra.cpu/socketID":   {IntValue: ptr.To(socketID)},
+				"dra.cpu/smtEnabled": {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
+				"dra.cpu/numCPUs":    {IntValue: ptr.To(availableCPUsInNUMANode)},
+			}
+			device.SetCompatibilityAttributes(deviceAttrs, int64(numaID))
 
 			devices = append(devices, resourceapi.Device{
-				Name: deviceName,
-				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-					"dra.cpu/numaNodeID": {IntValue: &numaID},
-					"dra.cpu/socketID":   {IntValue: &socketID},
-					"dra.cpu/numCPUs":    {IntValue: &availableCPUsInNUMANode},
-					"dra.cpu/smtEnabled": {BoolValue: &smtEnabled},
-					// TODO(pravk03): Remove. Hack to align with NIC (DRANet). We need some standard attribute to align other resources with CPU.
-					"dra.net/numaNode": {IntValue: &numaID},
-				},
+				Name:                     deviceName,
+				Attributes:               deviceAttrs,
 				Capacity:                 deviceCapacity,
 				AllowMultipleAllocations: ptr.To(true),
 			})
@@ -186,28 +187,24 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 	var allDevices []resourceapi.Device
 	for _, group := range coreGroups {
 		for _, cpu := range group {
-			numaNode := int64(cpu.NUMANodeID)
-			cacheL3ID := int64(cpu.UncoreCacheID)
-			socketID := int64(cpu.SocketID)
-			coreID := int64(cpu.CoreID)
-			cpuID := int64(cpu.CpuID)
-			coreType := cpu.CoreType.String()
+			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				"dra.cpu/numaNodeID": {IntValue: ptr.To(int64(cpu.NUMANodeID))},
+				"dra.cpu/socketID":   {IntValue: ptr.To(int64(cpu.SocketID))},
+				"dra.cpu/smtEnabled": {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
+				"dra.cpu/cacheL3ID":  {IntValue: ptr.To(int64(cpu.UncoreCacheID))},
+				"dra.cpu/coreType":   {StringValue: ptr.To(cpu.CoreType.String())},
+				"dra.cpu/coreID":     {IntValue: ptr.To(int64(cpu.CoreID))},
+				"dra.cpu/cpuID":      {IntValue: ptr.To(int64(cpu.CpuID))},
+			}
+			device.SetCompatibilityAttributes(deviceAttrs, int64(cpu.NUMANodeID))
+
 			deviceName := fmt.Sprintf("%s%03d", cpuDevicePrefix, devId)
 			devId++
 			cp.deviceNameToCPUID[deviceName] = cpu.CpuID
 			cpuDevice := resourceapi.Device{
-				Name: deviceName,
-				Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-					"dra.cpu/numaNodeID": {IntValue: &numaNode},
-					"dra.cpu/cacheL3ID":  {IntValue: &cacheL3ID},
-					"dra.cpu/coreType":   {StringValue: &coreType},
-					"dra.cpu/socketID":   {IntValue: &socketID},
-					"dra.cpu/coreID":     {IntValue: &coreID},
-					"dra.cpu/cpuID":      {IntValue: &cpuID},
-					// TODO(pravk03): Remove. Hack to align with NIC (DRANet). We need some standard attribute to align other resources with CPU.
-					"dra.net/numaNode": {IntValue: &numaNode},
-				},
-				Capacity: make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity),
+				Name:       deviceName,
+				Attributes: deviceAttrs,
+				Capacity:   make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity),
 			}
 			allDevices = append(allDevices, cpuDevice)
 		}


### PR DESCRIPTION
remove temporary variables and add a function whose purpose is to add attributes to enable compatibility with other relevant DRA drivers (dranet for now).

We will keep this function until all the attributes we need get standardized in kubernetes core - or any other mechanism the community will pick.

Unfortunately, at the moment the only way to be compatible with nonstandard attribute is crosscheck from both sides (driver <=> driver) creating a dense compatibility matrix.

This is awkward and scales poorly but it's all we have atm.