### PR TITLE
manifests: use stable image instead of staging

### DIFF
--- a/manifests/base/daemonset-dracpu.part.yaml
+++ b/manifests/base/daemonset-dracpu.part.yaml
@@ -82,7 +82,7 @@ spec:
         - /dracpu
         - --v=4
         - --cpu-device-mode=grouped
-        image: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu:latest
+        image: registry.k8s.io/dra-driver-cpu/dra-driver-cpu:v0.1.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Switch the image from the staging:latest tag which tracks HEAD and is not stable to the latest tagged release `v0.1.0` from registry.k8s.io. Let's advertise versioned and latest build rather than than whatever most recently landed on main.
Another reason, as I mentioned in https://github.com/kubernetes-sigs/dra-driver-cpu/issues/107 is, staging images have retention policy of 90 days. 