### PR TITLE
Update CPU topology discovery to support ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ IMAGE := ${STAGING_IMAGE_NAME}:${TAG}
 IMAGE_CI := ${REGISTRY_CI}/${IMAGE_NAME}:${TAG}
 IMAGE_TEST := ${REGISTRY_CI}/${IMAGE_NAME}-test:${TAG}
 # target platform(s)
-PLATFORMS?=linux/amd64
+PLATFORMS?=linux/amd64,linux/arm64
+LOCAL_PLATFORM?=linux/$(ARCH)
 
 # set convenient defaults for user variables
 DRACPU_E2E_CPU_DEVICE_MODE ?= grouped
@@ -108,7 +109,7 @@ image: ## docker build load
 
 build-image: ## build image
 	docker buildx build . \
-		--platform="${PLATFORMS}" \
+		--platform="${LOCAL_PLATFORM}" \
 		--tag="${IMAGE}" \
 		--tag="${IMAGE_LATEST}" \
 		--tag="${IMAGE_CI}" \
@@ -200,7 +201,7 @@ endif
 build-test-image: ## build tests image
 	docker buildx build . \
 		--file test/image/Dockerfile \
-		--platform="${PLATFORMS}" \
+		--platform="${LOCAL_PLATFORM}" \
 		--tag="${IMAGE_TEST}" \
 		--load
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The driver is deployed as a DaemonSet which contains two core components:
 
 - **DRA driver**: This component is the main control loop and handles the interaction with the Kubernetes API server for Dynamic Resource Allocation.
 
-  - **Topology Discovery**: It discovers the node's CPU topology, including details like sockets, NUMA nodes, cores, SMT siblings, Last-Level Cache (LLC), and core types (e.g., Performance-cores, Efficiency-cores). This is done by parsing `/proc/cpuinfo` and reading sysfs files.
+  - **Topology Discovery**: It discovers the node's CPU topology, including details like sockets, NUMA nodes, cores, SMT siblings, Last-Level Cache (LLC), and core types (e.g., Performance-cores, Efficiency-cores). This is done by reading sysfs files.
   - **ResourceSlice Publication**: Based on the `--cpu-device-mode` flag, it publishes `ResourceSlice` objects to the API server:
     - In `individual` mode, each allocatable CPU becomes a device in the `ResourceSlice`, with attributes detailing its topology.
     - In `grouped` mode, devices represent larger CPU aggregates (like NUMA nodes or sockets). These devices support consumable capacity, indicating the number of available CPUs within that group.
@@ -378,11 +378,24 @@ These notes collect contributor-oriented commands and repository quirks.
 
 ### Testing Local Changes in a Kind Cluster
 
-To deploy a kind cluster using a locally built image (instead of pulling from a registry), first generate manifests that reference the local image and then install the driver. `OVERRIDE_IMAGE=true` patches the generated manifests to use the image built from local sources. `kind-install-cpu-dra` calls `build-image` internally to build the image first, then loads it into the kind cluster and deploys the manifests.
+The simplest way to build the driver from source and deploy it into a new Kind cluster is using:
 
 ```bash
-make manifests OVERRIDE_IMAGE=true
-make kind-install-cpu-dra
+make ci-kind-setup
+```
+
+This command builds the driver image, creates a Kind cluster, loads the image, and installs the driver manifests in `grouped` mode (the default).
+
+To install the driver in `individual` mode instead, use:
+
+```bash
+DRACPU_E2E_CPU_DEVICE_MODE=individual make ci-kind-setup
+```
+
+To clean up the environment when finished, run:
+
+```bash
+make delete-kind-cluster
 ```
 
 ### Linting

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -199,7 +199,7 @@ func (s *SystemCPUInfo) IsSMTEnabled() (bool, error) {
 	if status == "on" {
 		return true, nil
 	}
-	if status == "off" || status == "forceoff" || status == "notsupported" {
+	if status == "off" || status == "forceoff" || status == "notsupported" || status == "notimplemented" {
 		return false, nil
 	}
 	return false, fmt.Errorf("unknown SMT status: %s", status)

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -103,11 +103,11 @@ type CPUInfo struct {
 	// NUMANodeID is the NUMA node ID, unique within each SocketID
 	NUMANodeID int `json:"numaNodeID"`
 
-	// NUMA Node Affinity Mask
-	NumaNodeAffinityMask string `json:"numaNodeAffinityMask"`
+	// NUMANodeCPUSet represents the set of CPUs that are in the same NUMA node.
+	NumaNodeCPUSet cpuset.CPUSet `json:"numaNodeCPUSet"`
 
 	// CPU Sibling of the CpuID
-	SiblingCpuID int `json:"sibling"`
+	SiblingCPUID int `json:"sibling"`
 
 	// Core Type (e-core or p-core)
 	CoreType CoreType `json:"coreType,omitempty"`
@@ -237,15 +237,15 @@ func (s *SystemCPUInfo) GetCPUInfos() ([]CPUInfo, error) {
 	cpuInfos := make([]CPUInfo, 0, onlineCPUs.Size())
 	for _, cpuID := range onlineCPUs.List() {
 		cpuInfo := CPUInfo{
-			CpuID:                cpuID,
-			SocketID:             -1,
-			CoreID:               -1,
-			ClusterID:            -1,
-			NUMANodeID:           -1,
-			NumaNodeAffinityMask: "",
-			UncoreCacheID:        -1,
-			SiblingCpuID:         -1,
-			CoreType:             CoreTypeUndefined,
+			CpuID:          cpuID,
+			SocketID:       -1,
+			CoreID:         -1,
+			ClusterID:      -1,
+			NUMANodeID:     -1,
+			NumaNodeCPUSet: cpuset.New(),
+			UncoreCacheID:  -1,
+			SiblingCPUID:   -1,
+			CoreType:       CoreTypeUndefined,
 		}
 
 		if isHybrid {
@@ -280,20 +280,30 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 	if err != nil {
 		return fmt.Errorf("could not read socket_id for cpu %d from sysfs: %w", cpuID, err)
 	}
-	socketID, _ := strconv.Atoi(strings.TrimSpace(socketStr))
+	socketID, err := strconv.Atoi(strings.TrimSpace(socketStr))
+	if err != nil {
+		return fmt.Errorf("could not parse socket_id %q for cpu %d: %w", socketStr, cpuID, err)
+	}
 	cpuInfo.SocketID = socketID
 
-	// Get Cluster ID from sysfs (for ARM)
+	// Get Cluster ID from sysfs. While this sysfs file is present on most
+	// architectures, on ARM this defines the physical boundary for shared resources (like L2 cache).
 	clusterPath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d/topology/cluster_id", cpuID))
 	clusterStr, err := ReadFile(clusterPath)
 	if err == nil {
-		clusterID, _ := strconv.Atoi(strings.TrimSpace(clusterStr))
-		// On many x86 systems, the kernel reports 65535 to indicate "No Cluster".
-		// We treat this as -1 to mean unknown/not applicable.
-		if clusterID == 65535 {
+		clusterID, err := strconv.Atoi(strings.TrimSpace(clusterStr))
+		if err != nil {
+			log.Printf("Warning: could not parse cluster_id %q for cpu %d: %v", clusterStr, cpuID, err)
 			cpuInfo.ClusterID = -1
 		} else {
-			cpuInfo.ClusterID = clusterID
+			// The kernel default for an undefined cluster id is -1.
+			// However, due to 16-bit unsigned type casting, sysfs exposes this as 65535.
+			// https://www.kernel.org/doc/Documentation/admin-guide/cputopology.rst
+			if clusterID == 65535 {
+				cpuInfo.ClusterID = -1
+			} else {
+				cpuInfo.ClusterID = clusterID
+			}
 		}
 	} else {
 		cpuInfo.ClusterID = -1 // Default to -1 if not present
@@ -305,7 +315,10 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 	if err != nil {
 		return fmt.Errorf("could not read core_id for cpu %d from sysfs: %w", cpuID, err)
 	}
-	coreID, _ := strconv.Atoi(strings.TrimSpace(coreStr))
+	coreID, err := strconv.Atoi(strings.TrimSpace(coreStr))
+	if err != nil {
+		return fmt.Errorf("could not parse core_id %q for cpu %d: %w", coreStr, cpuID, err)
+	}
 	cpuInfo.CoreID = coreID
 
 	// Get NUMA Node ID from sysfs
@@ -318,21 +331,26 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 	foundNode := false
 	for _, file := range files {
 		if strings.HasPrefix(file.Name(), "node") {
-			nodeID, err := strconv.ParseInt(strings.TrimPrefix(file.Name(), "node"), 10, 64)
+			nodeID, err := strconv.Atoi(strings.TrimPrefix(file.Name(), "node"))
 			if err != nil {
-				continue // Should not happen with a well-formed sysfs
+				log.Printf("Warning: could not parse NUMA node ID from %s: %v", file.Name(), err)
+				continue
 			}
-			cpuInfo.NUMANodeID = int(nodeID)
+			cpuInfo.NUMANodeID = nodeID
 			foundNode = true
 
 			// Get NUMA Affinity Mask
-			maskPath := hostSys(fmt.Sprintf("devices/system/node/node%d/cpumap", nodeID))
-			maskLines, err := ReadLines(maskPath)
-			if err != nil {
+			cpuListPath := hostSys(fmt.Sprintf("devices/system/node/node%d/cpulist", nodeID))
+			cpuListLines, err := ReadLines(cpuListPath)
+			if err != nil || len(cpuListLines) == 0 {
 				log.Printf("Warning: could not read NUMA affinity mask for node %d: %v", nodeID, err)
 				continue
 			}
-			cpuInfo.NumaNodeAffinityMask = formatAffinityMask(maskLines[0])
+			cpuInfo.NumaNodeCPUSet, err = cpuset.Parse(cpuListLines[0])
+			if err != nil {
+				log.Printf("Warning: could not parse NUMA affinity mask for node %d: %v", nodeID, err)
+				continue
+			}
 			break
 		}
 	}
@@ -382,22 +400,22 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 
 		cacheIdPath := filepath.Join(l3CacheDir, "id")
 		idStr, err := ReadFile(cacheIdPath)
-		var id int64
+		var id int
 		if err != nil {
 			// Fallback for ARM systems missing the 'id' file: use the lowest shared CPU ID as the cache ID.
 			if sharedCPUSet.Size() > 0 {
-				id = int64(sharedCPUSet.List()[0])
+				id = sharedCPUSet.List()[0]
 			} else {
-				id = int64(cpuID)
+				id = cpuID
 			}
 		} else {
-			id, err = strconv.ParseInt(strings.TrimSpace(idStr), 10, 64)
+			id, err = strconv.Atoi(strings.TrimSpace(idStr))
 			if err != nil {
 				return fmt.Errorf("could not parse L3 cache id '%s': %w", idStr, err)
 			}
 		}
 
-		cpuInfo.UncoreCacheID = int(id)
+		cpuInfo.UncoreCacheID = id
 		break
 	}
 
@@ -433,27 +451,10 @@ func populateCpuSiblings(cpuInfos []CPUInfo) {
 			cpu1Id, cpu2Id := siblingIds[0], siblingIds[1]
 			cpu1Index, cpu2Index := cpuIndexMap[cpu1Id], cpuIndexMap[cpu2Id]
 
-			cpuInfos[cpu1Index].SiblingCpuID = cpu2Id
-			cpuInfos[cpu2Index].SiblingCpuID = cpu1Id
+			cpuInfos[cpu1Index].SiblingCPUID = cpu2Id
+			cpuInfos[cpu2Index].SiblingCPUID = cpu1Id
 		}
 	}
-}
-
-func formatAffinityMask(mask string) string {
-	if strings.TrimSpace(mask) == "" {
-		return "0x0"
-	}
-	parts := strings.Split(mask, ",")
-	// Reverse the parts to handle the kernel's little-endian word order.
-	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
-		parts[i], parts[j] = parts[j], parts[i]
-	}
-	newMask := strings.Join(parts, "")
-	newMask = strings.TrimLeft(newMask, "0")
-	if newMask == "" {
-		return "0x0"
-	}
-	return "0x" + newMask
 }
 
 // ReadFile reads contents from a file.

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -299,15 +299,6 @@ func populateL3CacheIDs(cpuInfos []CPUInfo) error {
 
 			if strings.TrimSpace(levelStr) == "3" {
 				l3CacheDir := filepath.Join(cachePath, entry.Name())
-				cacheIdPath := filepath.Join(l3CacheDir, "id")
-				idStr, err := ReadFile(cacheIdPath)
-				if err != nil {
-					return fmt.Errorf("could not read L3 cache id from %s: %w", cacheIdPath, err)
-				}
-				id, err := strconv.ParseInt(strings.TrimSpace(idStr), 10, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse L3 cache id '%s': %w", idStr, err)
-				}
 
 				sharedCPUListPath := filepath.Join(l3CacheDir, "shared_cpu_list")
 				sharedCPUListStr, err := ReadFile(sharedCPUListPath)
@@ -318,6 +309,23 @@ func populateL3CacheIDs(cpuInfos []CPUInfo) error {
 				sharedCPUSet, err := cpuset.Parse(strings.TrimSpace(sharedCPUListStr))
 				if err != nil {
 					return fmt.Errorf("could not parse shared_cpu_list '%s': %w", sharedCPUListStr, err)
+				}
+
+				cacheIdPath := filepath.Join(l3CacheDir, "id")
+				idStr, err := ReadFile(cacheIdPath)
+				var id int64
+				if err != nil {
+					// Fallback for ARM systems missing the 'id' file: use the lowest shared CPU ID as the cache ID.
+					if sharedCPUSet.Size() > 0 {
+						id = int64(sharedCPUSet.List()[0])
+					} else {
+						id = int64(cpuInfos[i].CpuID)
+					}
+				} else {
+					id, err = strconv.ParseInt(strings.TrimSpace(idStr), 10, 64)
+					if err != nil {
+						return fmt.Errorf("could not parse L3 cache id '%s': %w", idStr, err)
+					}
 				}
 
 				// Update the L3Cache ID for all the cpus with the same cache.
@@ -417,6 +425,7 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 	return nil
 }
 
+// TODO: Handle more complex sibling relationships (e.g. 4-way SMT) if needed in the future. For now we only handle 2-way hyperthreading which is the most common case.
 func populateCpuSiblings(cpuInfos []CPUInfo) {
 	// Define a key struct to identify a unique physical core.
 	type coreLocation struct {
@@ -492,10 +501,6 @@ func ReadLines(filename string) ([]string, error) {
 
 func hostRoot(combineWith ...string) string {
 	return GetEnv("HOST_ROOT", "/", combineWith...)
-}
-
-func hostProc(combineWith ...string) string {
-	return hostRoot(combinePath("proc", combineWith...))
 }
 
 func hostSys(combineWith ...string) string {

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -266,85 +266,12 @@ func (s *SystemCPUInfo) GetCPUInfos() ([]CPUInfo, error) {
 		cpuInfos = append(cpuInfos, cpuInfo)
 	}
 
-	if err := populateL3CacheIDs(cpuInfos); err != nil {
-		return nil, fmt.Errorf("failed to populate L3 cache IDs: %w", err)
-	}
 	populateCpuSiblings(cpuInfos)
 
 	return cpuInfos, nil
 }
 
-func populateL3CacheIDs(cpuInfos []CPUInfo) error {
-	for i := range cpuInfos {
-		if cpuInfos[i].UncoreCacheID != -1 {
-			continue
-		}
-
-		cachePath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d/cache", cpuInfos[i].CpuID))
-		entries, err := os.ReadDir(cachePath)
-		if err != nil {
-			return fmt.Errorf("could not read cache dir %s: %w", cachePath, err)
-		}
-
-		for _, entry := range entries {
-			if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "index") {
-				continue
-			}
-
-			levelPath := filepath.Join(cachePath, entry.Name(), "level")
-			levelStr, err := ReadFile(levelPath)
-			if err != nil {
-				continue
-			}
-
-			if strings.TrimSpace(levelStr) == "3" {
-				l3CacheDir := filepath.Join(cachePath, entry.Name())
-
-				sharedCPUListPath := filepath.Join(l3CacheDir, "shared_cpu_list")
-				sharedCPUListStr, err := ReadFile(sharedCPUListPath)
-				if err != nil {
-					return fmt.Errorf("could not read shared_cpu_list from %s: %w", sharedCPUListPath, err)
-				}
-
-				sharedCPUSet, err := cpuset.Parse(strings.TrimSpace(sharedCPUListStr))
-				if err != nil {
-					return fmt.Errorf("could not parse shared_cpu_list '%s': %w", sharedCPUListStr, err)
-				}
-
-				cacheIdPath := filepath.Join(l3CacheDir, "id")
-				idStr, err := ReadFile(cacheIdPath)
-				var id int64
-				if err != nil {
-					// Fallback for ARM systems missing the 'id' file: use the lowest shared CPU ID as the cache ID.
-					if sharedCPUSet.Size() > 0 {
-						id = int64(sharedCPUSet.List()[0])
-					} else {
-						id = int64(cpuInfos[i].CpuID)
-					}
-				} else {
-					id, err = strconv.ParseInt(strings.TrimSpace(idStr), 10, 64)
-					if err != nil {
-						return fmt.Errorf("could not parse L3 cache id '%s': %w", idStr, err)
-					}
-				}
-
-				// Update the L3Cache ID for all the cpus with the same cache.
-				for j := range cpuInfos {
-					if sharedCPUSet.Contains(cpuInfos[j].CpuID) {
-						cpuInfos[j].UncoreCacheID = int(id)
-					}
-				}
-				break
-			}
-		}
-	}
-	return nil
-}
-
 func populateTopologyInfo(cpuInfo *CPUInfo) error {
-	// Cache the affinity masks so we don't read the same file multiple times.
-	numaMaskCache := make(map[int]string)
-
 	cpuID := cpuInfo.CpuID
 
 	// Get Socket ID from sysfs
@@ -398,19 +325,14 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 			cpuInfo.NUMANodeID = int(nodeID)
 			foundNode = true
 
-			//  Get NUMA Affinity Mask (from cache if possible)
-			mask, ok := numaMaskCache[int(nodeID)]
-			if !ok {
-				maskPath := hostSys(fmt.Sprintf("devices/system/node/node%d/cpumap", nodeID))
-				maskLines, err := ReadLines(maskPath)
-				if err != nil {
-					log.Printf("Warning: could not read NUMA affinity mask for node %d: %v", nodeID, err)
-					continue
-				}
-				mask = formatAffinityMask(maskLines[0])
-				numaMaskCache[int(nodeID)] = mask
+			// Get NUMA Affinity Mask
+			maskPath := hostSys(fmt.Sprintf("devices/system/node/node%d/cpumap", nodeID))
+			maskLines, err := ReadLines(maskPath)
+			if err != nil {
+				log.Printf("Warning: could not read NUMA affinity mask for node %d: %v", nodeID, err)
+				continue
 			}
-			cpuInfo.NumaNodeAffinityMask = mask
+			cpuInfo.NumaNodeAffinityMask = formatAffinityMask(maskLines[0])
 			break
 		}
 	}
@@ -420,6 +342,63 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 
 	if cpuInfo.SocketID < 0 || cpuInfo.CoreID < 0 || cpuInfo.NUMANodeID < 0 {
 		return fmt.Errorf("incomplete topology information for CPU %d (socket: %d, core: %d, NUMA node: %d)", cpuID, cpuInfo.SocketID, cpuInfo.CoreID, cpuInfo.NUMANodeID)
+	}
+
+	// Get L3 Cache ID
+	cachePath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d/cache", cpuID))
+	cacheEntries, err := os.ReadDir(cachePath)
+	if err != nil {
+		return fmt.Errorf("could not read cache dir %s: %w", cachePath, err)
+	}
+
+	for _, entry := range cacheEntries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "index") {
+			continue
+		}
+
+		levelPath := filepath.Join(cachePath, entry.Name(), "level")
+		levelStr, err := ReadFile(levelPath)
+		if err != nil {
+			continue
+		}
+
+		// We are only interested in L3 caches
+		if strings.TrimSpace(levelStr) != "3" {
+			continue
+		}
+
+		l3CacheDir := filepath.Join(cachePath, entry.Name())
+
+		sharedCPUListPath := filepath.Join(l3CacheDir, "shared_cpu_list")
+		sharedCPUListStr, err := ReadFile(sharedCPUListPath)
+		if err != nil {
+			return fmt.Errorf("could not read shared_cpu_list from %s: %w", sharedCPUListPath, err)
+		}
+
+		sharedCPUSet, err := cpuset.Parse(strings.TrimSpace(sharedCPUListStr))
+		if err != nil {
+			return fmt.Errorf("could not parse shared_cpu_list '%s': %w", sharedCPUListStr, err)
+		}
+
+		cacheIdPath := filepath.Join(l3CacheDir, "id")
+		idStr, err := ReadFile(cacheIdPath)
+		var id int64
+		if err != nil {
+			// Fallback for ARM systems missing the 'id' file: use the lowest shared CPU ID as the cache ID.
+			if sharedCPUSet.Size() > 0 {
+				id = int64(sharedCPUSet.List()[0])
+			} else {
+				id = int64(cpuID)
+			}
+		} else {
+			id, err = strconv.ParseInt(strings.TrimSpace(idStr), 10, 64)
+			if err != nil {
+				return fmt.Errorf("could not parse L3 cache id '%s': %w", idStr, err)
+			}
+		}
+
+		cpuInfo.UncoreCacheID = int(id)
+		break
 	}
 
 	return nil

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -97,6 +97,9 @@ type CPUInfo struct {
 	// SocketID is the physical socket ID
 	SocketID int `json:"socketID"`
 
+	// ClusterID is the cluster ID, which sits between Socket and Core on some architectures (e.g. ARM)
+	ClusterID int `json:"clusterID"`
+
 	// NUMANodeID is the NUMA node ID, unique within each SocketID
 	NUMANodeID int `json:"numaNodeID"`
 
@@ -148,8 +151,9 @@ func (s *SystemCPUInfo) GetCPUTopology() (*CPUTopology, error) {
 	sockets := sets.NewInt()
 	numaNodes := sets.NewInt()
 	type coreIdent struct {
-		SocketID int
-		coreID   int
+		SocketID  int
+		ClusterID int
+		CoreID    int
 	}
 	cores := sets.New[coreIdent]()
 	uncoreCaches := sets.NewInt()
@@ -159,9 +163,9 @@ func (s *SystemCPUInfo) GetCPUTopology() (*CPUTopology, error) {
 		cpuDetails[info.CpuID] = info
 		sockets.Insert(info.SocketID)
 		numaNodes.Insert(info.NUMANodeID)
-		// A core is unique by socket and core id
-		coreKey := coreIdent{SocketID: info.SocketID, coreID: info.CoreID}
-		cores[coreKey] = struct{}{}
+		// A core is unique by socket, cluster, and core id
+		coreKey := coreIdent{SocketID: info.SocketID, ClusterID: info.ClusterID, CoreID: info.CoreID}
+		cores.Insert(coreKey)
 		if info.UncoreCacheID != -1 {
 			uncoreCaches.Insert(info.UncoreCacheID)
 		}
@@ -170,12 +174,12 @@ func (s *SystemCPUInfo) GetCPUTopology() (*CPUTopology, error) {
 	smtEnabled, err := s.IsSMTEnabled()
 	if err != nil {
 		log.Printf("Warning: could not determine SMT status from sysfs: %v. Falling back to CPU/Core count.", err)
-		smtEnabled = len(cpuInfos) > len(cores)
+		smtEnabled = len(cpuInfos) > cores.Len()
 	}
 
 	return &CPUTopology{
 		NumCPUs:        len(cpuInfos),
-		NumCores:       len(cores),
+		NumCores:       cores.Len(),
 		NumSockets:     sockets.Len(),
 		NumNUMANodes:   numaNodes.Len(),
 		NumUncoreCache: uncoreCaches.Len(),
@@ -203,12 +207,19 @@ func (s *SystemCPUInfo) IsSMTEnabled() (bool, error) {
 
 // GetCPUInfos returns a slice of CPUInfo structs, one for each logical CPU.
 func (s *SystemCPUInfo) GetCPUInfos() ([]CPUInfo, error) {
-	filename := hostProc("cpuinfo")
-	lines, err := ReadLines(filename)
+	// Discover online CPUs from sysfs
+	onlineFilename := hostSys("devices/system/cpu/online")
+	onlineContent, err := ReadFile(onlineFilename)
 	if err != nil {
-		return []CPUInfo{}, err
+		return []CPUInfo{}, fmt.Errorf("could not read online CPUs from %s: %w", onlineFilename, err)
 	}
 
+	onlineCPUs, err := cpuset.Parse(strings.TrimSpace(onlineContent))
+	if err != nil {
+		return []CPUInfo{}, fmt.Errorf("could not parse online CPUs '%s': %w", onlineContent, err)
+	}
+
+	// Intel-specific hybrid detection (P-cores vs E-cores)
 	isHybrid := false
 	var eCoreCpus cpuset.CPUSet
 	eCoreFilename := hostSys("devices/cpu_atom/cpus")
@@ -223,105 +234,44 @@ func (s *SystemCPUInfo) GetCPUInfos() ([]CPUInfo, error) {
 		}
 	}
 
-	cpuInfos := []CPUInfo{}
-	var cpuInfoLines []string
-	for _, line := range lines {
-		// `/proc/cpuinfo` uses empty lines to denote a new CPU block of data.
-		if strings.TrimSpace(line) == "" {
-			// Parse and reset CPU lines.
-			cpuInfo := parseCPUInfo(isHybrid, eCoreCpus, cpuInfoLines...)
-			if cpuInfo != nil {
-				cpuInfos = append(cpuInfos, *cpuInfo)
+	cpuInfos := make([]CPUInfo, 0, onlineCPUs.Size())
+	for _, cpuID := range onlineCPUs.List() {
+		cpuInfo := CPUInfo{
+			CpuID:                cpuID,
+			SocketID:             -1,
+			CoreID:               -1,
+			ClusterID:            -1,
+			NUMANodeID:           -1,
+			NumaNodeAffinityMask: "",
+			UncoreCacheID:        -1,
+			SiblingCpuID:         -1,
+			CoreType:             CoreTypeUndefined,
+		}
+
+		if isHybrid {
+			if eCoreCpus.Contains(cpuID) {
+				cpuInfo.CoreType = CoreTypeEfficiency
+			} else {
+				cpuInfo.CoreType = CoreTypePerformance
 			}
-			cpuInfoLines = []string{}
 		} else {
-			// Gather CPU info lines for later processing.
-			cpuInfoLines = append(cpuInfoLines, line)
+			cpuInfo.CoreType = CoreTypeStandard
 		}
-	}
-	// Process the last block of cpu info.
-	if len(cpuInfoLines) > 0 {
-		cpuInfo := parseCPUInfo(isHybrid, eCoreCpus, cpuInfoLines...)
-		if cpuInfo != nil {
-			cpuInfos = append(cpuInfos, *cpuInfo)
+
+		if err := populateTopologyInfo(&cpuInfo); err != nil {
+			log.Printf("Warning: skipping CPU %d due to incomplete topology: %v", cpuID, err)
+			continue
 		}
+
+		cpuInfos = append(cpuInfos, cpuInfo)
 	}
 
-	if err := populateTopologyInfo(cpuInfos); err != nil {
-		return nil, fmt.Errorf("failed to populate topology info: %w", err)
-	}
 	if err := populateL3CacheIDs(cpuInfos); err != nil {
 		return nil, fmt.Errorf("failed to populate L3 cache IDs: %w", err)
 	}
 	populateCpuSiblings(cpuInfos)
+
 	return cpuInfos, nil
-}
-
-func parseCPUInfo(isHybrid bool, eCoreCpus cpuset.CPUSet, lines ...string) *CPUInfo {
-	cpuInfo := &CPUInfo{
-		CpuID:                -1,
-		SocketID:             -1,
-		CoreID:               -1,
-		NUMANodeID:           -1,
-		NumaNodeAffinityMask: "",
-		UncoreCacheID:        -1,
-		SiblingCpuID:         -1,
-		CoreType:             CoreTypeUndefined,
-	}
-
-	if len(lines) == 0 {
-		return nil
-	}
-
-	for _, line := range lines {
-		// Within each CPU block of data, each line uses ':' to separate the
-		// key-value pair (with whitespace padding).
-		fields := strings.Split(line, ":")
-		if len(fields) < 2 {
-			continue
-		}
-		key := strings.TrimSpace(fields[0])
-		value := strings.TrimSpace(fields[1])
-
-		var val int
-		var err error
-		switch key {
-		case "processor":
-			if val, err = strconv.Atoi(value); err != nil {
-				log.Printf("Warning: failed to parse processor ID %q: %v", value, err)
-			} else {
-				cpuInfo.CpuID = val
-			}
-		case "physical id":
-			if val, err = strconv.Atoi(value); err != nil {
-				log.Printf("Warning: failed to parse physical ID %q: %v", value, err)
-			} else {
-				cpuInfo.SocketID = val
-			}
-		case "core id":
-			if val, err = strconv.Atoi(value); err != nil {
-				log.Printf("Warning: failed to parse core ID %q: %v", value, err)
-			} else {
-				cpuInfo.CoreID = val
-			}
-		}
-	}
-
-	if isHybrid {
-		if eCoreCpus.Contains(cpuInfo.CpuID) {
-			cpuInfo.CoreType = CoreTypeEfficiency
-		} else {
-			cpuInfo.CoreType = CoreTypePerformance
-		}
-	} else {
-		cpuInfo.CoreType = CoreTypeStandard
-	}
-
-	if cpuInfo.CpuID < 0 || cpuInfo.SocketID < 0 || cpuInfo.CoreID < 0 {
-		return nil
-	}
-
-	return cpuInfo
 }
 
 func populateL3CacheIDs(cpuInfos []CPUInfo) error {
@@ -383,75 +333,102 @@ func populateL3CacheIDs(cpuInfos []CPUInfo) error {
 	return nil
 }
 
-func populateTopologyInfo(cpuInfos []CPUInfo) error {
+func populateTopologyInfo(cpuInfo *CPUInfo) error {
 	// Cache the affinity masks so we don't read the same file multiple times.
 	numaMaskCache := make(map[int]string)
 
-	for i := range cpuInfos {
-		cpuID := cpuInfos[i].CpuID
+	cpuID := cpuInfo.CpuID
 
-		// Get Socket ID from sysfs (most reliable source)
-		socketPath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d/topology/physical_package_id", cpuID))
-		socketStr, err := ReadFile(socketPath)
-		if err != nil {
-			// If sysfs fails for some reason, we keep the value from /proc/cpuinfo
-			log.Printf("Warning: could not read socket_id for cpu %d from sysfs: %v", cpuID, err)
+	// Get Socket ID from sysfs
+	socketPath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d/topology/physical_package_id", cpuID))
+	socketStr, err := ReadFile(socketPath)
+	if err != nil {
+		return fmt.Errorf("could not read socket_id for cpu %d from sysfs: %w", cpuID, err)
+	}
+	socketID, _ := strconv.Atoi(strings.TrimSpace(socketStr))
+	cpuInfo.SocketID = socketID
+
+	// Get Cluster ID from sysfs (for ARM)
+	clusterPath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d/topology/cluster_id", cpuID))
+	clusterStr, err := ReadFile(clusterPath)
+	if err == nil {
+		clusterID, _ := strconv.Atoi(strings.TrimSpace(clusterStr))
+		// On many x86 systems, the kernel reports 65535 to indicate "No Cluster".
+		// We treat this as -1 to mean unknown/not applicable.
+		if clusterID == 65535 {
+			cpuInfo.ClusterID = -1
 		} else {
-			// Overwrite with the definitive value from sysfs
-			socketID, _ := strconv.Atoi(strings.TrimSpace(socketStr))
-			cpuInfos[i].SocketID = socketID
+			cpuInfo.ClusterID = clusterID
 		}
+	} else {
+		cpuInfo.ClusterID = -1 // Default to -1 if not present
+	}
 
-		// Get NUMA Node ID from sysfs
-		nodePath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d", cpuID))
-		files, err := os.ReadDir(nodePath)
-		if err != nil {
-			return fmt.Errorf("could not read cpu dir %s: %w", nodePath, err)
-		}
+	// Get Core ID from sysfs
+	corePath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d/topology/core_id", cpuID))
+	coreStr, err := ReadFile(corePath)
+	if err != nil {
+		return fmt.Errorf("could not read core_id for cpu %d from sysfs: %w", cpuID, err)
+	}
+	coreID, _ := strconv.Atoi(strings.TrimSpace(coreStr))
+	cpuInfo.CoreID = coreID
 
-		foundNode := false
-		for _, file := range files {
-			if strings.HasPrefix(file.Name(), "node") {
-				nodeID, err := strconv.ParseInt(strings.TrimPrefix(file.Name(), "node"), 10, 64)
-				if err != nil {
-					continue // Should not happen with a well-formed sysfs
-				}
-				cpuInfos[i].NUMANodeID = int(nodeID)
-				foundNode = true
+	// Get NUMA Node ID from sysfs
+	nodePath := hostSys(fmt.Sprintf("devices/system/cpu/cpu%d", cpuID))
+	files, err := os.ReadDir(nodePath)
+	if err != nil {
+		return fmt.Errorf("could not read NUMA node for cpu %d from sysfs: %w", cpuID, err)
+	}
 
-				//  Get NUMA Affinity Mask (from cache if possible)
-				mask, ok := numaMaskCache[int(nodeID)]
-				if !ok {
-					maskPath := hostSys(fmt.Sprintf("devices/system/node/node%d/cpumap", nodeID))
-					maskLines, err := ReadLines(maskPath)
-					if err != nil {
-						return err
-					}
-					mask = formatAffinityMask(maskLines[0])
-					numaMaskCache[int(nodeID)] = mask
-				}
-				cpuInfos[i].NumaNodeAffinityMask = mask
-				break
+	foundNode := false
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "node") {
+			nodeID, err := strconv.ParseInt(strings.TrimPrefix(file.Name(), "node"), 10, 64)
+			if err != nil {
+				continue // Should not happen with a well-formed sysfs
 			}
-		}
-		if !foundNode {
-			log.Printf("Warning: could not determine NUMA node for CPU %d", cpuID)
+			cpuInfo.NUMANodeID = int(nodeID)
+			foundNode = true
+
+			//  Get NUMA Affinity Mask (from cache if possible)
+			mask, ok := numaMaskCache[int(nodeID)]
+			if !ok {
+				maskPath := hostSys(fmt.Sprintf("devices/system/node/node%d/cpumap", nodeID))
+				maskLines, err := ReadLines(maskPath)
+				if err != nil {
+					log.Printf("Warning: could not read NUMA affinity mask for node %d: %v", nodeID, err)
+					continue
+				}
+				mask = formatAffinityMask(maskLines[0])
+				numaMaskCache[int(nodeID)] = mask
+			}
+			cpuInfo.NumaNodeAffinityMask = mask
+			break
 		}
 	}
+	if !foundNode {
+		return fmt.Errorf("could not determine NUMA node for CPU %d", cpuID)
+	}
+
+	if cpuInfo.SocketID < 0 || cpuInfo.CoreID < 0 || cpuInfo.NUMANodeID < 0 {
+		return fmt.Errorf("incomplete topology information for CPU %d (socket: %d, core: %d, NUMA node: %d)", cpuID, cpuInfo.SocketID, cpuInfo.CoreID, cpuInfo.NUMANodeID)
+	}
+
 	return nil
 }
 
 func populateCpuSiblings(cpuInfos []CPUInfo) {
 	// Define a key struct to identify a unique physical core.
 	type coreLocation struct {
-		socket int
-		core   int
+		socket  int
+		cluster int
+		core    int
 	}
 
 	// Map each physical core to the list of logical CPUs (siblings) on it.
 	coreToCPU := make(map[coreLocation][]int)
 	for _, info := range cpuInfos {
-		key := coreLocation{socket: info.SocketID, core: info.CoreID}
+		key := coreLocation{socket: info.SocketID, cluster: info.ClusterID, core: info.CoreID}
 		coreToCPU[key] = append(coreToCPU[key], info.CpuID)
 	}
 

--- a/pkg/cpuinfo/cpuinfo_test.go
+++ b/pkg/cpuinfo/cpuinfo_test.go
@@ -536,6 +536,15 @@ func TestSMTDetection(t *testing.T) {
 			expectedSMT:   false,
 		},
 		{
+			name: "SMT notimplemented - ARM specific value indicating no SMT support",
+			topology: fakeCPUTopology{
+				numSockets: 1, numNumaNodesPerSocket: 1, numCoresPerNumaNode: 1, cpusPerCore: 1, coresPerL3: 1,
+			},
+			createSMTFile: true,
+			smtContent:    "notimplemented\n",
+			expectedSMT:   false,
+		},
+		{
 			name: "SMT unknown content from sysfs",
 			topology: fakeCPUTopology{
 				numSockets: 1, numNumaNodesPerSocket: 1, numCoresPerNumaNode: 1, cpusPerCore: 2, coresPerL3: 1,

--- a/pkg/cpuinfo/cpuinfo_test.go
+++ b/pkg/cpuinfo/cpuinfo_test.go
@@ -447,6 +447,18 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 			expectedErrorSubstring: "shared_cpu_list",
 		},
 		{
+			name: "missing cache id - ARM fallback behavior",
+			setup: func(t *testing.T, dir string) {
+				if err := os.Remove(filepath.Join(dir, "sys/devices/system/cpu/cpu0/cache/index3/id")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expectedErrorSubstring: "", // Should succeed with synthetic ID
+			expectedInfos: []CPUInfo{
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x1", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+			},
+		},
+		{
 			name: "x86 cluster_id 65535 fallback",
 			setup: func(t *testing.T, dir string) {
 				if err := os.WriteFile(filepath.Join(dir, "sys/devices/system/cpu/cpu0/topology/cluster_id"), []byte("65535\n"), 0600); err != nil {

--- a/pkg/cpuinfo/cpuinfo_test.go
+++ b/pkg/cpuinfo/cpuinfo_test.go
@@ -28,28 +28,6 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
-func TestParseCPUInfo(t *testing.T) {
-	lines := []string{
-		"processor\t: 0",
-		"physical id\t: 0",
-		"core id\t\t: 0",
-	}
-	eCoreCpus := cpuset.New()
-	cpuInfo := parseCPUInfo(false, eCoreCpus, lines...)
-	if cpuInfo == nil {
-		t.Fatal("parseCPUInfo returned nil")
-	}
-	if cpuInfo.CoreType != CoreTypeStandard {
-		t.Errorf("expected CoreTypeStandard, got %v", cpuInfo.CoreType)
-	}
-
-	eCoreCpusWithCpu0, _ := cpuset.Parse("0")
-	cpuInfo = parseCPUInfo(true, eCoreCpusWithCpu0, lines...)
-	if cpuInfo.CoreType != CoreTypeEfficiency {
-		t.Errorf("expected CoreTypeEfficiency, got %v", cpuInfo.CoreType)
-	}
-}
-
 func TestPopulateCpuSiblings(t *testing.T) {
 	testCases := []struct {
 		name             string
@@ -59,18 +37,18 @@ func TestPopulateCpuSiblings(t *testing.T) {
 		{
 			name: "2-way hyper-threading",
 			input: []CPUInfo{
-				{CpuID: 0, SocketID: 0, CoreID: 0, SiblingCpuID: -1},
-				{CpuID: 1, SocketID: 0, CoreID: 1, SiblingCpuID: -1},
-				{CpuID: 2, SocketID: 0, CoreID: 0, SiblingCpuID: -1},
-				{CpuID: 3, SocketID: 0, CoreID: 1, SiblingCpuID: -1},
+				{CpuID: 0, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCpuID: -1},
+				{CpuID: 1, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCpuID: -1},
+				{CpuID: 2, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCpuID: -1},
+				{CpuID: 3, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCpuID: -1},
 			},
 			expectedSiblings: map[int]int{0: 2, 1: 3, 2: 0, 3: 1},
 		},
 		{
 			name: "no hyper-threading",
 			input: []CPUInfo{
-				{CpuID: 0, SocketID: 0, CoreID: 0, SiblingCpuID: -1},
-				{CpuID: 1, SocketID: 0, CoreID: 1, SiblingCpuID: -1},
+				{CpuID: 0, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCpuID: -1},
+				{CpuID: 1, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCpuID: -1},
 			},
 			expectedSiblings: map[int]int{0: -1, 1: -1},
 		},
@@ -136,31 +114,17 @@ type fakeCPUTopology struct {
 	numCoresPerNumaNode   int
 	cpusPerCore           int
 	coresPerL3            int
+	numClustersPerSocket  int // Needed for ARM support
 	hybrid                bool
 	eCores                string
 }
 
 func createFakeCPUTopology(t *testing.T, dir string, topo fakeCPUTopology) {
+	if topo.numClustersPerSocket == 0 {
+		topo.numClustersPerSocket = 1 // Default to 1 cluster
+	}
 	coresPerSocket := topo.numNumaNodesPerSocket * topo.numCoresPerNumaNode
 	numCPUs := topo.numSockets * coresPerSocket * topo.cpusPerCore
-
-	// /proc/cpuinfo
-	procDir := filepath.Join(dir, "proc")
-	if err := os.Mkdir(procDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	var cpuinfoContent strings.Builder
-	for i := 0; i < numCPUs; i++ {
-		socketID := i / (coresPerSocket * topo.cpusPerCore)
-		coreID := i % coresPerSocket
-		cpuinfoContent.WriteString(fmt.Sprintf("processor\t: %d\n", i))
-		cpuinfoContent.WriteString(fmt.Sprintf("physical id\t: %d\n", socketID))
-		cpuinfoContent.WriteString(fmt.Sprintf("core id\t\t: %d\n", coreID))
-		cpuinfoContent.WriteString("\n")
-	}
-	if err := os.WriteFile(filepath.Join(procDir, "cpuinfo"), []byte(cpuinfoContent.String()), 0600); err != nil {
-		t.Fatal(err)
-	}
 
 	// /sys
 	sysDevicesDir := filepath.Join(dir, "sys/devices")
@@ -183,6 +147,16 @@ func createFakeCPUTopology(t *testing.T, dir string, topo fakeCPUTopology) {
 	if err := os.MkdirAll(cpuSysDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+
+	// Write online CPUs
+	onlineCPUs := fmt.Sprintf("0-%d", numCPUs-1)
+	if numCPUs == 1 {
+		onlineCPUs = "0"
+	}
+	if err := os.WriteFile(filepath.Join(cpuSysDir, "online"), []byte(onlineCPUs+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
 	nodeToCpus := make(map[int][]int)
 	for i := 0; i < numCPUs; i++ {
 		cpuDir := filepath.Join(cpuSysDir, fmt.Sprintf("cpu%d", i))
@@ -196,8 +170,18 @@ func createFakeCPUTopology(t *testing.T, dir string, topo fakeCPUTopology) {
 			t.Fatal(err)
 		}
 		socketID := i / (coresPerSocket * topo.cpusPerCore)
+		coreID := i % coresPerSocket
 		if err := os.WriteFile(filepath.Join(topologyDir, "physical_package_id"), []byte(fmt.Sprintf("%d\n", socketID)), 0600); err != nil {
 			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(topologyDir, "core_id"), []byte(fmt.Sprintf("%d\n", coreID)), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if topo.numClustersPerSocket > 1 {
+			clusterID := (i / topo.cpusPerCore) / (coresPerSocket / topo.numClustersPerSocket) % topo.numClustersPerSocket
+			if err := os.WriteFile(filepath.Join(topologyDir, "cluster_id"), []byte(fmt.Sprintf("%d\n", clusterID)), 0600); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		// node
@@ -287,10 +271,10 @@ func TestGetCPUInfos(t *testing.T) {
 				hybrid:                false,
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 2, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 3, CoreID: 1, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -304,8 +288,8 @@ func TestGetCPUInfos(t *testing.T) {
 				hybrid:                false,
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -319,14 +303,14 @@ func TestGetCPUInfos(t *testing.T) {
 				hybrid:                false,
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 2, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 3, CoreID: 1, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 4, CoreID: 0, SocketID: 1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 6, CoreType: CoreTypeStandard, UncoreCacheID: 1},
-				{CpuID: 5, CoreID: 1, SocketID: 1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 7, CoreType: CoreTypeStandard, UncoreCacheID: 1},
-				{CpuID: 6, CoreID: 0, SocketID: 1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 4, CoreType: CoreTypeStandard, UncoreCacheID: 1},
-				{CpuID: 7, CoreID: 1, SocketID: 1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 5, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 4, CoreID: 0, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 6, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 5, CoreID: 1, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 7, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 6, CoreID: 0, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 4, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 7, CoreID: 1, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 5, CoreType: CoreTypeStandard, UncoreCacheID: 1},
 			},
 		},
 		{
@@ -341,10 +325,10 @@ func TestGetCPUInfos(t *testing.T) {
 				eCores:                "2,3",
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
-				{CpuID: 2, CoreID: 2, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
-				{CpuID: 3, CoreID: 3, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 2, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 3, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -359,8 +343,26 @@ func TestGetCPUInfos(t *testing.T) {
 				eCores:                "",
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+			},
+		},
+		{
+			name: "ARM topology with clusters",
+			topology: fakeCPUTopology{
+				numSockets:            1,
+				numNumaNodesPerSocket: 1,
+				numCoresPerNumaNode:   4,
+				cpusPerCore:           1,
+				coresPerL3:            4,
+				numClustersPerSocket:  2,
+				hybrid:                false,
+			},
+			expectedInfos: []CPUInfo{
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 2, SocketID: 0, ClusterID: 1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 3, SocketID: 0, ClusterID: 1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 	}
@@ -410,10 +412,8 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			expectedErrorSubstring: "", // Should warn and continue, not error out
-			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0x1", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-			},
+			expectedErrorSubstring: "",          // Should warn and skip CPU
+			expectedInfos:          []CPUInfo{}, // CPU gets skipped
 		},
 		{
 			name: "missing cpumap",
@@ -422,7 +422,20 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			expectedErrorSubstring: "cpumap",
+			expectedErrorSubstring: "", // Should warn and continue
+			expectedInfos: []CPUInfo{
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+			},
+		},
+		{
+			name: "negative core_id",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "sys/devices/system/cpu/cpu0/topology/core_id"), []byte("-1\n"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expectedErrorSubstring: "",          // Should warn and skip CPU
+			expectedInfos:          []CPUInfo{}, // CPU gets skipped
 		},
 		{
 			name: "missing shared_cpu_list",
@@ -432,6 +445,18 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 				}
 			},
 			expectedErrorSubstring: "shared_cpu_list",
+		},
+		{
+			name: "x86 cluster_id 65535 fallback",
+			setup: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "sys/devices/system/cpu/cpu0/topology/cluster_id"), []byte("65535\n"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expectedErrorSubstring: "", // Should succeed and map 65535 to -1
+			expectedInfos: []CPUInfo{
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x1", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+			},
 		},
 	}
 
@@ -561,6 +586,58 @@ func TestSMTDetection(t *testing.T) {
 
 			if topo.SMTEnabled != tc.expectedSMT {
 				t.Errorf("expected SMTEnabled to be %v, got %v", tc.expectedSMT, topo.SMTEnabled)
+			}
+		})
+	}
+}
+
+func TestGetCPUTopology(t *testing.T) {
+	testCases := []struct {
+		name          string
+		topology      fakeCPUTopology
+		expectedCores int
+	}{
+		{
+			name: "single socket, 4 cores, 1 cluster",
+			topology: fakeCPUTopology{
+				numSockets:            1,
+				numNumaNodesPerSocket: 1,
+				numCoresPerNumaNode:   4,
+				cpusPerCore:           1,
+				coresPerL3:            4,
+				numClustersPerSocket:  1,
+			},
+			expectedCores: 4,
+		},
+		{
+			name: "single socket, 4 cores, 2 clusters",
+			topology: fakeCPUTopology{
+				numSockets:            1,
+				numNumaNodesPerSocket: 1,
+				numCoresPerNumaNode:   4,
+				cpusPerCore:           1,
+				coresPerL3:            4,
+				numClustersPerSocket:  2,
+			},
+			// Note: Even with clusters, if core_id is unique across clusters (as our helper does),
+			// it should still count correctly. But if core_id was reused, this would fail without cluster support.
+			expectedCores: 4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOST_ROOT", tmpDir)
+			createFakeCPUTopology(t, tmpDir, tc.topology)
+
+			provider := NewSystemCPUInfo()
+			topo, err := provider.GetCPUTopology()
+			if err != nil {
+				t.Fatalf("GetCPUTopology() failed: %v", err)
+			}
+			if topo.NumCores != tc.expectedCores {
+				t.Errorf("expected %d cores, got %d", tc.expectedCores, topo.NumCores)
 			}
 		})
 	}

--- a/pkg/cpuinfo/cpuinfo_test.go
+++ b/pkg/cpuinfo/cpuinfo_test.go
@@ -37,18 +37,18 @@ func TestPopulateCpuSiblings(t *testing.T) {
 		{
 			name: "2-way hyper-threading",
 			input: []CPUInfo{
-				{CpuID: 0, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCpuID: -1},
-				{CpuID: 1, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCpuID: -1},
-				{CpuID: 2, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCpuID: -1},
-				{CpuID: 3, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCpuID: -1},
+				{CpuID: 0, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCPUID: -1},
+				{CpuID: 1, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCPUID: -1},
+				{CpuID: 2, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCPUID: -1},
+				{CpuID: 3, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCPUID: -1},
 			},
 			expectedSiblings: map[int]int{0: 2, 1: 3, 2: 0, 3: 1},
 		},
 		{
 			name: "no hyper-threading",
 			input: []CPUInfo{
-				{CpuID: 0, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCpuID: -1},
-				{CpuID: 1, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCpuID: -1},
+				{CpuID: 0, SocketID: 0, ClusterID: -1, CoreID: 0, SiblingCPUID: -1},
+				{CpuID: 1, SocketID: 0, ClusterID: -1, CoreID: 1, SiblingCPUID: -1},
 			},
 			expectedSiblings: map[int]int{0: -1, 1: -1},
 		},
@@ -62,47 +62,9 @@ func TestPopulateCpuSiblings(t *testing.T) {
 				infoMap[info.CpuID] = info
 			}
 			for cpuID, expectedSiblingID := range tc.expectedSiblings {
-				if infoMap[cpuID].SiblingCpuID != expectedSiblingID {
-					t.Errorf("cpu %d: expected sibling %d, got %d", cpuID, expectedSiblingID, infoMap[cpuID].SiblingCpuID)
+				if infoMap[cpuID].SiblingCPUID != expectedSiblingID {
+					t.Errorf("cpu %d: expected sibling %d, got %d", cpuID, expectedSiblingID, infoMap[cpuID].SiblingCPUID)
 				}
-			}
-		})
-	}
-}
-
-func TestFormatAffinityMask(t *testing.T) {
-	testCases := []struct {
-		name     string
-		mask     string
-		expected string
-	}{
-		{
-			name:     "single word",
-			mask:     "0000000f",
-			expected: "0xf",
-		},
-		{
-			name:     "two words from kernel",
-			mask:     "00000001,0000000f",
-			expected: "0xf00000001",
-		},
-		{
-			name:     "four words from kernel",
-			mask:     "ffff0000,0000ffff,00ff00ff,ff00ff00",
-			expected: "0xff00ff0000ff00ff0000ffffffff0000",
-		},
-		{
-			name:     "empty mask",
-			mask:     "",
-			expected: "0x0",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := formatAffinityMask(tc.mask)
-			if result != tc.expected {
-				t.Errorf("expected %s, got %s", tc.expected, result)
 			}
 		})
 	}
@@ -228,27 +190,8 @@ func createFakeCPUTopology(t *testing.T, dir string, topo fakeCPUTopology) {
 			t.Fatal(err)
 		}
 		cpusForNode := cpuset.New(cpus...)
-		// Convert cpuset to a hex string and write to cpumap.
-		// This simulates the kernel's behavior of storing cpumaps as comma-separated hex words.
-		const wordSize = 32
-		words := []string{}
-		for i := 0; i < cpusForNode.Size(); i += wordSize {
-			wordCpus := []int{}
-			for j := i; j < i+wordSize; j++ {
-				if cpusForNode.Contains(j) {
-					wordCpus = append(wordCpus, j%wordSize)
-				}
-			}
-			wordSet := cpuset.New(wordCpus...)
-			mask := 0
-			for _, cpu := range wordSet.List() {
-				// The value of cpu is always < 32, so this conversion is safe.
-				mask |= (1 << uint(cpu)) //nolint:gosec
-			}
-			words = append(words, fmt.Sprintf("%08x", mask))
-		}
 
-		if err := os.WriteFile(filepath.Join(nodeDir, "cpumap"), []byte(strings.Join(words, ",")+"\n"), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(nodeDir, "cpulist"), []byte(cpusForNode.String()+"\n"), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -271,10 +214,10 @@ func TestGetCPUInfos(t *testing.T) {
 				hybrid:                false,
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 2, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 3, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -288,8 +231,8 @@ func TestGetCPUInfos(t *testing.T) {
 				hybrid:                false,
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -303,14 +246,14 @@ func TestGetCPUInfos(t *testing.T) {
 				hybrid:                false,
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 2, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 3, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 4, CoreID: 0, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 6, CoreType: CoreTypeStandard, UncoreCacheID: 1},
-				{CpuID: 5, CoreID: 1, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 7, CoreType: CoreTypeStandard, UncoreCacheID: 1},
-				{CpuID: 6, CoreID: 0, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 4, CoreType: CoreTypeStandard, UncoreCacheID: 1},
-				{CpuID: 7, CoreID: 1, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeAffinityMask: "0xf0", SiblingCpuID: 5, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 2, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 3, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 0, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: 1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 4, CoreID: 0, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeCPUSet: cpuset.New(4, 5, 6, 7), SiblingCPUID: 6, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 5, CoreID: 1, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeCPUSet: cpuset.New(4, 5, 6, 7), SiblingCPUID: 7, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 6, CoreID: 0, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeCPUSet: cpuset.New(4, 5, 6, 7), SiblingCPUID: 4, CoreType: CoreTypeStandard, UncoreCacheID: 1},
+				{CpuID: 7, CoreID: 1, SocketID: 1, ClusterID: -1, NUMANodeID: 1, NumaNodeCPUSet: cpuset.New(4, 5, 6, 7), SiblingCPUID: 5, CoreType: CoreTypeStandard, UncoreCacheID: 1},
 			},
 		},
 		{
@@ -325,10 +268,10 @@ func TestGetCPUInfos(t *testing.T) {
 				eCores:                "2,3",
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
-				{CpuID: 2, CoreID: 2, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
-				{CpuID: 3, CoreID: 3, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 2, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 3, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypeEfficiency, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -343,8 +286,8 @@ func TestGetCPUInfos(t *testing.T) {
 				eCores:                "",
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x3", SiblingCpuID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1), SiblingCPUID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1), SiblingCPUID: -1, CoreType: CoreTypePerformance, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -359,10 +302,10 @@ func TestGetCPUInfos(t *testing.T) {
 				hybrid:                false,
 			},
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: 0, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 2, CoreID: 2, SocketID: 0, ClusterID: 1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
-				{CpuID: 3, CoreID: 3, SocketID: 0, ClusterID: 1, NUMANodeID: 0, NumaNodeAffinityMask: "0xf", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: 0, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 1, CoreID: 1, SocketID: 0, ClusterID: 0, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 2, CoreID: 2, SocketID: 0, ClusterID: 1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 3, CoreID: 3, SocketID: 0, ClusterID: 1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0, 1, 2, 3), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 	}
@@ -416,15 +359,15 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 			expectedInfos:          []CPUInfo{}, // CPU gets skipped
 		},
 		{
-			name: "missing cpumap",
+			name: "missing cpulist",
 			setup: func(t *testing.T, dir string) {
-				if err := os.Remove(filepath.Join(dir, "sys/devices/system/node/node0/cpumap")); err != nil {
+				if err := os.Remove(filepath.Join(dir, "sys/devices/system/node/node0/cpulist")); err != nil {
 					t.Fatal(err)
 				}
 			},
 			expectedErrorSubstring: "", // Should warn and continue
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -456,7 +399,7 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 			},
 			expectedErrorSubstring: "", // Should succeed with synthetic ID
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x1", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 		{
@@ -468,7 +411,7 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 			},
 			expectedErrorSubstring: "", // Should succeed and map 65535 to -1
 			expectedInfos: []CPUInfo{
-				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeAffinityMask: "0x1", SiblingCpuID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
+				{CpuID: 0, CoreID: 0, SocketID: 0, ClusterID: -1, NUMANodeID: 0, NumaNodeCPUSet: cpuset.New(0), SiblingCPUID: -1, CoreType: CoreTypeStandard, UncoreCacheID: 0},
 			},
 		},
 	}

--- a/pkg/cpuinfo/cpuinfo_test.go
+++ b/pkg/cpuinfo/cpuinfo_test.go
@@ -444,7 +444,8 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			expectedErrorSubstring: "shared_cpu_list",
+			expectedErrorSubstring: "",          // Should warn and skip CPU
+			expectedInfos:          []CPUInfo{}, // CPU gets skipped
 		},
 		{
 			name: "missing cache id - ARM fallback behavior",

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -169,13 +169,13 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 		if processedCpus[cpu.CpuID] {
 			continue
 		}
-		if cpu.SiblingCpuID == -1 || reservedCPUs[cpu.SiblingCpuID] {
+		if cpu.SiblingCPUID == -1 || reservedCPUs[cpu.SiblingCPUID] {
 			coreGroups = append(coreGroups, []cpuinfo.CPUInfo{cpu})
 			processedCpus[cpu.CpuID] = true
 		} else {
-			coreGroups = append(coreGroups, []cpuinfo.CPUInfo{cpu, cpuInfoMap[cpu.SiblingCpuID]})
+			coreGroups = append(coreGroups, []cpuinfo.CPUInfo{cpu, cpuInfoMap[cpu.SiblingCPUID]})
 			processedCpus[cpu.CpuID] = true
-			processedCpus[cpu.SiblingCpuID] = true
+			processedCpus[cpu.SiblingCPUID] = true
 		}
 	}
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -86,41 +86,41 @@ func (m *mockCdiMgr) RemoveDevice(deviceName string) error {
 var (
 	// Sibling CPUs are non-consecutive: (0,2), (1,3)
 	mockCPUInfos_SingleSocket_4CPUS_HT = []cpuinfo.CPUInfo{
-		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 2},
-		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 3},
-		{CpuID: 2, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 0},
-		{CpuID: 3, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 1},
+		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 2},
+		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 3},
+		{CpuID: 2, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 0},
+		{CpuID: 3, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 1},
 	}
 	mockCPUInfos_SingleSocket_4CPUs_HT_Off = []cpuinfo.CPUInfo{
-		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: -1},
-		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: -1},
-		{CpuID: 2, CoreID: 2, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: -1},
-		{CpuID: 3, CoreID: 3, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: -1},
+		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: -1},
+		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: -1},
+		{CpuID: 2, CoreID: 2, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: -1},
+		{CpuID: 3, CoreID: 3, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: -1},
 	}
 	// P-core sibling is non-consecutive: (0,2)
 	mockCPUInfos_SingleSocket_Hybrid_HT = []cpuinfo.CPUInfo{
-		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 2},
-		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypeEfficiency, SiblingCpuID: 3},
-		{CpuID: 2, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 0},
-		{CpuID: 3, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypeEfficiency, SiblingCpuID: 1},
+		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 2},
+		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypeEfficiency, SiblingCPUID: 3},
+		{CpuID: 2, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 0},
+		{CpuID: 3, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypeEfficiency, SiblingCPUID: 1},
 	}
 	// 2 sockets, 2 cores/socket, HT on. Total 8 logical CPUs.
 	mockCPUInfos_DualSocket_4CPUsPerSocket_HT = []cpuinfo.CPUInfo{
-		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 4},
-		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 5},
-		{CpuID: 2, CoreID: 2, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 6},
-		{CpuID: 3, CoreID: 3, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 7},
-		{CpuID: 4, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 0},
-		{CpuID: 5, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 1},
-		{CpuID: 6, CoreID: 2, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 2},
-		{CpuID: 7, CoreID: 3, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: 3},
+		{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 4},
+		{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 5},
+		{CpuID: 2, CoreID: 2, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 6},
+		{CpuID: 3, CoreID: 3, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 7},
+		{CpuID: 4, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 0},
+		{CpuID: 5, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 1},
+		{CpuID: 6, CoreID: 2, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 2},
+		{CpuID: 7, CoreID: 3, SocketID: 1, NUMANodeID: 1, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: 3},
 	}
 	mockCPUInfos_DualSocket_EqualsResourceSliceLimit = func() []cpuinfo.CPUInfo {
 		var infos []cpuinfo.CPUInfo
 		cpusPerNumaNode := maxDevicesPerResourceSlice / 2
 		for i := 0; i < maxDevicesPerResourceSlice; i++ {
 			numaNodeID := i / cpusPerNumaNode
-			infos = append(infos, cpuinfo.CPUInfo{CpuID: i, CoreID: i, SocketID: numaNodeID, NUMANodeID: numaNodeID, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: -1})
+			infos = append(infos, cpuinfo.CPUInfo{CpuID: i, CoreID: i, SocketID: numaNodeID, NUMANodeID: numaNodeID, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: -1})
 		}
 		return infos
 	}()
@@ -130,7 +130,7 @@ var (
 		cpusPerNumaNode := numCPUS / 2
 		for i := 0; i < numCPUS; i++ {
 			numaNodeID := i / cpusPerNumaNode
-			infos = append(infos, cpuinfo.CPUInfo{CpuID: i, CoreID: i, SocketID: numaNodeID, NUMANodeID: numaNodeID, CoreType: cpuinfo.CoreTypePerformance, SiblingCpuID: -1})
+			infos = append(infos, cpuinfo.CPUInfo{CpuID: i, CoreID: i, SocketID: numaNodeID, NUMANodeID: numaNodeID, CoreType: cpuinfo.CoreTypePerformance, SiblingCPUID: -1})
 		}
 		return infos
 	}()
@@ -146,7 +146,7 @@ var (
 					SocketID:     socketID,
 					NUMANodeID:   socketID,
 					CoreType:     cpuinfo.CoreTypePerformance,
-					SiblingCpuID: baseCpuID + coreID*2 + 1,
+					SiblingCPUID: baseCpuID + coreID*2 + 1,
 				})
 
 				// Create the second logical CPU (thread 1) on the same core
@@ -156,7 +156,7 @@ var (
 					SocketID:     socketID,
 					NUMANodeID:   socketID,
 					CoreType:     cpuinfo.CoreTypePerformance,
-					SiblingCpuID: baseCpuID + coreID*2,
+					SiblingCPUID: baseCpuID + coreID*2,
 				})
 			}
 		}
@@ -381,18 +381,18 @@ func TestPublishResources(t *testing.T) {
 				cpuIDToDeviceName[cpuID] = devName
 			}
 			for _, info := range tc.cpuInfos {
-				if info.SiblingCpuID == -1 || info.CpuID > info.SiblingCpuID {
+				if info.SiblingCPUID == -1 || info.CpuID > info.SiblingCPUID {
 					continue
 				}
 
-				if tc.reservedCPUs.Contains(info.CpuID) || tc.reservedCPUs.Contains(info.SiblingCpuID) {
+				if tc.reservedCPUs.Contains(info.CpuID) || tc.reservedCPUs.Contains(info.SiblingCPUID) {
 					continue
 				}
 
 				deviceName1, ok := cpuIDToDeviceName[info.CpuID]
 				require.True(t, ok, "device for cpuID %d not found in slices", info.CpuID)
-				deviceName2, ok := cpuIDToDeviceName[info.SiblingCpuID]
-				require.True(t, ok, "device for sibling cpuID %d not found in slices", info.SiblingCpuID)
+				deviceName2, ok := cpuIDToDeviceName[info.SiblingCPUID]
+				require.True(t, ok, "device for sibling cpuID %d not found in slices", info.SiblingCPUID)
 
 				var devNum1, devNum2 int
 				_, err := fmt.Sscanf(deviceName1, "cpudev%d", &devNum1)
@@ -400,7 +400,7 @@ func TestPublishResources(t *testing.T) {
 				_, err = fmt.Sscanf(deviceName2, "cpudev%d", &devNum2)
 				require.NoError(t, err)
 
-				require.Equal(t, devNum1+1, devNum2, "hyperthread device names are not successive for core %d (cpus %d, %d)", info.CoreID, info.CpuID, info.SiblingCpuID)
+				require.Equal(t, devNum1+1, devNum2, "hyperthread device names are not successive for core %d (cpus %d, %d)", info.CoreID, info.CpuID, info.SiblingCPUID)
 			}
 		})
 	}


### PR DESCRIPTION
* Refactor the CPU discovery mechanism from using ` /proc/cpuinfo` to sysfs based approach (`/sys/devices/system/cpu`)
* Implemented a fallback for L3 cache discovery when cache id file is not present
* Updated SMT detection to correctly handle `notimplemented` status