### PR TITLE
fix: set imagePullPolicy to IfNotPresent for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ manifests: dist install-yq ## create the install manifest
 	@cd dist && cp -a ../manifests/base/*.part.yaml .
 ifeq ($(OVERRIDE_IMAGE),true)
 	@$(YQ) -i '.spec.template.spec.containers[0].image = "${IMAGE}"' dist/daemonset-dracpu.part.yaml
+	@$(YQ) -i '.spec.template.spec.containers[0].imagePullPolicy = "IfNotPresent"' dist/daemonset-dracpu.part.yaml
 	@$(YQ) -i '.spec.template.metadata.labels["build"] = "${GIT_VERSION}"' dist/daemonset-dracpu.part.yaml
 endif
 	@$(YQ) '.' \


### PR DESCRIPTION
When building manifests with a locally overridden image (OVERRIDE_IMAGE=true), set image pull policy to `IfNotPresent` to avoid unnecessary pull of an image which is already loaded to the kind, otherwise Pods can't run as the image with `v*-dirty` tag doesn't exist on the upstream registry. 


