### PR TITLE
fix: pin github actions to commit SHA

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,9 +17,9 @@ jobs:
       DRACPU_E2E_CPU_DEVICE_MODE: individual
       DRACPU_E2E_VERBOSE: 1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Setup golang
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25'
     - name: Kind version check
@@ -38,9 +38,9 @@ jobs:
       DRACPU_E2E_CPU_DEVICE_MODE: grouped
       DRACPU_E2E_VERBOSE: 1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Setup golang
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25'
     - name: Kind version check

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25'
     - name: Build
@@ -25,11 +25,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
       - name: Install golangci-lint

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
     - name: Install pre-commit
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Pin `actions/checkout`, `actions/setup-python` and `actions/setup-go` to commit SHAs as. Otherwise, most of the github action jobs are failing as in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/122, with the following:
```YAML
Error: The actions actions/checkout@v4 and actions/setup-python@v5 are not allowed in kubernetes-sigs/dra-driver-cpu because all actions must be pinned to a full-length commit SHA.
```
```sh
curl -s https://api.github.com/repos/actions/checkout/git/ref/tags/v4 | grep sh
    "sha": "34e114876b0b11c390a56381ad16ebd13914f8d5",

curl -s https://api.github.com/repos/actions/setup-go/git/ref/tags/v5 | grep sh
    "sha": "40f1582b2485089dde7abd97c1529aa768e1baff",
    
curl -s https://api.github.com/repos/actions/setup-python/git/ref/tags/v5 | grep sh
    "sha": "a26af69be951a213d495a4c3e4e4022e16d87065",
```
Also use the same version (v5) of setup-go across all workflows.