### PR TITLE
ci: precommit: workaround go 1.25 toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ GOLANGCI_LINT = $(OUT_DIR)/golangci-lint
 
 # disable CGO by default for static binaries
 CGO_ENABLED=0
+# remove once either we bump golang to 1.26 or https://github.com/golang/go/issues/75031 is fixed
+TOOOLCHAIN_MODE ?= $(shell go env GOVERSION)+auto
 export GOROOT GO111MODULE CGO_ENABLED
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
@@ -51,7 +53,7 @@ clean: ## clean
 	rm -rf "$(OUT_DIR)/"
 
 test-unit: ## run tests
-	CGO_ENABLED=1 go test -v -race -count 1 -coverprofile=coverage.out ./pkg/...
+	CGO_ENABLED=1 GOTOOLCHAIN=${TOOOLCHAIN_MODE} go test -v -race -count 1 -coverprofile=coverage.out ./pkg/...
 
 update: ## runs go mod tidy and go get -u
 	go get -u ./...


### PR DESCRIPTION
we were hit by https://stackoverflow.com/questions/79780882/go-no-such-tool-covdata-in-go-1-25 and this manifests when we add go source code without tests, which is generally bad but sometimes that can happen and be OK in very specific cases.

Nevertheless, let's keep our false negatives and CI runs as close to zero as possible