### PR TITLE
cmd: flag: don't panic on -h

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -62,6 +62,9 @@ func newCPUDeviceModeValue(val *string, def string) *cpuDeviceModeValue {
 }
 
 func (v *cpuDeviceModeValue) String() string {
+	if v == nil || v.value == nil {
+		return ""
+	}
 	return *v.value
 }
 
@@ -83,6 +86,9 @@ func newGroupByValue(val *string, def string) *groupByValue {
 }
 
 func (v *groupByValue) String() string {
+	if v == nil || v.value == nil {
+		return ""
+	}
 	return *v.value
 }
 


### PR DESCRIPTION
prevent panic when we simply run `dracpu -h`.
We trivially need to handle unitialized custom flag.Var.