### PR TITLE
Default to stripping DWARF info and symbol table from binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@
 FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG TARGETARCH
 ARG GOARCH=${TARGETARCH} CGO_ENABLED=0
+ARG LDFLAGS=-s -w
 
 # cache go modules
 WORKDIR /go/src/app
@@ -24,7 +25,7 @@ RUN go mod download
 
 # build
 COPY . .
-RUN go build -o /go/bin/dracpu ./cmd/dracpu
+RUN go build -ldflags "${LDFLAGS}" -o /go/bin/dracpu ./cmd/dracpu
 
 # copy binary onto base image
 FROM gcr.io/distroless/base-debian12


### PR DESCRIPTION
DWARF debug info and symbol tables are primarily needed during debugging (e.g. with Delve). Since DWARF was originally designed for C and its utility in Go is minimal, there is little reason to include it in the builds by default.

The diff in terms of image size (before and after)
```
docker images --format "{{.Repository}} {{.Size}}" | grep dra
dra-cpu 137MB
dra-cpu 104MB
```