### PR TITLE
feat: add Helm chart for driver deployment

### DIFF
--- a/.github/workflows/helm-e2e.yaml
+++ b/.github/workflows/helm-e2e.yaml
@@ -1,0 +1,91 @@
+name: helm e2e
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'deployment/helm/**'
+      - '.github/workflows/helm-e2e.yaml'
+
+env:
+  TAG: ci-${{ github.sha }}
+  # Matches REGISTRY_CI/IMAGE_NAME in the Makefile
+  IMAGE: dev.kind.local/ci/dra-driver-cpu
+
+jobs:
+  helm-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.25'
+
+      - name: Install kind
+        run: |
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Install kubectl
+        run: |
+          if ! command -v kubectl &>/dev/null; then
+            curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            sudo mv kubectl /usr/local/bin/kubectl
+          fi
+
+      - name: Build the image
+        run: make build-image
+
+      - name: Create kind cluster
+        run: |
+          kind delete cluster --name dra-driver-cpu || true
+          kind create cluster --name dra-driver-cpu --config hack/ci/kind-ci.yaml
+          kind get kubeconfig --name dra-driver-cpu > /tmp/kubeconfig-dra-driver-cpu
+          kubectl --kubeconfig /tmp/kubeconfig-dra-driver-cpu \
+            label node dra-driver-cpu-worker node-role.kubernetes.io/worker=''
+
+      - name: Load driver image into kind
+        run: |
+          kind load docker-image --name dra-driver-cpu \
+            "${IMAGE}:${TAG}"
+
+      - name: Install driver via Helm
+        run: |
+          helm install dra-driver-cpu deployment/helm/dra-driver-cpu \
+            --kubeconfig /tmp/kubeconfig-dra-driver-cpu \
+            --namespace kube-system \
+            --set fullnameOverride=dracpu \
+            --set podLabels.app=dracpu \
+            --set image.repository="${IMAGE}" \
+            --set image.tag="${TAG}" \
+            --set image.pullPolicy=Never
+
+      - name: Wait for resourceSlices
+        run: KUBECONFIG=/tmp/kubeconfig-dra-driver-cpu hack/ci/wait-resourcelices.sh
+
+      - name: Check daemonSet pods are Running & Ready
+        run: |
+          kubectl --kubeconfig /tmp/kubeconfig-dra-driver-cpu \
+            rollout status daemonset/dracpu -n kube-system --timeout=120s
+
+      - name: Final check
+        if: failure()
+        continue-on-error: true
+        run: |
+          kubectl --kubeconfig /tmp/kubeconfig-dra-driver-cpu get pods -A -o wide || true
+          kubectl --kubeconfig /tmp/kubeconfig-dra-driver-cpu describe daemonset dracpu -n kube-system || true
+          kubectl --kubeconfig /tmp/kubeconfig-dra-driver-cpu logs -n kube-system -l app=dracpu --tail=100 || true
+          kubectl --kubeconfig /tmp/kubeconfig-dra-driver-cpu get resourceslice -o yaml || true
+
+      - name: Delete kind cluster
+        if: always()
+        run: kind delete cluster --name dra-driver-cpu

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,0 +1,18 @@
+name: Helm Lint
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'deployment/helm/**'
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
+      - name: Run Helm lint
+        run: make helm-lint

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Check helm-docs is up to date
         run: make helm-docs-check
+
+      - name: Check values.schema.json is up to date
+        run: make helm-schema-check

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -4,6 +4,7 @@ on:
     branches: [ main ]
     paths:
       - 'deployment/helm/**'
+      - '.github/workflows/helm-lint.yaml'
 
 jobs:
   helm-lint:
@@ -11,8 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.25'
+
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Run Helm lint
         run: make helm-lint
+
+      - name: Check helm-docs is up to date
+        run: make helm-docs-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,13 +22,13 @@ repos:
       - id: check-added-large-files
       - id: trailing-whitespace
       - id: end-of-file-fixer
-        exclude: helm/.*/README.md$
+        exclude: deployment/helm/.*/README.md$
       - id: detect-private-key
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22
     hooks:
       - id: mdformat
-        exclude: (\.chglog/.*|helm/.*)\.md
+        exclude: (\.chglog/.*|deployment/helm/.*)\.md
         additional_dependencies:
           - mdformat-toc
           - mdformat-tables

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ ARCH=$(shell go env GOARCH)
 YQ_VERSION ?= 4.47.1
 # matches golang 1.25.z
 GOLANGCI_LINT_VERSION ?= 2.7.2
+HELM_DOCS_VERSION ?= 1.14.2
 # paths
 YQ = $(OUT_DIR)/yq
 GOLANGCI_LINT = $(OUT_DIR)/golangci-lint
@@ -234,3 +235,12 @@ install-golangci-lint: $(OUT_DIR) ## make sure the golangci-lint tool is availab
 
 helm-lint:
 	helm lint --strict deployment/helm/dra-driver-cpu
+
+.PHONY: helm-docs
+helm-docs: ## regenerate helm chart README from values.yaml annotations and README.md.gotmpl
+	go run github.com/norwoodj/helm-docs/cmd/helm-docs@v$(HELM_DOCS_VERSION) --chart-search-root=deployment/helm
+
+.PHONY: helm-docs-check
+helm-docs-check: helm-docs ## verify helm chart README is up to date; fails if regeneration produces a diff
+	@git diff --exit-code deployment/helm/ || \
+		(echo "ERROR: Helm chart README.md is out of date. Run 'make helm-docs' to update it." && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -231,3 +231,6 @@ install-yq: $(OUT_DIR)  ## make sure the yq tool is available locally
 .PHONY: install-golangci-lint
 install-golangci-lint: $(OUT_DIR) ## make sure the golangci-lint tool is available locally
 	@hack/fetch-golangci-lint.sh $(OUT_DIR) $(GOLANGCI_LINT_VERSION)
+
+helm-lint:
+	helm lint --strict deployment/helm/dra-driver-cpu

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ YQ_VERSION ?= 4.47.1
 # matches golang 1.25.z
 GOLANGCI_LINT_VERSION ?= 2.7.2
 HELM_DOCS_VERSION ?= 1.14.2
+HELM_SCHEMA_VERSION ?= 2.3.1
 # paths
 YQ = $(OUT_DIR)/yq
 GOLANGCI_LINT = $(OUT_DIR)/golangci-lint
@@ -244,3 +245,16 @@ helm-docs: ## regenerate helm chart README from values.yaml annotations and READ
 helm-docs-check: helm-docs ## verify helm chart README is up to date; fails if regeneration produces a diff
 	@git diff --exit-code deployment/helm/ || \
 		(echo "ERROR: Helm chart README.md is out of date. Run 'make helm-docs' to update it." && exit 1)
+
+.PHONY: helm-schema
+helm-schema: ## regenerate values.schema.json from values.yaml @schema annotations
+	go run github.com/losisin/helm-values-schema-json/v2@v$(HELM_SCHEMA_VERSION) \
+		-f deployment/helm/dra-driver-cpu/values.yaml \
+		-o deployment/helm/dra-driver-cpu/values.schema.json \
+		--use-helm-docs \
+		--indent 2
+
+.PHONY: helm-schema-check
+helm-schema-check: helm-schema ## verify values.schema.json is up to date; fails if regeneration produces a diff
+	@git diff --exit-code deployment/helm/dra-driver-cpu/values.schema.json || \
+		(echo "ERROR: values.schema.json is out of date. Run 'make helm-schema' to update it." && exit 1)

--- a/README.md
+++ b/README.md
@@ -221,6 +221,16 @@ This discrepancy is a known issue being addressed by [KEP-5517: Native Resource 
   kubectl apply -f dist/install.yaml
   ```
 
+### Installation via Helm
+
+The driver can also be installed using the provided Helm chart:
+
+```bash
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system
+```
+
+See the [Helm chart README](deployment/helm/dra-driver-cpu/README.md) for the full list of configuration options.
+
 ### Example Usage
 
 The driver supports two modes of operation. Each mode has a complete example manifest that includes both the ResourceClaim(s) and a sample Pod. The ResourceClaim requests a specific number of exclusive CPUs from the driver, and is referenced in the Pod spec to receive the allocated CPUs.

--- a/deployment/helm/dra-driver-cpu/.helmignore
+++ b/deployment/helm/dra-driver-cpu/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/helm/dra-driver-cpu/Chart.yaml
+++ b/deployment/helm/dra-driver-cpu/Chart.yaml
@@ -1,0 +1,44 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v2
+name: dra-driver-cpu
+description: Kubernetes DRA driver for managing CPU resources with topology-aware allocation,
+  exclusive CPU assignment, and shared CPU pool management via the Dynamic Resource Allocation
+  framework.
+type: application
+version: 0.1.0
+appVersion: latest
+kubeVersion: ">= 1.34.0-0"
+sources:
+  - https://github.com/kubernetes-sigs/dra-driver-cpu
+home: https://github.com/kubernetes-sigs/dra-driver-cpu
+keywords:
+  - dra
+  - dra-driver
+  - cpu
+  - kubernetes
+  - resource-management
+  - numa
+maintainers:
+  - name: johnbelamaric
+    url: https://github.com/johnbelamaric
+  - name: pohly
+    url: https://github.com/pohly
+  - name: klueska
+    url: https://github.com/klueska
+  - name: ffromani
+    url: https://github.com/ffromani
+  - name: pravk03
+    url: https://github.com/pravk03

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -1,0 +1,60 @@
+# dra-driver-cpu Helm Chart
+
+Deploys the [dra-driver-cpu](https://github.com/kubernetes-sigs/dra-driver-cpu) DaemonSet — a Kubernetes Dynamic Resource Allocation (DRA) driver for managing CPU resources.
+
+## Installation
+
+From a local checkout:
+
+```bash
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system
+```
+
+To override values at install time:
+
+```bash
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system \
+  --set args.cpuDeviceMode=individual \
+  --set args.reservedCPUs="0-1"
+```
+
+## Configuration
+
+The following table lists the configurable parameters and their default values:
+
+| Parameter | Description | Default |
+|---|---|---|
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full release name | `""` |
+| `image.repository` | Container image repository | `us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu` |
+| `image.tag` | Image tag (falls back to `Chart.AppVersion` if empty) | `latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | List of image pull secrets | `[]` |
+| `rbac.create` | Create RBAC resources (ClusterRole and ClusterRoleBinding) | `true` |
+| `serviceAccount.annotations` | Annotations to add to the ServiceAccount | `{}` |
+| `podAnnotations` | Annotations to add to pods | `{}` |
+| `podLabels` | Extra labels to add to pods | `{}` |
+| `resources.requests.cpu` | CPU resource request | `100m` |
+| `resources.requests.memory` | Memory resource request | `50Mi` |
+| `resources.limits` | Resource limits (unset by default) | `{}` |
+| `tolerations` | Node tolerations | all NoSchedule taints tolerated |
+| `args.logLevel` | Log verbosity (`--v`) | `4` |
+| `args.cpuDeviceMode` | CPU exposure mode: `grouped` or `individual` | `grouped` |
+| `args.groupBy` | Grouping criteria when `cpuDeviceMode=grouped`: `numanode` or `socket` | `numanode` |
+| `args.reservedCPUs` | CPUs reserved for system/kubelet (e.g. `0-1`). Omitted if empty. | `""` |
+| `args.hostnameOverride` | Override the node name used by the driver. Omitted if empty. | `""` |
+| `healthzPath` | Path for liveness and readiness probes | `/healthz` |
+| `healthzPort` | Port the HTTP server binds to; used for the container port and probes | `8080` |
+
+Parameters can be set at install time using `--set` or a custom values file:
+
+```bash
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system --set args.logLevel=4
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f my-values.yaml
+```
+
+## Uninstallation
+
+```bash
+helm uninstall dra-driver-cpu -n kube-system
+```

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -1,6 +1,6 @@
 # dra-driver-cpu Helm Chart
 
-Deploys the [dra-driver-cpu](https://github.com/kubernetes-sigs/dra-driver-cpu) DaemonSet — a Kubernetes Dynamic Resource Allocation (DRA) driver for managing CPU resources.
+Kubernetes DRA driver for managing CPU resources with topology-aware allocation, exclusive CPU assignment, and shared CPU pool management via the Dynamic Resource Allocation framework.
 
 ## Installation
 
@@ -18,40 +18,38 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system \
   --set args.reservedCPUs="0-1"
 ```
 
-## Configuration
-
-The following table lists the configurable parameters and their default values:
-
-| Parameter | Description | Default |
-|---|---|---|
-| `nameOverride` | Override the chart name | `""` |
-| `fullnameOverride` | Override the full release name | `""` |
-| `image.repository` | Container image repository | `us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu` |
-| `image.tag` | Image tag (falls back to `Chart.AppVersion` if empty) | `latest` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `imagePullSecrets` | List of image pull secrets | `[]` |
-| `rbac.create` | Create RBAC resources (ClusterRole and ClusterRoleBinding) | `true` |
-| `serviceAccount.annotations` | Annotations to add to the ServiceAccount | `{}` |
-| `podAnnotations` | Annotations to add to pods | `{}` |
-| `podLabels` | Extra labels to add to pods | `{}` |
-| `resources.requests.cpu` | CPU resource request | `100m` |
-| `resources.requests.memory` | Memory resource request | `50Mi` |
-| `resources.limits` | Resource limits (unset by default) | `{}` |
-| `tolerations` | Node tolerations | all NoSchedule taints tolerated |
-| `args.logLevel` | Log verbosity (`--v`) | `4` |
-| `args.cpuDeviceMode` | CPU exposure mode: `grouped` or `individual` | `grouped` |
-| `args.groupBy` | Grouping criteria when `cpuDeviceMode=grouped`: `numanode` or `socket` | `numanode` |
-| `args.reservedCPUs` | CPUs reserved for system/kubelet (e.g. `0-1`). Omitted if empty. | `""` |
-| `args.hostnameOverride` | Override the node name used by the driver. Omitted if empty. | `""` |
-| `healthzPath` | Path for liveness and readiness probes | `/healthz` |
-| `healthzPort` | Port the HTTP server binds to; used for the container port and probes | `8080` |
-
 Parameters can be set at install time using `--set` or a custom values file:
 
 ```bash
 helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system --set args.logLevel=4
 helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f my-values.yaml
 ```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| args.cpuDeviceMode | string | `"grouped"` | CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device) |
+| args.groupBy | string | `"numanode"` | Grouping criteria when `cpuDeviceMode=grouped`: `numanode` or `socket` |
+| args.hostnameOverride | string | `""` | Override the node name the driver registers under; omitted when empty |
+| args.logLevel | int | `4` | Log verbosity level passed as `--v` |
+| args.reservedCPUs | string | `""` | CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty |
+| fullnameOverride | string | `""` | Override the full release name |
+| healthzPath | string | `"/healthz"` | Path for liveness and readiness probes |
+| healthzPort | int | `8080` | Port the HTTP server binds to; used for the container port and probes |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu"` | Container image repository |
+| image.tag | string | `""` | Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time |
+| imagePullSecrets | list | `[]` | List of image pull secrets |
+| nameOverride | string | `""` | Override the chart name |
+| podAnnotations | object | `{}` | Annotations to add to pods |
+| podLabels | object | `{}` | Extra labels to add to pods |
+| rbac.create | bool | `true` | Create RBAC resources (ClusterRole and ClusterRoleBinding) |
+| resources.limits | object | `{}` | Resource limits (unset by default) |
+| resources.requests.cpu | string | `"100m"` | CPU resource request |
+| resources.requests.memory | string | `"50Mi"` | Memory resource request |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
+| tolerations | list | `[{"effect":"NoSchedule","operator":"Exists"}]` | Node tolerations; defaults to tolerating all NoSchedule taints |
 
 ## Uninstallation
 

--- a/deployment/helm/dra-driver-cpu/README.md.gotmpl
+++ b/deployment/helm/dra-driver-cpu/README.md.gotmpl
@@ -1,0 +1,34 @@
+# {{ .Name }} Helm Chart
+
+{{ template "chart.description" . }}
+
+## Installation
+
+From a local checkout:
+
+```bash
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system
+```
+
+To override values at install time:
+
+```bash
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system \
+  --set args.cpuDeviceMode=individual \
+  --set args.reservedCPUs="0-1"
+```
+
+Parameters can be set at install time using `--set` or a custom values file:
+
+```bash
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system --set args.logLevel=4
+helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f my-values.yaml
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Uninstallation
+
+```bash
+helm uninstall dra-driver-cpu -n kube-system
+```

--- a/deployment/helm/dra-driver-cpu/templates/_helpers.tpl
+++ b/deployment/helm/dra-driver-cpu/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dra-driver-cpu.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dra-driver-cpu.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dra-driver-cpu.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dra-driver-cpu.labels" -}}
+helm.sh/chart: {{ include "dra-driver-cpu.chart" . }}
+{{ include "dra-driver-cpu.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dra-driver-cpu.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dra-driver-cpu.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/clusterrole.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/clusterrole.yaml
@@ -1,0 +1,70 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.rbac.create }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "dra-driver-cpu.fullname" . }}
+  labels:
+    {{- include "dra-driver-cpu.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceslices
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaims
+      - deviceclasses
+    verbs:
+      - get
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaims/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/driver
+    resourceNames:
+      - dra.cpu
+    verbs:
+      - associated-node:patch
+      - associated-node:update
+{{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/clusterrolebinding.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/clusterrolebinding.yaml
@@ -1,0 +1,30 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.rbac.create }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "dra-driver-cpu.fullname" . }}
+  labels:
+    {{- include "dra-driver-cpu.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dra-driver-cpu.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dra-driver-cpu.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -1,0 +1,114 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "dra-driver-cpu.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dra-driver-cpu.labels" . | nindent 4 }}
+    tier: node
+    k8s-app: {{ include "dra-driver-cpu.name" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dra-driver-cpu.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dra-driver-cpu.labels" . | nindent 8 }}
+        tier: node
+        k8s-app: {{ include "dra-driver-cpu.name" . }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      serviceAccountName: {{ include "dra-driver-cpu.fullname" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: dracpu
+        args:
+          - /dracpu
+          - --v={{ .Values.args.logLevel }}
+          - --cpu-device-mode={{ .Values.args.cpuDeviceMode }}
+          - --group-by={{ .Values.args.groupBy }}
+          {{- if .Values.healthzPort }}
+          - --bind-address=:{{ .Values.healthzPort }}
+          {{- end }}
+          {{- if .Values.args.reservedCPUs }}
+          - --reserved-cpus={{ .Values.args.reservedCPUs }}
+          {{- end }}
+          {{- if .Values.args.hostnameOverride }}
+          - --hostname-override={{ .Values.args.hostnameOverride }}
+          {{- end }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - name: healthz
+            containerPort: {{ .Values.healthzPort }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.healthzPath }}
+            port: healthz
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.healthzPath }}
+            port: healthz
+          initialDelaySeconds: 5
+        resources:
+          requests:
+            {{- toYaml .Values.resources.requests | nindent 12 }}
+          {{- with .Values.resources.limits }}
+          limits:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "SYS_ADMIN"]
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/plugins
+        - name: plugin-registry
+          mountPath: /var/lib/kubelet/plugins_registry
+        - name: nri-plugin
+          mountPath: /var/run/nri
+        - name: cdi-dir
+          mountPath: /var/run/cdi
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/plugins
+      - name: plugin-registry
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+      - name: nri-plugin
+        hostPath:
+          path: /var/run/nri
+      - name: cdi-dir
+        hostPath:
+          path: /var/run/cdi
+          type: DirectoryOrCreate

--- a/deployment/helm/dra-driver-cpu/templates/deviceclass.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/deviceclass.yaml
@@ -1,0 +1,22 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: dra.cpu
+spec:
+  selectors:
+    - cel:
+        expression: device.driver == "dra.cpu"

--- a/deployment/helm/dra-driver-cpu/templates/serviceaccount.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/serviceaccount.yaml
@@ -1,0 +1,25 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dra-driver-cpu.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dra-driver-cpu.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full release name."
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "pullPolicy"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Falls back to Chart.AppVersion if empty."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy."
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" }
+        }
+      },
+      "description": "List of image pull secrets."
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["create"],
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create RBAC resources (ClusterRole and ClusterRoleBinding)."
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the ServiceAccount."
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations to add to pods."
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Extra labels to add to pods."
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": { "type": "string" },
+          "operator": { "type": "string", "enum": ["Exists", "Equal"] },
+          "value": { "type": "string" },
+          "effect": { "type": "string", "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"] },
+          "tolerationSeconds": { "type": "integer" }
+        }
+      },
+      "description": "Node tolerations for the DaemonSet pods."
+    },
+    "args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logLevel", "cpuDeviceMode", "groupBy"],
+      "properties": {
+        "logLevel": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Log verbosity (--v)."
+        },
+        "cpuDeviceMode": {
+          "type": "string",
+          "enum": ["grouped", "individual"],
+          "description": "CPU exposure mode."
+        },
+        "groupBy": {
+          "type": "string",
+          "enum": ["numanode", "socket"],
+          "description": "Grouping criteria when cpuDeviceMode=grouped."
+        },
+        "reservedCPUs": {
+          "type": "string",
+          "description": "CPUs to exclude from DRA allocation (e.g. '0-1'). Omitted if empty."
+        },
+        "hostnameOverride": {
+          "type": "string",
+          "description": "Override the node name used by the driver. Omitted if empty."
+        }
+      }
+    },
+    "healthzPath": {
+      "type": "string",
+      "description": "Path for the HTTP healthz endpoint."
+    },
+    "healthzPort": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "Port the HTTP server binds to; used for the container port and probes."
+    }
+  }
+}

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -1,151 +1,173 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
-    "nameOverride": {
-      "type": "string",
-      "description": "Override the chart name."
+    "args": {
+      "type": "object",
+      "required": [
+        "logLevel",
+        "cpuDeviceMode",
+        "groupBy"
+      ],
+      "properties": {
+        "cpuDeviceMode": {
+          "description": "CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device)",
+          "type": "string",
+          "enum": [
+            "grouped",
+            "individual"
+          ]
+        },
+        "groupBy": {
+          "description": "Grouping criteria when `cpuDeviceMode=grouped`: `numanode` or `socket`",
+          "type": "string",
+          "enum": [
+            "numanode",
+            "socket"
+          ]
+        },
+        "hostnameOverride": {
+          "description": "Override the node name the driver registers under; omitted when empty",
+          "type": "string"
+        },
+        "logLevel": {
+          "description": "Log verbosity level passed as `--v`",
+          "type": "integer",
+          "minimum": 0
+        },
+        "reservedCPUs": {
+          "description": "CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `\"0-1\"`); omitted when empty",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     },
     "fullnameOverride": {
-      "type": "string",
-      "description": "Override the full release name."
+      "description": "Override the full release name",
+      "type": "string"
+    },
+    "healthzPath": {
+      "description": "Path for liveness and readiness probes",
+      "type": "string"
+    },
+    "healthzPort": {
+      "description": "Port the HTTP server binds to; used for the container port and probes",
+      "type": "integer",
+      "maximum": 65535,
+      "minimum": 1
     },
     "image": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["repository", "pullPolicy"],
+      "required": [
+        "repository",
+        "pullPolicy"
+      ],
       "properties": {
-        "repository": {
+        "pullPolicy": {
+          "description": "Image pull policy",
           "type": "string",
-          "description": "Container image repository."
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        },
+        "repository": {
+          "description": "Container image repository",
+          "type": "string"
         },
         "tag": {
-          "type": "string",
-          "description": "Image tag. Falls back to Chart.AppVersion if empty."
-        },
-        "pullPolicy": {
-          "type": "string",
-          "enum": ["Always", "IfNotPresent", "Never"],
-          "description": "Image pull policy."
-        }
-      }
-    },
-    "imagePullSecrets": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["name"],
-        "properties": {
-          "name": { "type": "string" }
+          "description": "Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time",
+          "type": "string"
         }
       },
-      "description": "List of image pull secrets."
+      "additionalProperties": false
+    },
+    "imagePullSecrets": {
+      "description": "List of image pull secrets",
+      "type": "array"
+    },
+    "nameOverride": {
+      "description": "Override the chart name",
+      "type": "string"
+    },
+    "podAnnotations": {
+      "description": "Annotations to add to pods",
+      "type": "object"
+    },
+    "podLabels": {
+      "description": "Extra labels to add to pods",
+      "type": "object"
     },
     "rbac": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["create"],
+      "required": [
+        "create"
+      ],
       "properties": {
         "create": {
-          "type": "boolean",
-          "description": "Create RBAC resources (ClusterRole and ClusterRoleBinding)."
+          "description": "Create RBAC resources (ClusterRole and ClusterRoleBinding)",
+          "type": "boolean"
         }
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "annotations": {
-          "type": "object",
-          "description": "Annotations to add to the ServiceAccount."
-        }
-      }
-    },
-    "podAnnotations": {
-      "type": "object",
-      "description": "Annotations to add to pods."
-    },
-    "podLabels": {
-      "type": "object",
-      "description": "Extra labels to add to pods."
+      },
+      "additionalProperties": false
     },
     "resources": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
+        "limits": {
+          "description": "Resource limits (unset by default)",
+          "type": "object"
+        },
         "requests": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
-            "cpu": { "type": "string" },
-            "memory": { "type": "string" }
-          }
-        },
-        "limits": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "cpu": { "type": "string" },
-            "memory": { "type": "string" }
-          }
+            "cpu": {
+              "description": "CPU resource request",
+              "type": "string"
+            },
+            "memory": {
+              "description": "Memory resource request",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations to add to the ServiceAccount",
+          "type": "object"
         }
       }
     },
     "tolerations": {
+      "description": "Node tolerations; defaults to tolerating all NoSchedule taints",
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "key": { "type": "string" },
-          "operator": { "type": "string", "enum": ["Exists", "Equal"] },
-          "value": { "type": "string" },
-          "effect": { "type": "string", "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"] },
-          "tolerationSeconds": { "type": "integer" }
-        }
-      },
-      "description": "Node tolerations for the DaemonSet pods."
-    },
-    "args": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["logLevel", "cpuDeviceMode", "groupBy"],
-      "properties": {
-        "logLevel": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Log verbosity (--v)."
-        },
-        "cpuDeviceMode": {
-          "type": "string",
-          "enum": ["grouped", "individual"],
-          "description": "CPU exposure mode."
-        },
-        "groupBy": {
-          "type": "string",
-          "enum": ["numanode", "socket"],
-          "description": "Grouping criteria when cpuDeviceMode=grouped."
-        },
-        "reservedCPUs": {
-          "type": "string",
-          "description": "CPUs to exclude from DRA allocation (e.g. '0-1'). Omitted if empty."
-        },
-        "hostnameOverride": {
-          "type": "string",
-          "description": "Override the node name used by the driver. Omitted if empty."
+          "effect": {
+            "type": "string",
+            "enum": [
+              "NoSchedule",
+              "PreferNoSchedule",
+              "NoExecute"
+            ]
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "Exists",
+              "Equal"
+            ]
+          }
         }
       }
-    },
-    "healthzPath": {
-      "type": "string",
-      "description": "Path for the HTTP healthz endpoint."
-    },
-    "healthzPort": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 65535,
-      "description": "Port the HTTP server binds to; used for the container port and probes."
     }
   }
 }

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -1,0 +1,53 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu
+  # tag defaults to .Chart.AppVersion when empty, which is set to the release tag at package time
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+rbac:
+  create: true
+
+serviceAccount:
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "50Mi"
+  limits: {}
+
+tolerations:
+  - operator: "Exists"
+    effect: "NoSchedule"
+
+args:
+  logLevel: 4
+  cpuDeviceMode: "grouped"
+  groupBy: "numanode"  # numanode or socket; only used when cpuDeviceMode=grouped
+  reservedCPUs: ""  # e.g. "0-1"
+  hostnameOverride: ""
+
+healthzPath: /healthz
+healthzPort: 8080

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -17,20 +17,22 @@ nameOverride: ""
 # -- Override the full release name
 fullnameOverride: ""
 
+# @schema additionalProperties:false
 image:
   # -- Container image repository
-  repository: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu
+  repository: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu # @schema required:true
   # -- Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time
   tag: ""
   # -- Image pull policy
-  pullPolicy: IfNotPresent
+  pullPolicy: IfNotPresent # @schema required:true;enum:[Always, IfNotPresent, Never]
 
 # -- List of image pull secrets
 imagePullSecrets: []
 
+# @schema additionalProperties:false
 rbac:
   # -- Create RBAC resources (ClusterRole and ClusterRoleBinding)
-  create: true
+  create: true # @schema type:boolean;required:true
 
 serviceAccount:
   # -- Annotations to add to the ServiceAccount
@@ -41,7 +43,9 @@ podAnnotations: {}
 # -- Extra labels to add to pods
 podLabels: {}
 
+# @schema additionalProperties:false
 resources:
+  # @schema additionalProperties:false
   requests:
     # -- CPU resource request
     cpu: "100m"
@@ -52,16 +56,17 @@ resources:
 
 # -- Node tolerations; defaults to tolerating all NoSchedule taints
 tolerations:
-  - operator: "Exists"
-    effect: "NoSchedule"
+  - operator: "Exists" # @schema enum:[Exists, Equal]
+    effect: "NoSchedule" # @schema enum:[NoSchedule, PreferNoSchedule, NoExecute]
 
+# @schema additionalProperties:false
 args:
   # -- Log verbosity level passed as `--v`
-  logLevel: 4
+  logLevel: 4 # @schema type:integer;minimum:0;required:true
   # -- CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device)
-  cpuDeviceMode: "grouped"
+  cpuDeviceMode: "grouped" # @schema enum:[grouped, individual];required:true
   # -- Grouping criteria when `cpuDeviceMode=grouped`: `numanode` or `socket`
-  groupBy: "numanode"
+  groupBy: "numanode" # @schema enum:[numanode, socket];required:true
   # -- CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty
   reservedCPUs: ""
   # -- Override the node name the driver registers under; omitted when empty
@@ -70,4 +75,4 @@ args:
 # -- Path for liveness and readiness probes
 healthzPath: /healthz
 # -- Port the HTTP server binds to; used for the container port and probes
-healthzPort: 8080
+healthzPort: 8080 # @schema type:integer;minimum:1;maximum:65535

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -12,42 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# -- Override the chart name
 nameOverride: ""
+# -- Override the full release name
 fullnameOverride: ""
 
 image:
+  # -- Container image repository
   repository: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu
-  # tag defaults to .Chart.AppVersion when empty, which is set to the release tag at package time
+  # -- Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time
   tag: ""
+  # -- Image pull policy
   pullPolicy: IfNotPresent
 
+# -- List of image pull secrets
 imagePullSecrets: []
 
 rbac:
+  # -- Create RBAC resources (ClusterRole and ClusterRoleBinding)
   create: true
 
 serviceAccount:
+  # -- Annotations to add to the ServiceAccount
   annotations: {}
 
+# -- Annotations to add to pods
 podAnnotations: {}
+# -- Extra labels to add to pods
 podLabels: {}
 
 resources:
   requests:
+    # -- CPU resource request
     cpu: "100m"
+    # -- Memory resource request
     memory: "50Mi"
+  # -- Resource limits (unset by default)
   limits: {}
 
+# -- Node tolerations; defaults to tolerating all NoSchedule taints
 tolerations:
   - operator: "Exists"
     effect: "NoSchedule"
 
 args:
+  # -- Log verbosity level passed as `--v`
   logLevel: 4
+  # -- CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device)
   cpuDeviceMode: "grouped"
-  groupBy: "numanode"  # numanode or socket; only used when cpuDeviceMode=grouped
-  reservedCPUs: ""  # e.g. "0-1"
+  # -- Grouping criteria when `cpuDeviceMode=grouped`: `numanode` or `socket`
+  groupBy: "numanode"
+  # -- CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty
+  reservedCPUs: ""
+  # -- Override the node name the driver registers under; omitted when empty
   hostnameOverride: ""
 
+# -- Path for liveness and readiness probes
 healthzPath: /healthz
+# -- Port the HTTP server binds to; used for the container port and probes
 healthzPort: 8080


### PR DESCRIPTION
Add a Helm chart for driver installation. This PR adds:
- Helm chart for driver installation
- Documentation to describe installation and available values
- Linter CI for the charts & schema validation

Follow-up (_TODO_)
- chart packaging and publishing to `ghcr.io/kubernetes-sigs/dra-driver-cpu/charts/dra-driver-cpu`
- versioned releases from tags, `0.0.0-main` from main branch

Note: currently all the templates (DeamonSet, ServiceAccount, etc are based on the what is available in install.yaml).

Fixes: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/72