### PR TITLE
feat: add custom Prometheus metrics for CPU allocation monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ This discrepancy is a known issue being addressed by [KEP-5517: Native Resource 
 
 **1-to-1 Claim to Container:** This driver enforces that a specific CPU `ResourceClaim` can only be used by *one* container within or across pods. See [Sharing resource claims](#sharing-resource-claims).
 
+## Metrics
+
+> **Note**: The metrics exposed by this driver are provisional and may change or be removed in future releases.
+
+The driver exposes Prometheus metrics via the `/metrics` HTTP endpoint on the address configured by `--bind-address` (default `:8080`).
+
+| Metric Name                              | Type      | Description                                                               |
+| ---------------------------------------- | --------- | ------------------------------------------------------------------------- |
+| `dra_cpu_allocated_cpus`                 | Gauge     | Number of CPUs currently allocated to resource claims.                    |
+| `dra_cpu_available_cpus`                 | Gauge     | Number of CPUs available for allocation.                                  |
+| `dra_cpu_reserved_cpus`                  | Gauge     | Number of CPUs reserved and excluded from allocation.                     |
+| `dra_cpu_resource_claims_active`         | Gauge     | Number of currently active resource claim allocations.                    |
+| `dra_cpu_prepare_claims_success_total`   | Counter   | Total number of successful PrepareResourceClaims operations.              |
+| `dra_cpu_prepare_claims_error_total`     | Counter   | Total number of failed PrepareResourceClaims operations.                  |
+| `dra_cpu_unprepare_claims_total`         | Counter   | Total number of UnprepareResourceClaims operations.                       |
+| `dra_cpu_prepare_claim_duration_seconds` | Histogram | Duration of individual resource claim prepare operations in seconds.      |
+| `dra_cpu_claim_allocated_cpus`           | Histogram | Number of CPUs allocated per claim. Buckets: 1, 2, 4, 8, 16, 32, 64, 128. |
+
+Use `--show-metrics` to print all registered metrics to stdout and exit without starting the driver.
+
 ## Prerequisites
 
 The driver relies on [NRI (Node Resource Interface)](https://github.com/containerd/nri) to pin containers to their

--- a/README.md
+++ b/README.md
@@ -392,8 +392,8 @@ The command prints JSON metadata for custom `dra_cpu_*` metrics only. It does no
 | `dra_cpu_available_cpus`                 | Gauge     | none     | CPUs still available for allocation after reserved and active claim CPUs are excluded. |
 | `dra_cpu_reserved_cpus`                  | Gauge     | none     | CPUs excluded from DRA management by driver configuration.                             |
 | `dra_cpu_resource_claims_active`         | Gauge     | none     | Resource claims currently recorded as active by the allocation store.                  |
-| `dra_cpu_prepare_claims_total`           | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success` or `error`.           |
-| `dra_cpu_unprepare_claims_total`         | Counter   | `result` | Per-claim `UnprepareResourceClaims` results. `result` is `success` or `error`.         |
+| `dra_cpu_prepare_claims_total`           | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success`, `error`, or `unknown`. |
+| `dra_cpu_unprepare_claims_total`         | Counter   | `result` | Per-claim `UnprepareResourceClaims` results. `result` is `success`, `error`, or `unknown`. |
 | `dra_cpu_prepare_claim_duration_seconds` | Histogram | none     | Per-claim prepare latency in seconds.                                                  |
 | `dra_cpu_claim_allocated_cpus`           | Histogram | none     | CPUs allocated for each newly successful claim allocation.                             |
 

--- a/README.md
+++ b/README.md
@@ -386,16 +386,16 @@ dracpu --show-metrics
 
 The command prints JSON metadata for custom `dra_cpu_*` metrics only. It does not include default Go runtime, process, or Prometheus client metrics.
 
-| Metric                                   | Type      | Labels   | Description                                                                            |
-| ---------------------------------------- | --------- | -------- | -------------------------------------------------------------------------------------- |
-| `dra_cpu_allocated_cpus`                 | Gauge     | none     | CPUs currently allocated to prepared resource claims.                                  |
-| `dra_cpu_available_cpus`                 | Gauge     | none     | CPUs still available for allocation after reserved and active claim CPUs are excluded. |
-| `dra_cpu_reserved_cpus`                  | Gauge     | none     | CPUs excluded from DRA management by driver configuration.                             |
-| `dra_cpu_resource_claims_active`         | Gauge     | none     | Resource claims currently recorded as active by the allocation store.                  |
-| `dra_cpu_prepare_claims_total`           | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success`, `error`, or `unknown`. |
+| Metric                                   | Type      | Labels   | Description                                                                                |
+| ---------------------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------ |
+| `dra_cpu_allocated_cpus`                 | Gauge     | none     | CPUs currently allocated to prepared resource claims.                                      |
+| `dra_cpu_available_cpus`                 | Gauge     | none     | CPUs still available for allocation after reserved and active claim CPUs are excluded.     |
+| `dra_cpu_reserved_cpus`                  | Gauge     | none     | CPUs excluded from DRA management by driver configuration.                                 |
+| `dra_cpu_resource_claims_active`         | Gauge     | none     | Resource claims currently recorded as active by the allocation store.                      |
+| `dra_cpu_prepare_claims_total`           | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success`, `error`, or `unknown`.   |
 | `dra_cpu_unprepare_claims_total`         | Counter   | `result` | Per-claim `UnprepareResourceClaims` results. `result` is `success`, `error`, or `unknown`. |
-| `dra_cpu_prepare_claim_duration_seconds` | Histogram | none     | Per-claim prepare latency in seconds.                                                  |
-| `dra_cpu_claim_allocated_cpus`           | Histogram | none     | CPUs allocated for each newly successful claim allocation.                             |
+| `dra_cpu_prepare_claim_duration_seconds` | Histogram | none     | Per-claim prepare latency in seconds.                                                      |
+| `dra_cpu_claim_allocated_cpus`           | Histogram | none     | CPUs allocated for each newly successful claim allocation.                                 |
 
 The custom metrics intentionally avoid labels for namespace, pod, claim, device, node, socket, NUMA node, group mode, and error reason. Those labels would either be high-cardinality or need more API design before becoming part of the driver's metric surface. Node identity should come from scrape target labels.
 

--- a/README.md
+++ b/README.md
@@ -371,6 +371,34 @@ The driver allocates the specified cores directly (after validating that they ar
 >   - The cores are not reserved using the driver's `--reserved-cpus` configuration flag.
 > - **Error Handling**: If validation fails (e.g. core conflict, size mismatch, duplicate target, or offline cores), the driver returns a failure immediately in Kubelet's `PrepareResourceClaims` hook, causing pod startup to fail.
 
+## Metrics
+
+The driver exposes Prometheus metrics on the existing HTTP `/metrics` endpoint served by `--bind-address` (default `:8080`).
+
+> [!NOTE]
+> Driver custom metrics are ALPHA. They are useful for early observability, but metric names, labels, buckets, and semantics may change in future releases.
+
+Custom driver metrics can also be listed programmatically without starting the driver:
+
+```bash
+dracpu --show-metrics
+```
+
+The command prints JSON metadata for custom `dra_cpu_*` metrics only. It does not include default Go runtime, process, or Prometheus client metrics.
+
+| Metric                                   | Type      | Labels   | Description                                                                            |
+| ---------------------------------------- | --------- | -------- | -------------------------------------------------------------------------------------- |
+| `dra_cpu_allocated_cpus`                 | Gauge     | none     | CPUs currently allocated to prepared resource claims.                                  |
+| `dra_cpu_available_cpus`                 | Gauge     | none     | CPUs still available for allocation after reserved and active claim CPUs are excluded. |
+| `dra_cpu_reserved_cpus`                  | Gauge     | none     | CPUs excluded from DRA management by driver configuration.                             |
+| `dra_cpu_resource_claims_active`         | Gauge     | none     | Resource claims currently recorded as active by the allocation store.                  |
+| `dra_cpu_prepare_claims_total`           | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success` or `error`.           |
+| `dra_cpu_unprepare_claims_total`         | Counter   | `result` | Per-claim `UnprepareResourceClaims` results. `result` is `success` or `error`.         |
+| `dra_cpu_prepare_claim_duration_seconds` | Histogram | none     | Per-claim prepare latency in seconds.                                                  |
+| `dra_cpu_claim_allocated_cpus`           | Histogram | none     | CPUs allocated for each newly successful claim allocation.                             |
+
+The custom metrics intentionally avoid labels for namespace, pod, claim, device, node, socket, NUMA node, group mode, and error reason. Those labels would either be high-cardinality or need more API design before becoming part of the driver's metric surface. Node identity should come from scrape target labels.
+
 ## Prerequisites
 
 The driver relies on [NRI (Node Resource Interface)](https://github.com/containerd/nri) to pin containers to their

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -24,10 +24,13 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/driver"
+	_ "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sys/unix"
 	"k8s.io/client-go/kubernetes"
@@ -50,6 +53,7 @@ var (
 	ready            atomic.Bool
 	cpuDeviceMode    string
 	groupBy          string
+	showMetrics      bool
 )
 
 type cpuDeviceModeValue struct {
@@ -107,11 +111,17 @@ func init() {
 	flag.StringVar(&reservedCPUs, "reserved-cpus", "", "cpuset of CPUs to be excluded from ResourceSlice.")
 	flag.Var(newCPUDeviceModeValue(&cpuDeviceMode, driver.CPU_DEVICE_MODE_GROUPED), "cpu-device-mode", "Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device.")
 	flag.Var(newGroupByValue(&groupBy, driver.GROUP_BY_NUMA_NODE), "group-by", "When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket' or 'numanode'.")
+	flag.BoolVar(&showMetrics, "show-metrics", false, "Print all registered metrics to stdout and exit.")
 }
 
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
+
+	if showMetrics {
+		printRegisteredMetrics()
+		os.Exit(0)
+	}
 
 	printVersion()
 	flag.VisitAll(func(f *flag.Flag) {
@@ -234,4 +244,19 @@ func printVersion() {
 		}
 	}
 	klog.Infof("dracpu go %s build: %s time: %s", info.GoVersion, vcsRevision, vcsTime)
+}
+
+func printRegisteredMetrics() {
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error gathering metrics: %v\n", err)
+		os.Exit(1)
+	}
+	for _, mf := range families {
+		if !strings.HasPrefix(mf.GetName(), "dra_cpu_") {
+			continue
+		}
+		fmt.Printf("# %s\n", mf.GetHelp())
+		fmt.Printf("%s (type: %s)\n\n", mf.GetName(), mf.GetType())
+	}
 }

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -34,6 +35,8 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/internal/driverconfig"
 	"github.com/kubernetes-sigs/dra-driver-cpu/internal/gatherinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/driver"
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sys/unix"
 	"k8s.io/client-go/kubernetes"
@@ -70,6 +73,14 @@ func main() {
 
 	ctxlog.AddFlags(flag.CommandLine)
 	flag.Parse()
+
+	if driverFlags.ShowMetrics {
+		if err := printMetricsMetadata(os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "print metrics metadata: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	logger := ctxlog.Setup()
 
@@ -169,6 +180,7 @@ func run(logger logr.Logger) error {
 		CPUDeviceMode:    driverFlags.CPUDeviceMode,
 		CPUDeviceGroupBy: driverFlags.GroupBy,
 		ExposePCIeRoots:  driverFlags.ExposePCIeRoots,
+		Metrics:          cpumetrics.New(prometheus.DefaultRegisterer),
 	}
 	driverProviders := driver.Providers{
 		K8SClient: clientset,
@@ -213,4 +225,8 @@ func printVersion(logger logr.Logger) {
 		return
 	}
 	logger.Info("dracpu", "goVersion", info.GoVersion, "build", info.VCSRevision, "time", info.VCSTime)
+}
+
+func printMetricsMetadata(w io.Writer) error {
+	return cpumetrics.WriteJSON(w)
 }

--- a/cmd/dracpu/metrics_test.go
+++ b/cmd/dracpu/metrics_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintMetricsMetadata(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, printMetricsMetadata(&buf))
+
+	var descriptors []cpumetrics.Descriptor
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &descriptors))
+	require.Equal(t, cpumetrics.Descriptors(), descriptors)
+	require.Contains(t, buf.String(), "dra_cpu_allocated_cpus")
+	require.NotContains(t, buf.String(), "go_gc_duration_seconds")
+}

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knqyf263/go-plugin v0.9.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.40.0
 	k8s.io/api v0.36.0
@@ -55,6 +56,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knqyf263/go-plugin v0.9.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -63,7 +65,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20251114084447-edf4cb3d2116 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/internal/driverconfig/config.go
+++ b/internal/driverconfig/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	CPUDeviceMode    string `json:"cpuDeviceMode"`
 	GroupBy          string `json:"groupBy,omitempty"`
 	ExposePCIeRoots  bool   `json:"exposePCIeRoots,omitempty"`
+	ShowMetrics      bool   `json:"showMetrics,omitempty"`
 }
 
 func Default() Config {
@@ -51,6 +52,7 @@ func (c *Config) AddFlags(fs *flag.FlagSet) {
 	fs.Var(newCPUDeviceModeValue(&c.CPUDeviceMode, c.CPUDeviceMode), "cpu-device-mode", "Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device.")
 	fs.Var(newGroupByValue(&c.GroupBy, c.GroupBy), "group-by", "When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket', 'numanode', or 'machine' (machine mode requires an external scheduler to include cpuset configuration in claim allocation results).")
 	fs.BoolVar(&c.ExposePCIeRoots, "expose-pcie-roots", c.ExposePCIeRoots, "Discover and expose PCIe roots as device attributes. Requires the DRAListTypeAttributes=true Feature Gate in the cluster.")
+	fs.BoolVar(&c.ShowMetrics, "show-metrics", c.ShowMetrics, "Print custom driver metrics metadata as JSON and exit.")
 }
 
 func (c *Config) applyDefaults() {

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driverconfig
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddFlagsShowMetrics(t *testing.T) {
+	cfg := Default()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	require.NoError(t, fs.Parse([]string{"--show-metrics"}))
+	require.True(t, cfg.ShowMetrics)
+}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -23,10 +23,12 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpumanager"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -266,6 +268,7 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 	}
 
 	for _, claim := range claims {
+		start := time.Now()
 		if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
 			klog.Infof("Claim %s/%s is for a grouped resource", claim.Namespace, claim.Name)
 			result[claim.UID] = cp.prepareGroupedResourceClaim(ctx, claim)
@@ -273,6 +276,8 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 			klog.Infof("Claim %s/%s is for an individual resource", claim.Namespace, claim.Name)
 			result[claim.UID] = cp.prepareResourceClaim(ctx, claim)
 		}
+		metrics.Default.PrepareClaimDuration.Observe(time.Since(start).Seconds())
+		metrics.Default.RecordPrepareResult(result[claim.UID].Err)
 	}
 	return result, nil
 }
@@ -339,6 +344,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 	}
 
 	cp.cpuAllocationStore.AddResourceClaimAllocation(claim.UID, cpuAssignment)
+	metrics.Default.ClaimAllocatedCPUs.Observe(float64(cpuAssignment.Size()))
 
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, cpuAssignment.String())
@@ -398,6 +404,7 @@ func (cp *CPUDriver) prepareResourceClaim(_ context.Context, claim *resourceapi.
 
 	claimCPUSet := cpuset.New(claimCPUIDs...)
 	cp.cpuAllocationStore.AddResourceClaimAllocation(claim.UID, claimCPUSet)
+	metrics.Default.ClaimAllocatedCPUs.Observe(float64(claimCPUSet.Size()))
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, claimCPUSet.String())
 	if err := cp.cdiMgr.AddDevice(deviceName, envVar); err != nil {
@@ -441,6 +448,7 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 		if err != nil {
 			klog.Infof("error unpreparing resources for claim %s/%s : %v", claim.Namespace, claim.Name, err)
 		}
+		metrics.Default.UnprepareClaimTotal.Inc()
 	}
 	return result, nil
 }

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"time"
 
 	"github.com/go-logr/logr"
 	opaqueapi "github.com/kubernetes-sigs/dra-driver-cpu/api"
@@ -30,6 +31,7 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpumanager"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -315,12 +317,18 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 	}
 
 	for _, claim := range claims {
+		start := time.Now()
 		cLogger := logger.WithValues("claim", ctxlog.KObj(claim), "claimUID", claim.UID)
 		if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
 			result[claim.UID] = cp.prepareGroupedResourceClaim(cLogger, claim)
 		} else {
 			result[claim.UID] = cp.prepareResourceClaim(cLogger, claim)
 		}
+		prepareResult := cpumetrics.ResultSuccess
+		if result[claim.UID].Err != nil {
+			prepareResult = cpumetrics.ResultError
+		}
+		cp.metricsRecorder().RecordPrepare(prepareResult, time.Since(start))
 	}
 	return result, nil
 }
@@ -418,6 +426,8 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		return result
 	}
 	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, cpuAssignment)
+	cp.metricsRecorder().RecordClaimAllocatedCPUs(cpuAssignment.Size())
+	cp.refreshAllocationMetrics()
 	return result
 }
 
@@ -474,6 +484,8 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		return result
 	}
 	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, claimCPUSet)
+	cp.metricsRecorder().RecordClaimAllocatedCPUs(claimCPUSet.Size())
+	cp.refreshAllocationMetrics()
 	return result
 }
 
@@ -529,9 +541,33 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 		result[claim.UID] = err
 		if err != nil {
 			cLogger.Error(err, "error unpreparing resources for claim")
+			cp.metricsRecorder().RecordUnprepare(cpumetrics.ResultError)
+		} else {
+			cp.metricsRecorder().RecordUnprepare(cpumetrics.ResultSuccess)
+			cp.refreshAllocationMetrics()
 		}
 	}
 	return result, nil
+}
+
+func (cp *CPUDriver) metricsRecorder() cpumetrics.Recorder {
+	if cp.metrics == nil {
+		return cpumetrics.Noop()
+	}
+	return cp.metrics
+}
+
+func (cp *CPUDriver) refreshAllocationMetrics() {
+	if cp.cpuAllocationStore == nil {
+		return
+	}
+	snapshot := cp.cpuAllocationStore.Snapshot()
+	cp.metricsRecorder().SetAllocationState(cpumetrics.AllocationState{
+		AllocatedCPUs:        snapshot.AllocatedCPUs,
+		AvailableCPUs:        snapshot.AvailableCPUs,
+		ReservedCPUs:         snapshot.ReservedCPUs,
+		ActiveResourceClaims: snapshot.ActiveResourceClaims,
+	})
 }
 
 func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplugin.NamespacedObject) error {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -470,6 +470,7 @@ func TestPublishResourcesGroupedModeInitializesLookupMaps(t *testing.T) {
 				CPUInfo: &cpuinfo.MockCPUInfoProvider{
 					CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 				},
+				SysFS: testSysFS(mockCPUInfos_DualSocket_4CPUsPerSocket_HT),
 			}
 			conf := Config{
 				DriverName:       testDriverName,

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/internal/ctxlog"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -104,6 +105,7 @@ type CPUDriver struct {
 	claimTracker            *store.ClaimTracker
 	pcieRootMapper          *store.PCIeRootMapper
 	devicesPerResourceSlice int
+	metrics                 cpumetrics.Recorder
 }
 
 // Providers group the interfaces the CPUDriver depends on
@@ -135,6 +137,7 @@ type Config struct {
 	CPUDeviceMode    string
 	CPUDeviceGroupBy string
 	ExposePCIeRoots  bool
+	Metrics          cpumetrics.Recorder
 }
 
 func (cfg Config) DevicesPerResourceSlice() int {
@@ -151,6 +154,10 @@ func (cfg Config) DevicesPerResourceSlice() int {
 func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, error) {
 	logger = logger.WithValues("driver", config.DriverName)
 
+	metricsRecorder := config.Metrics
+	if metricsRecorder == nil {
+		metricsRecorder = cpumetrics.Noop()
+	}
 	plugin := &CPUDriver{
 		driverName:              config.DriverName,
 		nodeName:                config.NodeName,
@@ -164,6 +171,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 		claimTracker:            store.NewClaimTracker(),
 		pcieRootMapper:          store.NewPCIeRootMapper(),
 		devicesPerResourceSlice: config.DevicesPerResourceSlice(),
+		metrics:                 metricsRecorder,
 	}
 	sysfs := providers.EnsureSysFS()
 
@@ -190,6 +198,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 	}
 
 	plugin.cpuAllocationStore = store.NewCPUAllocation(plugin.cpuTopology, config.ReservedCPUs)
+	plugin.refreshAllocationMetrics()
 	plugin.podConfigStore = store.NewPodConfig()
 
 	if plugin.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/utils/cpuset"
+)
+
+func TestMetricsCountersOnPrepareUnprepare(t *testing.T) {
+	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
+	topo, _ := mockProvider.GetCPUTopology()
+
+	newDriver := func() *CPUDriver {
+		metrics.ResetForTest()
+		return &CPUDriver{
+			driverName: testDriverName,
+			deviceNameToCPUID: map[string]int{
+				"cpudev0": 0,
+				"cpudev1": 1,
+			},
+			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+			cdiMgr:             newMockCdiMgr(),
+		}
+	}
+
+	t.Run("prepare success increments counter", func(t *testing.T) {
+		driver := newDriver()
+		claims := []*resourceapi.ResourceClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{UID: "claim-counter-1", Name: "test-claim"},
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{Driver: testDriverName, Pool: testNodeName, Device: "cpudev0"},
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := driver.PrepareResourceClaims(context.Background(), claims)
+		require.NoError(t, err)
+
+		success := metrics.Default.PrepareClaimTotal.WithLabelValues("success")
+		errCtr := metrics.Default.PrepareClaimTotal.WithLabelValues("error")
+		require.InDelta(t, 1, testutil.ToFloat64(success), 0.01)
+		require.InDelta(t, 0, testutil.ToFloat64(errCtr), 0.01)
+	})
+
+	t.Run("prepare error increments error counter", func(t *testing.T) {
+		driver := newDriver()
+		claims := []*resourceapi.ResourceClaim{
+			{ObjectMeta: metav1.ObjectMeta{UID: "claim-counter-2", Name: "test-claim-err"}},
+		}
+		_, err := driver.PrepareResourceClaims(context.Background(), claims)
+		require.NoError(t, err)
+
+		errCtr := metrics.Default.PrepareClaimTotal.WithLabelValues("error")
+		require.InDelta(t, 1, testutil.ToFloat64(errCtr), 0.01)
+	})
+
+	t.Run("unprepare increments counter", func(t *testing.T) {
+		driver := newDriver()
+		claims := []kubeletplugin.NamespacedObject{{UID: "claim-counter-3"}}
+		_, err := driver.UnprepareResourceClaims(context.Background(), claims)
+		require.NoError(t, err)
+		require.InDelta(t, 1, testutil.ToFloat64(metrics.Default.UnprepareClaimTotal), 0.01)
+	})
+
+	t.Run("prepare records duration histogram", func(t *testing.T) {
+		driver := newDriver()
+		claims := []*resourceapi.ResourceClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{UID: "claim-duration-1", Name: "test-claim-dur"},
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{Driver: testDriverName, Pool: testNodeName, Device: "cpudev0"},
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := driver.PrepareResourceClaims(context.Background(), claims)
+		require.NoError(t, err)
+		require.Greater(t, testutil.CollectAndCount(metrics.Default.PrepareClaimDuration), 0)
+	})
+
+	t.Run("prepare records allocated CPUs histogram", func(t *testing.T) {
+		driver := newDriver()
+		claims := []*resourceapi.ResourceClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{UID: "claim-alloc-cpus-1", Name: "test-claim-alloc"},
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{
+							Results: []resourceapi.DeviceRequestAllocationResult{
+								{Driver: testDriverName, Pool: testNodeName, Device: "cpudev0"},
+								{Driver: testDriverName, Pool: testNodeName, Device: "cpudev1"},
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := driver.PrepareResourceClaims(context.Background(), claims)
+		require.NoError(t, err)
+		require.Equal(t, 1, testutil.CollectAndCount(metrics.Default.ClaimAllocatedCPUs))
+	})
+}

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -134,8 +134,8 @@ func TestMetricsPrepareResults(t *testing.T) {
 	require.NoError(t, prepared["claim-success"].Err)
 	require.Error(t, prepared["claim-error"].Err)
 
-	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_prepare_claims_total", map[string]string{"result": cpumetrics.ResultSuccess}))
-	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_prepare_claims_total", map[string]string{"result": cpumetrics.ResultError}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_prepare_claims_total", map[string]string{"result": cpumetrics.ResultSuccess.String()}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_prepare_claims_total", map[string]string{"result": cpumetrics.ResultError.String()}))
 	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_prepare_claim_duration_seconds", nil))
 }
 
@@ -174,7 +174,7 @@ func TestMetricsUnprepareResults(t *testing.T) {
 	unprepared, err := driver.UnprepareResourceClaims(context.Background(), []kubeletplugin.NamespacedObject{{UID: claimUID}})
 	require.NoError(t, err)
 	require.NoError(t, unprepared[claimUID])
-	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultSuccess}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultSuccess.String()}))
 	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_allocated_cpus", nil))
 	require.Equal(t, float64(4), metricValue(t, reg, "dra_cpu_available_cpus", nil))
 	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_resource_claims_active", nil))
@@ -183,5 +183,5 @@ func TestMetricsUnprepareResults(t *testing.T) {
 	unprepared, err = driver.UnprepareResourceClaims(context.Background(), []kubeletplugin.NamespacedObject{{UID: "claim-error"}})
 	require.NoError(t, err)
 	require.Error(t, unprepared["claim-error"])
-	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultError}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultError.String()}))
 }

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/utils/cpuset"
+)
+
+func newMetricsTestDriver(t *testing.T) (*CPUDriver, *prometheus.Registry) {
+	t.Helper()
+	logger := testr.New(t)
+	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
+	topo, err := mockProvider.GetCPUTopology(logger)
+	require.NoError(t, err)
+
+	reg := prometheus.NewRegistry()
+	recorder := cpumetrics.New(reg)
+	cpuStore := store.NewCPUAllocation(topo, cpuset.New())
+	driver := &CPUDriver{
+		driverName: testDriverName,
+		deviceNameToCPUID: map[string]int{
+			"cpudev0": 0,
+			"cpudev1": 1,
+			"cpudev2": 2,
+			"cpudev3": 3,
+		},
+		cpuAllocationStore: cpuStore,
+		cdiMgr:             newMockCdiMgr(),
+		metrics:            recorder,
+	}
+	driver.refreshAllocationMetrics()
+	return driver, reg
+}
+
+func individualMetricsClaim(uid types.UID, devices ...string) *resourceapi.ResourceClaim {
+	results := make([]resourceapi.DeviceRequestAllocationResult, 0, len(devices))
+	for _, device := range devices {
+		results = append(results, resourceapi.DeviceRequestAllocationResult{
+			Driver: testDriverName,
+			Pool:   testNodeName,
+			Device: device,
+		})
+	}
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{UID: uid, Name: string(uid)},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{Results: results},
+			},
+		},
+	}
+}
+
+func metricValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.Metric {
+			if metricLabelsMatch(metric, labels) {
+				return metricSampleValue(metric)
+			}
+		}
+	}
+	require.FailNow(t, fmt.Sprintf("metric %s with labels %v not found", name, labels))
+	return 0
+}
+
+func metricLabelsMatch(metric *dto.Metric, want map[string]string) bool {
+	if len(metric.Label) != len(want) {
+		return false
+	}
+	for _, label := range metric.Label {
+		if want[label.GetName()] != label.GetValue() {
+			return false
+		}
+	}
+	return true
+}
+
+func metricSampleValue(metric *dto.Metric) float64 {
+	switch {
+	case metric.Gauge != nil:
+		return metric.Gauge.GetValue()
+	case metric.Counter != nil:
+		return metric.Counter.GetValue()
+	case metric.Histogram != nil:
+		return float64(metric.Histogram.GetSampleCount())
+	default:
+		return 0
+	}
+}
+
+func TestMetricsPrepareResults(t *testing.T) {
+	driver, reg := newMetricsTestDriver(t)
+
+	prepared, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{
+		individualMetricsClaim("claim-success", "cpudev0"),
+		{ObjectMeta: metav1.ObjectMeta{UID: "claim-error", Name: "claim-error"}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, prepared["claim-success"].Err)
+	require.Error(t, prepared["claim-error"].Err)
+
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_prepare_claims_total", map[string]string{"result": cpumetrics.ResultSuccess}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_prepare_claims_total", map[string]string{"result": cpumetrics.ResultError}))
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_prepare_claim_duration_seconds", nil))
+}
+
+func TestMetricsAllocationStateAndClaimSize(t *testing.T) {
+	driver, reg := newMetricsTestDriver(t)
+
+	prepared, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{
+		individualMetricsClaim("claim-alloc", "cpudev0", "cpudev1"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, prepared["claim-alloc"].Err)
+
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_allocated_cpus", nil))
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_available_cpus", nil))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_reserved_cpus", nil))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_resource_claims_active", nil))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_claim_allocated_cpus", nil))
+
+	prepared, err = driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{
+		individualMetricsClaim("claim-alloc", "cpudev0", "cpudev1"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, prepared["claim-alloc"].Err)
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_claim_allocated_cpus", nil), "duplicate prepare must not record a new allocation size")
+}
+
+func TestMetricsUnprepareResults(t *testing.T) {
+	driver, reg := newMetricsTestDriver(t)
+	claimUID := types.UID("claim-unprepare")
+	prepared, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{
+		individualMetricsClaim(claimUID, "cpudev0", "cpudev1"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, prepared[claimUID].Err)
+
+	unprepared, err := driver.UnprepareResourceClaims(context.Background(), []kubeletplugin.NamespacedObject{{UID: claimUID}})
+	require.NoError(t, err)
+	require.NoError(t, unprepared[claimUID])
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultSuccess}))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_allocated_cpus", nil))
+	require.Equal(t, float64(4), metricValue(t, reg, "dra_cpu_available_cpus", nil))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_resource_claims_active", nil))
+
+	driver.cdiMgr.(*mockCdiMgr).removeError = fmt.Errorf("remove failed")
+	unprepared, err = driver.UnprepareResourceClaims(context.Background(), []kubeletplugin.NamespacedObject{{UID: "claim-error"}})
+	require.NoError(t, err)
+	require.Error(t, unprepared["claim-error"])
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultError}))
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const Subsystem = "dra_cpu"
+
+// Metrics bundles all Prometheus collectors used by the driver.
+// Struct-based design enables dependency injection and hermetic tests.
+type Metrics struct {
+	PrepareClaimTotal    *prometheus.CounterVec
+	UnprepareClaimTotal  prometheus.Counter
+	PrepareClaimDuration prometheus.Histogram
+	ClaimAllocatedCPUs   prometheus.Histogram
+
+	AllocatedCPUs        prometheus.Gauge
+	AvailableCPUs        prometheus.Gauge
+	ReservedCPUs         prometheus.Gauge
+	ActiveResourceClaims prometheus.Gauge
+}
+
+// New creates a Metrics instance and registers all collectors with the
+// provided registerer. Passing a fresh registry makes tests independent.
+func New(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		PrepareClaimTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "prepare_claim_total",
+			Help:      "Total PrepareResourceClaims operations, by result.",
+		}, []string{"result"}),
+		UnprepareClaimTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Subsystem: Subsystem,
+			Name:      "unprepare_claims_total",
+			Help:      "Total UnprepareResourceClaims operations.",
+		}),
+		PrepareClaimDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "prepare_claim_duration_seconds",
+			Help:      "Duration of prepare operations in seconds.",
+			Buckets:   prometheus.DefBuckets,
+		}),
+		ClaimAllocatedCPUs: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Subsystem: Subsystem,
+			Name:      "claim_allocated_cpus",
+			Help:      "Number of CPUs allocated per claim.",
+			Buckets:   []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024},
+		}),
+		AllocatedCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: Subsystem, Name: "allocated_cpus",
+			Help: "Number of CPUs currently allocated to resource claims.",
+		}),
+		AvailableCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: Subsystem, Name: "available_cpus",
+			Help: "Number of CPUs available for allocation.",
+		}),
+		ReservedCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: Subsystem, Name: "reserved_cpus",
+			Help: "Number of CPUs reserved and excluded from allocation.",
+		}),
+		ActiveResourceClaims: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: Subsystem, Name: "resource_claims_active",
+			Help: "Number of currently active resource claim allocations.",
+		}),
+	}
+	reg.MustRegister(
+		m.PrepareClaimTotal,
+		m.UnprepareClaimTotal,
+		m.PrepareClaimDuration,
+		m.ClaimAllocatedCPUs,
+		m.AllocatedCPUs,
+		m.AvailableCPUs,
+		m.ReservedCPUs,
+		m.ActiveResourceClaims,
+	)
+	return m
+}
+
+// RecordPrepareResult is a helper: label "success" or "error".
+func (m *Metrics) RecordPrepareResult(err error) {
+	label := "success"
+	if err != nil {
+		label = "error"
+	}
+	m.PrepareClaimTotal.WithLabelValues(label).Inc()
+}
+
+// Default is the process-wide Metrics instance registered with the default
+// Prometheus registry. Tests may replace via ResetForTest.
+var Default = New(prometheus.DefaultRegisterer)
+
+// ResetForTest replaces Default with a fresh Metrics bound to a new registry.
+// Returns the new registry for assertions. Test-only.
+func ResetForTest() *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+	Default = New(reg)
+	return reg
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,6 +32,7 @@ type Result string
 const (
 	ResultSuccess Result = "success"
 	ResultError   Result = "error"
+	ResultUnknown Result = "unknown"
 )
 
 func (r Result) String() string {
@@ -40,8 +41,10 @@ func (r Result) String() string {
 		return string(ResultSuccess)
 	case ResultError:
 		return string(ResultError)
+	case ResultUnknown:
+		return string(ResultUnknown)
 	default:
-		return string(ResultError)
+		return string(ResultUnknown)
 	}
 }
 
@@ -205,6 +208,10 @@ func New(reg prometheus.Registerer) *Metrics {
 		m.prepareClaimDuration,
 		m.claimAllocatedCPUs,
 	)
+	for _, result := range []Result{ResultSuccess, ResultError, ResultUnknown} {
+		m.prepareClaims.WithLabelValues(result.String())
+		m.unprepareClaims.WithLabelValues(result.String())
+	}
 	return m
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,12 +24,26 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	subsystem = "dra_cpu"
+const stability = "ALPHA"
 
-	ResultSuccess = "success"
-	ResultError   = "error"
+// Result is the bounded label domain for operation result metrics.
+type Result string
+
+const (
+	ResultSuccess Result = "success"
+	ResultError   Result = "error"
 )
+
+func (r Result) String() string {
+	switch r {
+	case ResultSuccess:
+		return string(ResultSuccess)
+	case ResultError:
+		return string(ResultError)
+	default:
+		return string(ResultError)
+	}
+}
 
 // Descriptor describes a custom driver metric for programmatic introspection.
 type Descriptor struct {
@@ -51,8 +65,8 @@ type AllocationState struct {
 // Recorder records driver metrics.
 type Recorder interface {
 	SetAllocationState(AllocationState)
-	RecordPrepare(result string, duration time.Duration)
-	RecordUnprepare(result string)
+	RecordPrepare(result Result, duration time.Duration)
+	RecordUnprepare(result Result)
 	RecordClaimAllocatedCPUs(cpus int)
 }
 
@@ -68,65 +82,91 @@ type Metrics struct {
 	claimAllocatedCPUs   prometheus.Histogram
 }
 
-var descriptors = []Descriptor{
-	{
-		Name:      "dra_cpu_allocated_cpus",
-		Type:      "gauge",
-		Stability: "ALPHA",
-		Help:      "Number of CPUs currently allocated to prepared resource claims.",
-	},
-	{
-		Name:      "dra_cpu_available_cpus",
-		Type:      "gauge",
-		Stability: "ALPHA",
-		Help:      "Number of CPUs available for allocation after reserved and active claim CPUs are excluded.",
-	},
-	{
-		Name:      "dra_cpu_reserved_cpus",
-		Type:      "gauge",
-		Stability: "ALPHA",
-		Help:      "Number of CPUs reserved and excluded from DRA management.",
-	},
-	{
-		Name:      "dra_cpu_resource_claims_active",
-		Type:      "gauge",
-		Stability: "ALPHA",
-		Help:      "Number of resource claims currently recorded as active by the allocation store.",
-	},
-	{
-		Name:      "dra_cpu_prepare_claims_total",
-		Type:      "counter",
-		Stability: "ALPHA",
-		Help:      "Total number of per-claim PrepareResourceClaims results.",
-		Labels:    []string{"result"},
-	},
-	{
-		Name:      "dra_cpu_unprepare_claims_total",
-		Type:      "counter",
-		Stability: "ALPHA",
-		Help:      "Total number of per-claim UnprepareResourceClaims results.",
-		Labels:    []string{"result"},
-	},
-	{
-		Name:      "dra_cpu_prepare_claim_duration_seconds",
-		Type:      "histogram",
-		Stability: "ALPHA",
-		Help:      "Duration of per-claim prepare operations in seconds.",
-	},
-	{
-		Name:      "dra_cpu_claim_allocated_cpus",
-		Type:      "histogram",
-		Stability: "ALPHA",
-		Help:      "Number of CPUs allocated for each newly successful claim allocation.",
-	},
+type metricKind string
+
+const (
+	metricGauge     metricKind = "gauge"
+	metricCounter   metricKind = "counter"
+	metricHistogram metricKind = "histogram"
+)
+
+type metricSpec struct {
+	name    string
+	kind    metricKind
+	help    string
+	labels  []string
+	buckets []float64
+}
+
+var (
+	allocatedCPUsSpec = metricSpec{
+		name: "dra_cpu_allocated_cpus",
+		kind: metricGauge,
+		help: "Number of CPUs currently allocated to prepared resource claims.",
+	}
+	availableCPUsSpec = metricSpec{
+		name: "dra_cpu_available_cpus",
+		kind: metricGauge,
+		help: "Number of CPUs available for allocation after reserved and active claim CPUs are excluded.",
+	}
+	reservedCPUsSpec = metricSpec{
+		name: "dra_cpu_reserved_cpus",
+		kind: metricGauge,
+		help: "Number of CPUs reserved and excluded from DRA management.",
+	}
+	activeResourceClaimsSpec = metricSpec{
+		name: "dra_cpu_resource_claims_active",
+		kind: metricGauge,
+		help: "Number of resource claims currently recorded as active by the allocation store.",
+	}
+	prepareClaimsSpec = metricSpec{
+		name:   "dra_cpu_prepare_claims_total",
+		kind:   metricCounter,
+		help:   "Total number of per-claim PrepareResourceClaims results.",
+		labels: []string{"result"},
+	}
+	unprepareClaimsSpec = metricSpec{
+		name:   "dra_cpu_unprepare_claims_total",
+		kind:   metricCounter,
+		help:   "Total number of per-claim UnprepareResourceClaims results.",
+		labels: []string{"result"},
+	}
+	prepareClaimDurationSpec = metricSpec{
+		name:    "dra_cpu_prepare_claim_duration_seconds",
+		kind:    metricHistogram,
+		help:    "Duration of per-claim prepare operations in seconds.",
+		buckets: prometheus.DefBuckets,
+	}
+	claimAllocatedCPUsSpec = metricSpec{
+		name:    "dra_cpu_claim_allocated_cpus",
+		kind:    metricHistogram,
+		help:    "Number of CPUs allocated for each newly successful claim allocation.",
+		buckets: []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024},
+	}
+)
+
+var metricSpecs = []metricSpec{
+	allocatedCPUsSpec,
+	availableCPUsSpec,
+	reservedCPUsSpec,
+	activeResourceClaimsSpec,
+	prepareClaimsSpec,
+	unprepareClaimsSpec,
+	prepareClaimDurationSpec,
+	claimAllocatedCPUsSpec,
 }
 
 // Descriptors returns metadata for custom CPU driver metrics.
 func Descriptors() []Descriptor {
-	out := make([]Descriptor, len(descriptors))
-	for i, descriptor := range descriptors {
-		out[i] = descriptor
-		out[i].Labels = append([]string{}, descriptor.Labels...)
+	out := make([]Descriptor, len(metricSpecs))
+	for i, spec := range metricSpecs {
+		out[i] = Descriptor{
+			Name:      spec.name,
+			Type:      string(spec.kind),
+			Stability: stability,
+			Help:      spec.help,
+			Labels:    append([]string{}, spec.labels...),
+		}
 	}
 	return out
 }
@@ -145,48 +185,14 @@ func New(reg prometheus.Registerer) *Metrics {
 	}
 
 	m := &Metrics{
-		allocatedCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
-			Subsystem: subsystem,
-			Name:      "allocated_cpus",
-			Help:      descriptors[0].Help,
-		}),
-		availableCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
-			Subsystem: subsystem,
-			Name:      "available_cpus",
-			Help:      descriptors[1].Help,
-		}),
-		reservedCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
-			Subsystem: subsystem,
-			Name:      "reserved_cpus",
-			Help:      descriptors[2].Help,
-		}),
-		activeResourceClaims: prometheus.NewGauge(prometheus.GaugeOpts{
-			Subsystem: subsystem,
-			Name:      "resource_claims_active",
-			Help:      descriptors[3].Help,
-		}),
-		prepareClaims: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      "prepare_claims_total",
-			Help:      descriptors[4].Help,
-		}, []string{"result"}),
-		unprepareClaims: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Subsystem: subsystem,
-			Name:      "unprepare_claims_total",
-			Help:      descriptors[5].Help,
-		}, []string{"result"}),
-		prepareClaimDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Subsystem: subsystem,
-			Name:      "prepare_claim_duration_seconds",
-			Help:      descriptors[6].Help,
-			Buckets:   prometheus.DefBuckets,
-		}),
-		claimAllocatedCPUs: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Subsystem: subsystem,
-			Name:      "claim_allocated_cpus",
-			Help:      descriptors[7].Help,
-			Buckets:   []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024},
-		}),
+		allocatedCPUs:        newGauge(allocatedCPUsSpec),
+		availableCPUs:        newGauge(availableCPUsSpec),
+		reservedCPUs:         newGauge(reservedCPUsSpec),
+		activeResourceClaims: newGauge(activeResourceClaimsSpec),
+		prepareClaims:        newCounterVec(prepareClaimsSpec),
+		unprepareClaims:      newCounterVec(unprepareClaimsSpec),
+		prepareClaimDuration: newHistogram(prepareClaimDurationSpec),
+		claimAllocatedCPUs:   newHistogram(claimAllocatedCPUsSpec),
 	}
 
 	reg.MustRegister(
@@ -202,6 +208,28 @@ func New(reg prometheus.Registerer) *Metrics {
 	return m
 }
 
+func newGauge(spec metricSpec) prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: spec.name,
+		Help: spec.help,
+	})
+}
+
+func newCounterVec(spec metricSpec) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: spec.name,
+		Help: spec.help,
+	}, spec.labels)
+}
+
+func newHistogram(spec metricSpec) prometheus.Histogram {
+	return prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    spec.name,
+		Help:    spec.help,
+		Buckets: spec.buckets,
+	})
+}
+
 func (m *Metrics) SetAllocationState(state AllocationState) {
 	m.allocatedCPUs.Set(float64(state.AllocatedCPUs))
 	m.availableCPUs.Set(float64(state.AvailableCPUs))
@@ -209,13 +237,13 @@ func (m *Metrics) SetAllocationState(state AllocationState) {
 	m.activeResourceClaims.Set(float64(state.ActiveResourceClaims))
 }
 
-func (m *Metrics) RecordPrepare(result string, duration time.Duration) {
-	m.prepareClaims.WithLabelValues(result).Inc()
+func (m *Metrics) RecordPrepare(result Result, duration time.Duration) {
+	m.prepareClaims.WithLabelValues(result.String()).Inc()
 	m.prepareClaimDuration.Observe(duration.Seconds())
 }
 
-func (m *Metrics) RecordUnprepare(result string) {
-	m.unprepareClaims.WithLabelValues(result).Inc()
+func (m *Metrics) RecordUnprepare(result Result) {
+	m.unprepareClaims.WithLabelValues(result.String()).Inc()
 }
 
 func (m *Metrics) RecordClaimAllocatedCPUs(cpus int) {
@@ -230,6 +258,6 @@ func Noop() Recorder {
 }
 
 func (noopRecorder) SetAllocationState(AllocationState)  {}
-func (noopRecorder) RecordPrepare(string, time.Duration) {}
-func (noopRecorder) RecordUnprepare(string)              {}
+func (noopRecorder) RecordPrepare(Result, time.Duration) {}
+func (noopRecorder) RecordUnprepare(Result)              {}
 func (noopRecorder) RecordClaimAllocatedCPUs(int)        {}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -124,7 +124,10 @@ var descriptors = []Descriptor{
 // Descriptors returns metadata for custom CPU driver metrics.
 func Descriptors() []Descriptor {
 	out := make([]Descriptor, len(descriptors))
-	copy(out, descriptors)
+	for i, descriptor := range descriptors {
+		out[i] = descriptor
+		out[i].Labels = append([]string{}, descriptor.Labels...)
+	}
 	return out
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,232 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	subsystem = "dra_cpu"
+
+	ResultSuccess = "success"
+	ResultError   = "error"
+)
+
+// Descriptor describes a custom driver metric for programmatic introspection.
+type Descriptor struct {
+	Name      string   `json:"name"`
+	Type      string   `json:"type"`
+	Stability string   `json:"stability"`
+	Help      string   `json:"help"`
+	Labels    []string `json:"labels"`
+}
+
+// AllocationState is the allocation state represented by CPU allocation gauges.
+type AllocationState struct {
+	AllocatedCPUs        int
+	AvailableCPUs        int
+	ReservedCPUs         int
+	ActiveResourceClaims int
+}
+
+// Recorder records driver metrics.
+type Recorder interface {
+	SetAllocationState(AllocationState)
+	RecordPrepare(result string, duration time.Duration)
+	RecordUnprepare(result string)
+	RecordClaimAllocatedCPUs(cpus int)
+}
+
+// Metrics owns all custom Prometheus collectors for the CPU driver.
+type Metrics struct {
+	allocatedCPUs        prometheus.Gauge
+	availableCPUs        prometheus.Gauge
+	reservedCPUs         prometheus.Gauge
+	activeResourceClaims prometheus.Gauge
+	prepareClaims        *prometheus.CounterVec
+	unprepareClaims      *prometheus.CounterVec
+	prepareClaimDuration prometheus.Histogram
+	claimAllocatedCPUs   prometheus.Histogram
+}
+
+var descriptors = []Descriptor{
+	{
+		Name:      "dra_cpu_allocated_cpus",
+		Type:      "gauge",
+		Stability: "ALPHA",
+		Help:      "Number of CPUs currently allocated to prepared resource claims.",
+	},
+	{
+		Name:      "dra_cpu_available_cpus",
+		Type:      "gauge",
+		Stability: "ALPHA",
+		Help:      "Number of CPUs available for allocation after reserved and active claim CPUs are excluded.",
+	},
+	{
+		Name:      "dra_cpu_reserved_cpus",
+		Type:      "gauge",
+		Stability: "ALPHA",
+		Help:      "Number of CPUs reserved and excluded from DRA management.",
+	},
+	{
+		Name:      "dra_cpu_resource_claims_active",
+		Type:      "gauge",
+		Stability: "ALPHA",
+		Help:      "Number of resource claims currently recorded as active by the allocation store.",
+	},
+	{
+		Name:      "dra_cpu_prepare_claims_total",
+		Type:      "counter",
+		Stability: "ALPHA",
+		Help:      "Total number of per-claim PrepareResourceClaims results.",
+		Labels:    []string{"result"},
+	},
+	{
+		Name:      "dra_cpu_unprepare_claims_total",
+		Type:      "counter",
+		Stability: "ALPHA",
+		Help:      "Total number of per-claim UnprepareResourceClaims results.",
+		Labels:    []string{"result"},
+	},
+	{
+		Name:      "dra_cpu_prepare_claim_duration_seconds",
+		Type:      "histogram",
+		Stability: "ALPHA",
+		Help:      "Duration of per-claim prepare operations in seconds.",
+	},
+	{
+		Name:      "dra_cpu_claim_allocated_cpus",
+		Type:      "histogram",
+		Stability: "ALPHA",
+		Help:      "Number of CPUs allocated for each newly successful claim allocation.",
+	},
+}
+
+// Descriptors returns metadata for custom CPU driver metrics.
+func Descriptors() []Descriptor {
+	out := make([]Descriptor, len(descriptors))
+	copy(out, descriptors)
+	return out
+}
+
+// WriteJSON writes custom metric metadata as deterministic JSON.
+func WriteJSON(w io.Writer) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(Descriptors())
+}
+
+// New creates and registers the CPU driver custom metrics.
+func New(reg prometheus.Registerer) *Metrics {
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+
+	m := &Metrics{
+		allocatedCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "allocated_cpus",
+			Help:      descriptors[0].Help,
+		}),
+		availableCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "available_cpus",
+			Help:      descriptors[1].Help,
+		}),
+		reservedCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "reserved_cpus",
+			Help:      descriptors[2].Help,
+		}),
+		activeResourceClaims: prometheus.NewGauge(prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "resource_claims_active",
+			Help:      descriptors[3].Help,
+		}),
+		prepareClaims: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "prepare_claims_total",
+			Help:      descriptors[4].Help,
+		}, []string{"result"}),
+		unprepareClaims: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "unprepare_claims_total",
+			Help:      descriptors[5].Help,
+		}, []string{"result"}),
+		prepareClaimDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Subsystem: subsystem,
+			Name:      "prepare_claim_duration_seconds",
+			Help:      descriptors[6].Help,
+			Buckets:   prometheus.DefBuckets,
+		}),
+		claimAllocatedCPUs: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Subsystem: subsystem,
+			Name:      "claim_allocated_cpus",
+			Help:      descriptors[7].Help,
+			Buckets:   []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024},
+		}),
+	}
+
+	reg.MustRegister(
+		m.allocatedCPUs,
+		m.availableCPUs,
+		m.reservedCPUs,
+		m.activeResourceClaims,
+		m.prepareClaims,
+		m.unprepareClaims,
+		m.prepareClaimDuration,
+		m.claimAllocatedCPUs,
+	)
+	return m
+}
+
+func (m *Metrics) SetAllocationState(state AllocationState) {
+	m.allocatedCPUs.Set(float64(state.AllocatedCPUs))
+	m.availableCPUs.Set(float64(state.AvailableCPUs))
+	m.reservedCPUs.Set(float64(state.ReservedCPUs))
+	m.activeResourceClaims.Set(float64(state.ActiveResourceClaims))
+}
+
+func (m *Metrics) RecordPrepare(result string, duration time.Duration) {
+	m.prepareClaims.WithLabelValues(result).Inc()
+	m.prepareClaimDuration.Observe(duration.Seconds())
+}
+
+func (m *Metrics) RecordUnprepare(result string) {
+	m.unprepareClaims.WithLabelValues(result).Inc()
+}
+
+func (m *Metrics) RecordClaimAllocatedCPUs(cpus int) {
+	m.claimAllocatedCPUs.Observe(float64(cpus))
+}
+
+type noopRecorder struct{}
+
+// Noop returns a recorder that discards all metric observations.
+func Noop() Recorder {
+	return noopRecorder{}
+}
+
+func (noopRecorder) SetAllocationState(AllocationState)  {}
+func (noopRecorder) RecordPrepare(string, time.Duration) {}
+func (noopRecorder) RecordUnprepare(string)              {}
+func (noopRecorder) RecordClaimAllocatedCPUs(int)        {}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -36,6 +36,7 @@ func TestDescriptors(t *testing.T) {
 		names = append(names, desc.Name)
 		require.Equal(t, "ALPHA", desc.Stability)
 		require.NotEmpty(t, desc.Help)
+		require.NotNil(t, desc.Labels)
 	}
 
 	require.Equal(t, []string{

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescriptors(t *testing.T) {
+	descriptors := Descriptors()
+	require.Len(t, descriptors, 8)
+
+	names := make([]string, 0, len(descriptors))
+	for _, desc := range descriptors {
+		names = append(names, desc.Name)
+		require.Equal(t, "ALPHA", desc.Stability)
+		require.NotEmpty(t, desc.Help)
+	}
+
+	require.Equal(t, []string{
+		"dra_cpu_allocated_cpus",
+		"dra_cpu_available_cpus",
+		"dra_cpu_reserved_cpus",
+		"dra_cpu_resource_claims_active",
+		"dra_cpu_prepare_claims_total",
+		"dra_cpu_unprepare_claims_total",
+		"dra_cpu_prepare_claim_duration_seconds",
+		"dra_cpu_claim_allocated_cpus",
+	}, names)
+	require.Equal(t, []string{"result"}, descriptors[4].Labels)
+	require.Equal(t, []string{"result"}, descriptors[5].Labels)
+}
+
+func TestWriteJSON(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteJSON(&buf))
+	require.True(t, bytes.HasSuffix(buf.Bytes(), []byte("\n")))
+
+	var descriptors []Descriptor
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &descriptors))
+	require.Equal(t, Descriptors(), descriptors)
+}
+
+func TestMetricsRecordsCollectors(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg)
+
+	m.SetAllocationState(AllocationState{
+		AllocatedCPUs:        2,
+		AvailableCPUs:        6,
+		ReservedCPUs:         1,
+		ActiveResourceClaims: 1,
+	})
+	m.RecordPrepare(ResultSuccess, 150*time.Millisecond)
+	m.RecordPrepare(ResultError, 250*time.Millisecond)
+	m.RecordUnprepare(ResultSuccess)
+	m.RecordClaimAllocatedCPUs(2)
+
+	require.InDelta(t, 2, testutil.ToFloat64(m.allocatedCPUs), 0.01)
+	require.InDelta(t, 6, testutil.ToFloat64(m.availableCPUs), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.reservedCPUs), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.activeResourceClaims), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultSuccess)), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultError)), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.unprepareClaims.WithLabelValues(ResultSuccess)), 0.01)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	require.NotEmpty(t, families)
+	require.Equal(t, 1, testutil.CollectAndCount(m.prepareClaimDuration))
+	require.Equal(t, 1, testutil.CollectAndCount(m.claimAllocatedCPUs))
+}
+
+func TestNoopRecorder(t *testing.T) {
+	recorder := Noop()
+
+	require.NotPanics(t, func() {
+		recorder.SetAllocationState(AllocationState{})
+		recorder.RecordPrepare(ResultSuccess, time.Second)
+		recorder.RecordUnprepare(ResultError)
+		recorder.RecordClaimAllocatedCPUs(4)
+	})
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"bytes"
 	"encoding/json"
+	"slices"
 	"testing"
 	"time"
 
@@ -61,6 +62,31 @@ func TestWriteJSON(t *testing.T) {
 	var descriptors []Descriptor
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &descriptors))
 	require.Equal(t, Descriptors(), descriptors)
+}
+
+func TestNewRegistersExpectedMetricFamilies(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	New(reg)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(families))
+	for _, family := range families {
+		names = append(names, family.GetName())
+	}
+	slices.Sort(names)
+
+	require.Equal(t, []string{
+		"dra_cpu_allocated_cpus",
+		"dra_cpu_available_cpus",
+		"dra_cpu_claim_allocated_cpus",
+		"dra_cpu_prepare_claim_duration_seconds",
+		"dra_cpu_prepare_claims_total",
+		"dra_cpu_reserved_cpus",
+		"dra_cpu_resource_claims_active",
+		"dra_cpu_unprepare_claims_total",
+	}, names)
 }
 
 func TestMetricsRecordsCollectors(t *testing.T) {
@@ -124,8 +150,8 @@ func TestMetricsRejectsUnboundedResultLabels(t *testing.T) {
 	m.RecordPrepare(Result("timeout"), time.Second)
 	m.RecordUnprepare(Result("permission-denied"))
 
-	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultError.String())), 0.01)
-	require.InDelta(t, 1, testutil.ToFloat64(m.unprepareClaims.WithLabelValues(ResultError.String())), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultUnknown.String())), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.unprepareClaims.WithLabelValues(ResultUnknown.String())), 0.01)
 	requireMetricLabelValueAbsent(t, reg, "dra_cpu_prepare_claims_total", "result", "timeout")
 	requireMetricLabelValueAbsent(t, reg, "dra_cpu_unprepare_claims_total", "result", "permission-denied")
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -82,15 +82,52 @@ func TestMetricsRecordsCollectors(t *testing.T) {
 	require.InDelta(t, 6, testutil.ToFloat64(m.availableCPUs), 0.01)
 	require.InDelta(t, 1, testutil.ToFloat64(m.reservedCPUs), 0.01)
 	require.InDelta(t, 1, testutil.ToFloat64(m.activeResourceClaims), 0.01)
-	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultSuccess)), 0.01)
-	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultError)), 0.01)
-	require.InDelta(t, 1, testutil.ToFloat64(m.unprepareClaims.WithLabelValues(ResultSuccess)), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultSuccess.String())), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultError.String())), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.unprepareClaims.WithLabelValues(ResultSuccess.String())), 0.01)
 
 	families, err := reg.Gather()
 	require.NoError(t, err)
 	require.NotEmpty(t, families)
 	require.Equal(t, 1, testutil.CollectAndCount(m.prepareClaimDuration))
 	require.Equal(t, 1, testutil.CollectAndCount(m.claimAllocatedCPUs))
+}
+
+func TestDescriptorsMatchRegisteredCollectors(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg)
+	m.SetAllocationState(AllocationState{})
+	m.RecordPrepare(ResultSuccess, time.Second)
+	m.RecordPrepare(ResultError, time.Second)
+	m.RecordUnprepare(ResultSuccess)
+	m.RecordUnprepare(ResultError)
+	m.RecordClaimAllocatedCPUs(1)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	gotNames := make([]string, 0, len(families))
+	for _, family := range families {
+		gotNames = append(gotNames, family.GetName())
+	}
+
+	wantNames := make([]string, 0, len(Descriptors()))
+	for _, descriptor := range Descriptors() {
+		wantNames = append(wantNames, descriptor.Name)
+	}
+	require.ElementsMatch(t, wantNames, gotNames)
+}
+
+func TestMetricsRejectsUnboundedResultLabels(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg)
+
+	m.RecordPrepare(Result("timeout"), time.Second)
+	m.RecordUnprepare(Result("permission-denied"))
+
+	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultError.String())), 0.01)
+	require.InDelta(t, 1, testutil.ToFloat64(m.unprepareClaims.WithLabelValues(ResultError.String())), 0.01)
+	requireMetricLabelValueAbsent(t, reg, "dra_cpu_prepare_claims_total", "result", "timeout")
+	requireMetricLabelValueAbsent(t, reg, "dra_cpu_unprepare_claims_total", "result", "permission-denied")
 }
 
 func TestNoopRecorder(t *testing.T) {
@@ -102,4 +139,21 @@ func TestNoopRecorder(t *testing.T) {
 		recorder.RecordUnprepare(ResultError)
 		recorder.RecordClaimAllocatedCPUs(4)
 	})
+}
+
+func requireMetricLabelValueAbsent(t *testing.T, reg *prometheus.Registry, metricName, labelName, labelValue string) {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				require.False(t, label.GetName() == labelName && label.GetValue() == labelValue,
+					"metric %s has unexpected label %s=%q", metricName, labelName, labelValue)
+			}
+		}
+	}
 }

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
@@ -43,12 +44,14 @@ func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUS
 	allCPUsSet := cpuset.New(cpuIDs...)
 	availableCPUs := allCPUsSet.Difference(reservedCPUs)
 
-	return &CPUAllocation{
+	s := &CPUAllocation{
 		availableCPUs:            availableCPUs,
 		reservedCPUs:             reservedCPUs,
 		resourceClaimAllocations: make(map[types.UID]cpuset.CPUSet),
 		allocatedCPUs:            cpuset.New(),
 	}
+	s.updateMetricsLocked()
+	return s
 }
 
 // AddResourceClaimAllocation adds a new resource claim allocation to the store.
@@ -60,6 +63,7 @@ func (s *CPUAllocation) AddResourceClaimAllocation(claimUID types.UID, cpus cpus
 	}
 	s.resourceClaimAllocations[claimUID] = cpus
 	s.allocatedCPUs = s.allocatedCPUs.Union(cpus)
+	s.updateMetricsLocked()
 	klog.Infof("Added allocation for resource claim %s: CPUs %s", claimUID, cpus.String())
 }
 
@@ -70,6 +74,7 @@ func (s *CPUAllocation) RemoveResourceClaimAllocation(claimUID types.UID) {
 	if cpus, ok := s.resourceClaimAllocations[claimUID]; ok {
 		delete(s.resourceClaimAllocations, claimUID)
 		s.allocatedCPUs = s.allocatedCPUs.Difference(cpus)
+		s.updateMetricsLocked()
 		klog.Infof("Removed allocation for resource claim %s", claimUID)
 	}
 }
@@ -87,4 +92,14 @@ func (s *CPUAllocation) GetResourceClaimAllocation(claimUID types.UID) (cpuset.C
 	defer s.mu.RUnlock()
 	cpus, ok := s.resourceClaimAllocations[claimUID]
 	return cpus, ok
+}
+
+// updateMetricsLocked updates Prometheus gauges. Caller must hold s.mu
+// (write or exclusive during construction before sharing).
+func (s *CPUAllocation) updateMetricsLocked() {
+	m := metrics.Default
+	m.AllocatedCPUs.Set(float64(s.allocatedCPUs.Size()))
+	m.AvailableCPUs.Set(float64(s.availableCPUs.Difference(s.allocatedCPUs).Size()))
+	m.ReservedCPUs.Set(float64(s.reservedCPUs.Size()))
+	m.ActiveResourceClaims.Set(float64(len(s.resourceClaimAllocations)))
 }

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -34,6 +34,14 @@ type CPUAllocation struct {
 	allocatedCPUs            cpuset.CPUSet
 }
 
+// AllocationSnapshot is a point-in-time summary of CPU allocation state.
+type AllocationSnapshot struct {
+	AllocatedCPUs        int
+	AvailableCPUs        int
+	ReservedCPUs         int
+	ActiveResourceClaims int
+}
+
 // NewCPUAllocation creates a new CPUAllocation.
 func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUSet) *CPUAllocation {
 	cpuIDs := []int{}
@@ -101,4 +109,16 @@ func (s *CPUAllocation) GetAllocatedCPUs() cpuset.CPUSet {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.allocatedCPUs
+}
+
+// Snapshot returns a point-in-time summary of CPU allocation state.
+func (s *CPUAllocation) Snapshot() AllocationSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return AllocationSnapshot{
+		AllocatedCPUs:        s.allocatedCPUs.Size(),
+		AvailableCPUs:        s.availableCPUs.Difference(s.allocatedCPUs).Size(),
+		ReservedCPUs:         s.reservedCPUs.Size(),
+		ActiveResourceClaims: len(s.resourceClaimAllocations),
+	}
 }

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -215,6 +215,52 @@ func TestCPUAllocationGetAllocatedCPUs(t *testing.T) {
 	require.True(t, store.GetAllocatedCPUs().IsEmpty())
 }
 
+func TestCPUAllocationSnapshot(t *testing.T) {
+	logger := testr.New(t)
+	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
+	reserved := cpuset.New(0, 1)
+	store := newTestCPUAllocation(logger, allCPUs, reserved)
+
+	require.Equal(t, AllocationSnapshot{
+		AllocatedCPUs:        0,
+		AvailableCPUs:        6,
+		ReservedCPUs:         2,
+		ActiveResourceClaims: 0,
+	}, store.Snapshot())
+
+	store.AddResourceClaimAllocation(logger, "claim-1", cpuset.New(2, 3))
+	require.Equal(t, AllocationSnapshot{
+		AllocatedCPUs:        2,
+		AvailableCPUs:        4,
+		ReservedCPUs:         2,
+		ActiveResourceClaims: 1,
+	}, store.Snapshot())
+
+	store.AddResourceClaimAllocation(logger, "claim-1", cpuset.New(4, 5, 6))
+	require.Equal(t, AllocationSnapshot{
+		AllocatedCPUs:        3,
+		AvailableCPUs:        3,
+		ReservedCPUs:         2,
+		ActiveResourceClaims: 1,
+	}, store.Snapshot())
+
+	store.AddResourceClaimAllocation(logger, "claim-2", cpuset.New(2, 3))
+	require.Equal(t, AllocationSnapshot{
+		AllocatedCPUs:        5,
+		AvailableCPUs:        1,
+		ReservedCPUs:         2,
+		ActiveResourceClaims: 2,
+	}, store.Snapshot())
+
+	store.RemoveResourceClaimAllocation(logger, "claim-1")
+	require.Equal(t, AllocationSnapshot{
+		AllocatedCPUs:        2,
+		AvailableCPUs:        4,
+		ReservedCPUs:         2,
+		ActiveResourceClaims: 1,
+	}, store.Snapshot())
+}
+
 func getSharedCPUsNaive(availableCPUs cpuset.CPUSet, allocations map[types.UID]cpuset.CPUSet) cpuset.CPUSet {
 	allocated := cpuset.New()
 	for _, cpus := range allocations {

--- a/pkg/store/metrics_test.go
+++ b/pkg/store/metrics_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/cpuset"
+)
+
+func TestMetricsGaugesOnAllocationStoreChanges(t *testing.T) {
+	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
+	reserved := cpuset.New(0, 1)
+
+	tests := []struct {
+		name                      string
+		allocations               map[types.UID]cpuset.CPUSet
+		removals                  []types.UID
+		expectedAllocatedCPUs     float64
+		expectedAvailableCPUs     float64
+		expectedReservedCPUs      float64
+		expectedActiveClaimsGauge float64
+	}{
+		{
+			name:                  "initial state with no allocations",
+			expectedAvailableCPUs: 6, expectedReservedCPUs: 2,
+		},
+		{
+			name: "single allocation",
+			allocations: map[types.UID]cpuset.CPUSet{
+				"claim-1": cpuset.New(2, 3),
+			},
+			expectedAllocatedCPUs: 2, expectedAvailableCPUs: 4,
+			expectedReservedCPUs: 2, expectedActiveClaimsGauge: 1,
+		},
+		{
+			name: "multiple allocations",
+			allocations: map[types.UID]cpuset.CPUSet{
+				"claim-1": cpuset.New(2, 3),
+				"claim-2": cpuset.New(4, 5),
+			},
+			expectedAllocatedCPUs: 4, expectedAvailableCPUs: 2,
+			expectedReservedCPUs: 2, expectedActiveClaimsGauge: 2,
+		},
+		{
+			name: "allocate then remove",
+			allocations: map[types.UID]cpuset.CPUSet{
+				"claim-1": cpuset.New(2, 3),
+				"claim-2": cpuset.New(4, 5),
+			},
+			removals:              []types.UID{"claim-1"},
+			expectedAllocatedCPUs: 2, expectedAvailableCPUs: 4,
+			expectedReservedCPUs: 2, expectedActiveClaimsGauge: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics.ResetForTest()
+			s := newTestCPUAllocation(allCPUs, reserved)
+			for uid, cpus := range tc.allocations {
+				s.AddResourceClaimAllocation(uid, cpus)
+			}
+			for _, uid := range tc.removals {
+				s.RemoveResourceClaimAllocation(uid)
+			}
+
+			require.InDelta(t, tc.expectedAllocatedCPUs, testutil.ToFloat64(metrics.Default.AllocatedCPUs), 0.01)
+			require.InDelta(t, tc.expectedAvailableCPUs, testutil.ToFloat64(metrics.Default.AvailableCPUs), 0.01)
+			require.InDelta(t, tc.expectedReservedCPUs, testutil.ToFloat64(metrics.Default.ReservedCPUs), 0.01)
+			require.InDelta(t, tc.expectedActiveClaimsGauge, testutil.ToFloat64(metrics.Default.ActiveResourceClaims), 0.01)
+		})
+	}
+}


### PR DESCRIPTION
Add 7 custom Prometheus metrics to the /metrics endpoint:
- dra_cpu_allocated_cpus (gauge)
- dra_cpu_available_cpus (gauge)
- dra_cpu_reserved_cpus (gauge)
- dra_cpu_resource_claims_active (gauge)
- dra_cpu_prepare_claims_success_total (counter)
- dra_cpu_prepare_claims_error_total (counter)
- dra_cpu_unprepare_claims_total (counter)
- dra_cpu_prepare_claim_duration_seconds (histogram)

https://github.com/kubernetes-sigs/dra-driver-cpu/issues/73
