### PR TITLE
add CPU request validation in NRI CreateContainer hook

### DIFF
--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -77,8 +77,8 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	return nil, nil
 }
 
-func parseDRAEnvToClaimAllocations(envs []string) (map[types.UID]cpuset.CPUSet, error) {
-	allocations := make(map[types.UID]cpuset.CPUSet)
+func parseDRAEnvToClaimAllocations(envs []string) (ClaimAllocations, error) {
+	allocations := make(ClaimAllocations)
 	for _, env := range envs {
 		if !strings.HasPrefix(env, cdiEnvVarPrefix) {
 			continue
@@ -150,6 +150,12 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		klog.Infof("No guaranteed CPUs found in DRA env for pod %s/%s container %s. Using shared CPUs %s", pod.Namespace, pod.Name, ctr.Name, sharedCPUs.String())
 		adjust.SetLinuxCPUSetCPUs(sharedCPUs.String())
 	} else {
+		if err := claimAllocations.Validate(pod, ctr); err != nil {
+			klog.Errorf("CPU request validation failed for pod %s/%s container %s: %v",
+				pod.Namespace, pod.Name, ctr.Name, err)
+			return nil, nil, fmt.Errorf("CPU request validation failed: %w", err)
+		}
+
 		guaranteedCPUs := cpuset.New()
 		claimUIDs := []types.UID{}
 		for uid, cpus := range claimAllocations {

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -34,13 +34,13 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		envs                  []string
-		expectedAllocations   map[types.UID]cpuset.CPUSet
+		expectedAllocations   ClaimAllocations
 		expectedErrorContains string
 	}{
 		{
 			name: "single valid env",
 			envs: []string{fmt.Sprintf("%s_claim-uid-1=%s", cdiEnvVarPrefix, "0-1")},
-			expectedAllocations: map[types.UID]cpuset.CPUSet{
+			expectedAllocations: ClaimAllocations{
 				"claim-uid-1": cpuset.New(0, 1),
 			},
 		},
@@ -50,7 +50,7 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 				fmt.Sprintf("%s_claim-uid-1=%s", cdiEnvVarPrefix, "0,1"),
 				fmt.Sprintf("%s_claim-uid-2=%s", cdiEnvVarPrefix, "2,3"),
 			},
-			expectedAllocations: map[types.UID]cpuset.CPUSet{
+			expectedAllocations: ClaimAllocations{
 				"claim-uid-1": cpuset.New(0, 1),
 				"claim-uid-2": cpuset.New(2, 3),
 			},
@@ -58,7 +58,7 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 		{
 			name:                "no relevant envs",
 			envs:                []string{"OTHER_ENV=value"},
-			expectedAllocations: map[types.UID]cpuset.CPUSet{},
+			expectedAllocations: ClaimAllocations{},
 		},
 		{
 			name:                  "malformed env - no equals",
@@ -73,7 +73,7 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 		{
 			name:                "empty env",
 			envs:                []string{},
-			expectedAllocations: map[types.UID]cpuset.CPUSet{},
+			expectedAllocations: ClaimAllocations{},
 		},
 	}
 

--- a/pkg/driver/validation.go
+++ b/pkg/driver/validation.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"fmt"
+
+	"github.com/containerd/nri/pkg/api"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/cpuset"
+)
+
+const (
+	// minCPUShares is the Kubernetes minimum CPU shares for best-effort containers.
+	// Kubernetes sets this value for containers without CPU requests.
+	minCPUShares = uint64(2)
+
+	// cpuRequestTolerance allows for minor floating-point precision differences
+	// when comparing CPU requests (in cores) to claim allocations (in integer CPUs).
+	// Set to 0.01 to allow ~10ms difference per CPU core.
+	cpuRequestTolerance = 0.01
+)
+
+// ClaimAllocations represents CPU allocations from DRA claims.
+type ClaimAllocations map[types.UID]cpuset.CPUSet
+
+// TotalCPUs returns the total number of CPUs across all claims.
+func (ca ClaimAllocations) TotalCPUs() int {
+	total := 0
+	for _, cpus := range ca {
+		total += cpus.Size()
+	}
+	return total
+}
+
+// Validate checks that container CPU requests match the claim allocations.
+//
+// Validation behavior:
+//   - When container CPU shares > minCPUShares (2): validates that the request matches claim allocation
+//   - When container CPU shares <= minCPUShares or not set: validation passes (allows best-effort containers
+//     and Pod Level Resources scenarios where container-level requests are not specified)
+//
+// This lightweight validation serves as a final defense against common misconfigurations.
+func (ca ClaimAllocations) Validate(pod *api.PodSandbox, ctr *api.Container) error {
+	totalClaimCPUs := ca.TotalCPUs()
+
+	if ctr.Linux != nil && ctr.Linux.Resources != nil && ctr.Linux.Resources.Cpu != nil {
+		if ctr.Linux.Resources.Cpu.Shares != nil && ctr.Linux.Resources.Cpu.Shares.Value > minCPUShares {
+			containerCPUShares := ctr.Linux.Resources.Cpu.Shares.Value
+			containerCPURequest := float64(containerCPUShares) / 1024.0
+
+			diff := containerCPURequest - float64(totalClaimCPUs)
+			if diff < -cpuRequestTolerance || diff > cpuRequestTolerance {
+				return fmt.Errorf(
+					"container %s CPU request (%.2f cores, %d shares) does not match claim allocation (%d CPUs): "+
+						"when using DRA CPU claims, container CPU requests must exactly equal the claim size",
+					ctr.Name, containerCPURequest, containerCPUShares, totalClaimCPUs,
+				)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/driver/validation_test.go
+++ b/pkg/driver/validation_test.go
@@ -1,0 +1,442 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/containerd/nri/pkg/api"
+	"k8s.io/utils/cpuset"
+)
+
+func TestClaimAllocations_Validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *api.PodSandbox
+		container     *api.Container
+		claims        ClaimAllocations
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "matching container request - 10 CPUs",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 10240}, // 10 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), // 10 CPUs
+			},
+			expectError: false,
+		},
+		{
+			name: "matching container request - 4 CPUs",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 4096}, // 4 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3), // 4 CPUs
+			},
+			expectError: false,
+		},
+		{
+			name: "mismatched container request - request too low",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 5120}, // 5 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), // 10 CPUs
+			},
+			expectError:   true,
+			errorContains: "does not match claim allocation",
+		},
+		{
+			name: "mismatched container request - request too high",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 20480}, // 20 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), // 10 CPUs
+			},
+			expectError:   true,
+			errorContains: "does not match claim allocation",
+		},
+		{
+			name: "no container CPU request specified - should pass",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), // 10 CPUs
+			},
+			expectError: false,
+		},
+		{
+			name: "container with zero CPU shares - should pass",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 0},
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), // 10 CPUs
+			},
+			expectError: false,
+		},
+		{
+			name: "best-effort container with minimum CPU shares - should pass",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 2}, // Kubernetes minimum for best-effort
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0), // 1 CPU
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple claims - matching total",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 10240}, // 10 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3),       // 4 CPUs
+				"claim-2": cpuset.New(4, 5, 6, 7, 8, 9), // 6 CPUs
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple claims - mismatched total",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 8192}, // 8 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3),       // 4 CPUs
+				"claim-2": cpuset.New(4, 5, 6, 7, 8, 9), // 6 CPUs (total = 10)
+			},
+			expectError:   true,
+			errorContains: "does not match claim allocation",
+		},
+		{
+			name: "container without Linux resources - should pass",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				// No Linux field
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), // 10 CPUs
+			},
+			expectError: false,
+		},
+		{
+			name: "single CPU claim - matching",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 1024}, // 1 CPU * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0), // 1 CPU
+			},
+			expectError: false,
+		},
+		{
+			name: "edge case - off by one CPU (request 3, claim 4)",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 3072}, // 3 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3), // 4 CPUs
+			},
+			expectError:   true,
+			errorContains: "does not match claim allocation",
+		},
+		{
+			name: "edge case - within tolerance (1.009 CPUs vs 1 CPU)",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 1033}, // ~1.009 CPUs
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0), // 1 CPU
+			},
+			expectError: false,
+		},
+		{
+			name: "edge case - just outside tolerance (1.011 CPUs vs 1 CPU)",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 1035}, // ~1.011 CPUs
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0), // 1 CPU
+			},
+			expectError:   true,
+			errorContains: "does not match claim allocation",
+		},
+		{
+			name: "edge case - minimum shares + 1 (3 shares)",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 3}, // Just above minimum
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0), // 1 CPU
+			},
+			expectError:   true,
+			errorContains: "does not match claim allocation",
+		},
+		{
+			name: "edge case - large CPU count (100 CPUs)",
+			pod: &api.PodSandbox{
+				Name:      "test-pod",
+				Namespace: "default",
+			},
+			container: &api.Container{
+				Name: "test-container",
+				Linux: &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 102400}, // 100 CPUs * 1024
+						},
+					},
+				},
+			},
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+					20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+					40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+					60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+					80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99), // 100 CPUs
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.claims.Validate(tc.pod, tc.container)
+
+			if tc.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tc.expectError && err != nil {
+				if !strings.Contains(err.Error(), tc.errorContains) {
+					t.Errorf("error %q does not contain expected substring %q", err.Error(), tc.errorContains)
+				}
+			}
+		})
+	}
+}
+
+func TestClaimAllocations_TotalCPUs(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   ClaimAllocations
+		expected int
+	}{
+		{
+			name: "single claim with 4 CPUs",
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3),
+			},
+			expected: 4,
+		},
+		{
+			name: "multiple claims totaling 10 CPUs",
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0, 1, 2, 3),
+				"claim-2": cpuset.New(4, 5, 6, 7, 8, 9),
+			},
+			expected: 10,
+		},
+		{
+			name:     "empty claims",
+			claims:   ClaimAllocations{},
+			expected: 0,
+		},
+		{
+			name: "single CPU",
+			claims: ClaimAllocations{
+				"claim-1": cpuset.New(0),
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			total := tc.claims.TotalCPUs()
+			if total != tc.expected {
+				t.Errorf("expected %d CPUs, got %d", tc.expected, total)
+			}
+		})
+	}
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -66,7 +66,7 @@ func BeFailedToCreate(fxt *fixture.Fixture) types.GomegaMatcher {
 			return false, nil
 		}
 		if cntSt.State.Waiting.Reason != reasonCreateContainerError {
-			lh.Info("container terminated for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Terminated.Reason)
+			lh.Info("container waiting for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Waiting.Reason)
 			return false, nil
 		}
 		lh.Info("container creation error", "containerName", cntSt.Name)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
+	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = ginkgo.Describe("CPU request validation", ginkgo.Serial, ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		rootFxt           *fixture.Fixture
+		dracpuTesterImage string
+		cpuDeviceMode     string
+	)
+
+	ginkgo.BeforeAll(func(ctx context.Context) {
+		dracpuTesterImage = os.Getenv("DRACPU_E2E_TEST_IMAGE")
+		gomega.Expect(dracpuTesterImage).ToNot(gomega.BeEmpty(), "missing environment variable DRACPU_E2E_TEST_IMAGE")
+		ginkgo.GinkgoLogr.Info("test image", "pullSpec", dracpuTesterImage)
+
+		var err error
+		rootFxt, err = fixture.ForGinkgo()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture: %v", err)
+		infraFxt := rootFxt.WithPrefix("infra")
+		gomega.Expect(infraFxt.Setup(ctx)).To(gomega.Succeed())
+		ginkgo.DeferCleanup(infraFxt.Teardown)
+
+		ginkgo.By("checking the daemonset configuration")
+		daemonSet, err := rootFxt.K8SClientset.AppsV1().DaemonSets("kube-system").Get(ctx, "dracpu", metav1.GetOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
+		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
+		for _, arg := range daemonSet.Spec.Template.Spec.Containers[0].Args {
+			if val, ok := parseCPUDeviceModeArg(arg); ok {
+				cpuDeviceMode = val
+			}
+		}
+		ginkgo.GinkgoLogr.Info("cpu device mode", "value", cpuDeviceMode)
+	})
+
+	ginkgo.Context("with matching CPU requests", func() {
+		ginkgo.It("should successfully create container", func(ctx context.Context) {
+			fxt := rootFxt.WithPrefix("matching-request")
+			gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
+			ginkgo.DeferCleanup(fxt.Teardown)
+
+			claimCPUs := int64(1)
+			containerCPUs := resource.MustParse("1")
+
+			ginkgo.By("creating a ResourceClaim")
+			claim := makeResourceClaim(fxt.Namespace.Name, "test-claim", claimCPUs, cpuDeviceMode)
+			claim, err := fxt.K8SClientset.ResourceV1().ResourceClaims(fxt.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("creating a Pod with matching CPU request")
+			pod := makePodWithClaim(fxt.Namespace.Name, "test-pod", claim.Name, &containerCPUs, nil)
+			pod, err = fxt.K8SClientset.CoreV1().Pods(fxt.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("waiting for pod to be running")
+			err = e2epod.WaitToBeRunning(ctx, fxt.K8SClientset, pod.Namespace, pod.Name)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "pod should be running")
+		})
+	})
+
+	ginkgo.Context("with mismatched CPU requests", func() {
+		ginkgo.It("should fail to create container when request is too low", func(ctx context.Context) {
+			fxt := rootFxt.WithPrefix("mismatch-low")
+			gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
+			ginkgo.DeferCleanup(fxt.Teardown)
+
+			claimCPUs := int64(2)
+			containerCPUs := resource.MustParse("1") // Mismatch: claim has 2, request is 1
+
+			ginkgo.By("creating a ResourceClaim")
+			claim := makeResourceClaim(fxt.Namespace.Name, "test-claim", claimCPUs, cpuDeviceMode)
+			claim, err := fxt.K8SClientset.ResourceV1().ResourceClaims(fxt.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("creating a Pod with mismatched CPU request")
+			pod := makePodWithClaim(fxt.Namespace.Name, "test-pod", claim.Name, &containerCPUs, nil)
+			pod, err = fxt.K8SClientset.CoreV1().Pods(fxt.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("waiting for pod to fail with CreateContainerError")
+			gomega.Eventually(ctx, func(ctx context.Context) (*v1.Pod, error) {
+				return fxt.K8SClientset.CoreV1().Pods(fxt.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			}).
+				WithTimeout(2*time.Minute).
+				WithPolling(5*time.Second).
+				Should(BeFailedToCreate(fxt), "pod should fail to create container")
+		})
+
+		ginkgo.It("should fail to create container when request is too high", func(ctx context.Context) {
+			fxt := rootFxt.WithPrefix("mismatch-high")
+			gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
+			ginkgo.DeferCleanup(fxt.Teardown)
+
+			claimCPUs := int64(1)
+			containerCPUs := resource.MustParse("2") // Mismatch: claim has 1, request is 2
+
+			ginkgo.By("creating a ResourceClaim")
+			claim := makeResourceClaim(fxt.Namespace.Name, "test-claim", claimCPUs, cpuDeviceMode)
+			claim, err := fxt.K8SClientset.ResourceV1().ResourceClaims(fxt.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("creating a Pod with mismatched CPU request")
+			pod := makePodWithClaim(fxt.Namespace.Name, "test-pod", claim.Name, &containerCPUs, nil)
+			pod, err = fxt.K8SClientset.CoreV1().Pods(fxt.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("waiting for pod to fail with CreateContainerError")
+			gomega.Eventually(ctx, func(ctx context.Context) (*v1.Pod, error) {
+				return fxt.K8SClientset.CoreV1().Pods(fxt.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			}).
+				WithTimeout(2*time.Minute).
+				WithPolling(5*time.Second).
+				Should(BeFailedToCreate(fxt), "pod should fail to create container")
+		})
+	})
+
+	ginkgo.Context("without CPU requests specified", func() {
+		ginkgo.It("should successfully create container", func(ctx context.Context) {
+			fxt := rootFxt.WithPrefix("no-request")
+			gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
+			ginkgo.DeferCleanup(fxt.Teardown)
+
+			claimCPUs := int64(1)
+
+			ginkgo.By("creating a ResourceClaim")
+			claim := makeResourceClaim(fxt.Namespace.Name, "test-claim", claimCPUs, cpuDeviceMode)
+			claim, err := fxt.K8SClientset.ResourceV1().ResourceClaims(fxt.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("creating a Pod without CPU request")
+			pod := makePodWithClaim(fxt.Namespace.Name, "test-pod", claim.Name, nil, nil)
+			pod, err = fxt.K8SClientset.CoreV1().Pods(fxt.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("waiting for pod to be running")
+			err = e2epod.WaitToBeRunning(ctx, fxt.K8SClientset, pod.Namespace, pod.Name)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "pod should be running")
+		})
+	})
+})
+
+// makeResourceClaim creates a ResourceClaim for the given number of CPUs
+func makeResourceClaim(namespace, name string, cpuCount int64, deviceMode string) *resourcev1.ResourceClaim {
+	claim := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: makeResourceClaimSpec(int(cpuCount), deviceMode == "grouped"),
+	}
+	return claim
+}
+
+// makePodWithClaim creates a Pod that references a ResourceClaim
+func makePodWithClaim(namespace, name, claimName string, cpuRequest, cpuLimit *resource.Quantity) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "registry.k8s.io/pause:3.9",
+					Resources: v1.ResourceRequirements{
+						Claims: []v1.ResourceClaim{
+							{
+								Name: "claim-ref",
+							},
+						},
+					},
+				},
+			},
+			ResourceClaims: []v1.PodResourceClaim{
+				{
+					Name:              "claim-ref",
+					ResourceClaimName: ptr.To(claimName),
+				},
+			},
+		},
+	}
+
+	// Set CPU request/limit if specified
+	if cpuRequest != nil {
+		pod.Spec.Containers[0].Resources.Requests = v1.ResourceList{
+			v1.ResourceCPU: *cpuRequest,
+		}
+	}
+	if cpuLimit != nil {
+		pod.Spec.Containers[0].Resources.Limits = v1.ResourceList{
+			v1.ResourceCPU: *cpuLimit,
+		}
+	}
+
+	return pod
+}


### PR DESCRIPTION
Validation rules:
1. If container CPU request is specified, it must exactly match claim allocation
2. Pod-level resources validation (PLR) is a placeholder for future implementation

fixs:https://github.com/kubernetes-sigs/dra-driver-cpu/issues/108 