### PR TITLE
Repeated CPU allocation in prepareGroupedResourceClaim when multiple devices are involved

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -288,6 +288,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 	}
 
 	var cpuAssignment cpuset.CPUSet
+	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	for _, alloc := range claim.Status.Allocation.Devices.Results {
 		claimCPUCount := int64(0)
 		if alloc.Driver != cp.driverName {
@@ -308,7 +309,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 				return kubeletplugin.PrepareResult{Err: fmt.Errorf("no valid socket ID found for device %s", alloc.Device)}
 			}
 			socketCPUs := topo.CPUDetails.CPUsInSockets(socketID)
-			availableCPUsForDevice = cp.cpuAllocationStore.GetSharedCPUs().Intersection(socketCPUs)
+			availableCPUsForDevice = sharedCPUs.Difference(cpuAssignment).Intersection(socketCPUs)
 			klog.Infof("Socket %d CPUs:%s available CPUs: %s", socketID, socketCPUs.String(), availableCPUsForDevice.String())
 		} else { // numanode
 			numaNodeID, ok := cp.deviceNameToNUMANodeID[alloc.Device]
@@ -316,7 +317,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 				return kubeletplugin.PrepareResult{Err: fmt.Errorf("no valid NUMA node ID found for device %s", alloc.Device)}
 			}
 			numaCPUs := topo.CPUDetails.CPUsInNUMANodes(numaNodeID)
-			availableCPUsForDevice = cp.cpuAllocationStore.GetSharedCPUs().Intersection(numaCPUs)
+			availableCPUsForDevice = sharedCPUs.Difference(cpuAssignment).Intersection(numaCPUs)
 			klog.Infof("NUMA node %d CPUs:%s available CPUs: %s", numaNodeID, numaCPUs.String(), availableCPUsForDevice.String())
 		}
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -700,6 +700,56 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			expectedCPUSet: cpuset.New(0, 2, 4, 6),
 		},
 		{
+			name:     "SocketGrouped_SingleSocketHT_SameSocketTwice_NoCPUOverlap",
+			cpuInfos: mockCPUInfos_SingleSocket_4CPUS_HT,
+			groupBy:  GROUP_BY_SOCKET,
+			claims: []*resourceapi.ResourceClaim{
+				testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+					{
+						Driver:           testDriverName,
+						Pool:             testNodeName,
+						Device:           "cpudevsocket0",
+						Request:          "req-0",
+						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
+					},
+					{
+						Driver:           testDriverName,
+						Pool:             testNodeName,
+						Device:           "cpudevsocket0",
+						Request:          "req-1",
+						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
+					},
+				}),
+			},
+			// Two distinct CPUs must be allocated, no overlap
+			expectedCPUSet: cpuset.New(0, 2),
+		},
+		{
+			name:     "NUMAGrouped_SingleSocketHT_SameNUMATwice_NoCPUOverlap",
+			cpuInfos: mockCPUInfos_SingleSocket_4CPUS_HT,
+			groupBy:  GROUP_BY_NUMA_NODE,
+			claims: []*resourceapi.ResourceClaim{
+				testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+					{
+						Driver:           testDriverName,
+						Pool:             testNodeName,
+						Device:           "cpudevnuma0",
+						Request:          "req-0",
+						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
+					},
+					{
+						Driver:           testDriverName,
+						Pool:             testNodeName,
+						Device:           "cpudevnuma0",
+						Request:          "req-1",
+						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
+					},
+				}),
+			},
+			// Two distinct CPUs must be allocated, no overlap
+			expectedCPUSet: cpuset.New(0, 2),
+		},
+		{
 			name:               "SocketGrouped_SingleSocketHT_FullAlloc_Socket",
 			cpuInfos:           mockCPUInfos_SingleSocket_4CPUS_HT,
 			groupBy:            GROUP_BY_SOCKET,
@@ -881,6 +931,19 @@ func TestUnprepareResourceClaims(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func testClaimWithResults(claimUID types.UID, results []resourceapi.DeviceRequestAllocationResult) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{UID: claimUID, Name: string(claimUID)},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{
+					Results: results,
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Repeated CPU allocation in prepareGroupedResourceClaim when multiple devices are involved
https://github.com/kubernetes-sigs/dra-driver-cpu/issues/79