### PR TITLE
ci: precommit: don't run unit-tests

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,4 +18,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pre-commit
     - name: Run pre-commit
+      env:
+        SKIP_PRECOMMIT_UNIT_TESTS: "true"
       run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       # https://github.com/golangci/golangci-lint/blob/main/.pre-commit-hooks.yaml
       - id: make-tests
         name: Make Tests
-        entry: make test-unit
+        entry: bash -c 'if [ "${SKIP_PRECOMMIT_UNIT_TESTS}" != "true" ]; then make test-unit; fi'
         types: [go]
         language: system
         pass_filenames: false


### PR DESCRIPTION
Currently we run the unit tests both in the precommit lane and in the main build lane.
This surely wastes CI time and the benefits are unclear because ultimately precommit runs the same Makefile target as the main build lane. So it's really the very same work twice.

In this PR we remove the unit tests from the precommit lane, so each lane is now checking a different area.