### PR TITLE
Release exclusive CPUs in NRI StopContainer 

### DIFF
--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -178,6 +178,17 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	entries := "none"
 	if len(claimUIDs) > 0 {
+		// This early release in StopContainer is a workaround for a lifecycle mismatch between DRA and NRI.
+		// The proper place to release claim allocations is in the DRA UnprepareResourceClaims hook.
+		// However, NRI only allows pushing CPU mask updates to other containers during container lifecycle events
+		// (like StopContainer). If we wait until UnprepareResourceClaims to release the CPUs, we miss the opportunity
+		// to update the shared pool of existing containers, leaving them on a restricted pool until a new
+		// container event occurs.
+		// TODO: This workaround assumes that ResourceClaims are NOT shared across pods/containers. If claim sharing
+		// is supported in the future, this early release of CPUS will need an update.
+		for _, claimUID := range claimUIDs {
+			cp.cpuAllocationStore.RemoveResourceClaimAllocation(claimUID)
+		}
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
 		updates = cp.getSharedContainerUpdates(types.UID(ctr.GetId()))
 		cp.claimTracker.Cleanup(klog.FromContext(ctx), claimUIDs...)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -103,8 +103,13 @@ func getTesterPodCPUAllocation(cs kubernetes.Interface, ctx context.Context, pod
 	data, err := e2epod.GetLogs(cs, ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs for %s/%s/%s", pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
 
+	// Split logs by newline and find the last non-empty line
+	lines := strings.Split(strings.TrimSpace(data), "\n")
+	gomega.Expect(len(lines)).To(gomega.BeNumerically(">", 0), "logs should not be empty")
+	lastLine := lines[len(lines)-1]
+
 	testerInfo := discovery.DRACPUTester{}
-	gomega.Expect(json.Unmarshal([]byte(data), &testerInfo)).To(gomega.Succeed())
+	gomega.Expect(json.Unmarshal([]byte(lastLine), &testerInfo)).To(gomega.Succeed(), "cannot unmarshal last log line: %q", lastLine)
 
 	ret := CPUAllocation{}
 	ret.CPUAssigned, err = cpuset.Parse(testerInfo.Allocation.CPUs)
@@ -174,12 +179,8 @@ func makeTesterPodBestEffort(ns, image string) *v1.Pod {
 					Command: []string{"/dracputester"},
 					// at the moment we depend on pod logs to learn the cpu allocation.
 					// Therefore, the pod without resource claims, best-effort,
-					// will restart periodically to provide the up to date information.
-					// NOTE: restarting always ensuring there's the minimal and easiest
-					// amount of logs to process. The other option would be to periodically
-					// log the data, but then the client side will need to read and discard
-					// all but the latest update, which is wasteful. This approach is the simplest.
-					Args: []string{"-run-for", "10s"},
+					// will loop periodically to provide the up to date information.
+					// NOTE: We parse the last line of the logs to get the latest update.
 				},
 			},
 			RestartPolicy: v1.RestartPolicyAlways,

--- a/test/image/dracputester/app.go
+++ b/test/image/dracputester/app.go
@@ -18,10 +18,8 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"time"
@@ -98,44 +96,32 @@ func getAffinity() (cpuset.CPUSet, error) {
 }
 
 func main() {
-	runTimeout := 0 * time.Second
-	flag.DurationVar(&runTimeout, "run-for", runTimeout, "run for the given duration before exit after logging. Use 0 to run forever")
-	flag.Parse()
+	for {
+		cpus, err := cpuSet("/sys")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error determining allocated cpus: %v\n", err)
+			os.Exit(1)
+		}
+		cpuAff, err := getAffinity()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error determining CPU affinity: %v\n", err)
+			os.Exit(2)
+		}
+		info := discovery.DRACPUTester{
+			Buildinfo: discovery.NewBuildinfo(),
+			Allocation: discovery.DRACPUAllocation{
+				CPUs: cpus.String(),
+			},
+			Runtimeinfo: discovery.DRACPURuntimeinfo{
+				CPUAffinity: cpuAff.String(),
+			},
+		}
+		err = json.NewEncoder(os.Stdout).Encode(info)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error encoding info: %v\n", err)
+			os.Exit(2)
+		}
 
-	cpus, err := cpuSet("/sys")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error determining allocated cpus: %v\n", err)
-		os.Exit(1)
-	}
-	cpuAff, err := getAffinity()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error determining CPU affinity: %v\n", err)
-		os.Exit(2)
-	}
-	info := discovery.DRACPUTester{
-		Buildinfo: discovery.NewBuildinfo(),
-		Allocation: discovery.DRACPUAllocation{
-			CPUs: cpus.String(),
-		},
-		Runtimeinfo: discovery.DRACPURuntimeinfo{
-			CPUAffinity: cpuAff.String(),
-		},
-	}
-	err = json.NewEncoder(os.Stdout).Encode(info)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error encoding info: %v\n", err)
-		os.Exit(2)
-	}
-
-	if runTimeout > 0 {
-		time.Sleep(runTimeout)
-	} else {
-		signalCh := make(chan os.Signal, 2)
-		defer func() {
-			close(signalCh)
-		}()
-		signal.Notify(signalCh, os.Interrupt, unix.SIGINT)
-		<-signalCh
-		fmt.Fprintf(os.Stderr, "exiting: received signal\n")
+		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
Previously, the driver relied on the DRA `UnprepareResourceClaims` hook to release CPUs back to the shared pool. However, NRI only allows pushing CPU mask updates to other containers during container lifecycle events (like `StopContainer`). If we wait until `UnprepareResourceClaims` to release the CPUs, we miss the opportunity to update the shared pool of existing containers via NRI, leaving them on a restricted pool until a new container event occurs. This PR moves the release of exclusive CPUs into the NRI `StopContainer` hook.

The PR also improves E2E tests by removing dependency on container restarts. Instead, we record the CPU Mask every 5 seconds and read the last log line to get the last mask. Container restarts were resulting in presubmit test timeout as it results in kubelet CrashLoopBackOff.