### PR TITLE
rbac: add resourceclaims/driver associated-node verbs for dra.cpu

### DIFF
--- a/manifests/base/clusterrole-dracpu.part.yaml
+++ b/manifests/base/clusterrole-dracpu.part.yaml
@@ -34,6 +34,15 @@ rules:
       - patch
       - update
   - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/driver
+    resourceNames:
+      - dra.cpu
+    verbs:
+      - associated-node:patch
+      - associated-node:update
+  - apiGroups:
       - ""
     resources:
       - pods


### PR DESCRIPTION
## What
Add RBAC permissions for ResourceClaim driver synthetic subresource updates.

## Why
Kubernetes v1.36 introduces granular authorization for ResourceClaim status updates.
Node-local DRA drivers require associated-node permissions on resourceclaims/driver.

#Ref: kubernetes/kubernetes#138149