### PR TITLE
fix: nil pointer dereference in BeFailedToCreate matcher

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -66,7 +66,7 @@ func BeFailedToCreate(fxt *fixture.Fixture) types.GomegaMatcher {
 			return false, nil
 		}
 		if cntSt.State.Waiting.Reason != reasonCreateContainerError {
-			lh.Info("container terminated for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Terminated.Reason)
+			lh.Info("container waiting for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Waiting.Reason)
 			return false, nil
 		}
 		lh.Info("container creation error", "containerName", cntSt.Name)


### PR DESCRIPTION
BeFailedToCreate polls the pod [every 2 sec](https://github.com/kubernetes-sigs/dra-driver-cpu/blob/42454717c699ff81a3c890468ced1d071f4de069/test/e2e/sharing_test.go#L262), expecting it to be in Pending with the container in a Waiting state and reason `CreateContainerError`. However, the container enters a `ContainerCreating` state shortly, before reaching that error. If the poll happens during this transient window, the container is still Waiting but with a different reason(not terminated). The code then incorrectly accesses `State.Terminated.Reason`, which is nil in this case, resulting to a panic.

Example run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_dra-driver-cpu/122/pull-dra-driver-cpu-e2e-device-mode-individual-amd64/2044701134609715200

 ```bash
------------------------------
Claim sharing when sharing a CPU claim should fail to run a pod with multiple containers which share a claim [Serial, negative]
/home/prow/go/src/sigs.k8s.io/dra-driver-cpu/test/e2e/sharing_test.go:202
  "level"=0 "msg"="fixture setup" "namespace"="dracpu-e2e-sharingcpu-nj2jq"
  STEP: creating a cpu ResourceClaim on "dracpu-e2e-sharingcpu-nj2jq" @ 04/16/26 09:02:09.636
  STEP: creating a pod with multiple containers consuming the ResourceClaim on "dracpu-e2e-sharingcpu-nj2jq", ensuring it gets ContainerCreateError @ 04/16/26 09:02:09.64
  "level"=0 "msg"="no container in waiting state" "podUID"="7c0ebd72-35c6-4369-ae20-7d4826eea386" "namespace"="dracpu-e2e-sharingcpu-nj2jq" "name"="pod-with-cpu-claim-multicnt"
  [PANICKED] in [It] - /home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:382 @ 04/16/26 09:02:11.664
  "level"=0 "msg"="fixture teardown" "namespace"="dracpu-e2e-sharingcpu-nj2jq"
  "level"=0 "msg"="fixture teardown" "namespace"="dracpu-e2e-infra-rd62q"
• [PANICKED] [32.060 seconds]
Claim sharing when sharing a CPU claim [It] should fail to run a pod with multiple containers which share a claim [Serial, negative]
/home/prow/go/src/sigs.k8s.io/dra-driver-cpu/test/e2e/sharing_test.go:202
  [PANICKED] Test Panicked
  In [It] at: /home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:382 @ 04/16/26 09:02:11.664
  runtime error: invalid memory address or nil pointer dereference
  Full Stack Trace
    github.com/onsi/gomega/internal.(*AsyncAssertion).pollMatcher.func1()
    	/home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:382 +0xe6
    panic({0x1bdaf40?, 0x31dfbd0?})
    	/usr/local/go/src/runtime/panic.go:783 +0x132
    github.com/kubernetes-sigs/dra-driver-cpu/test/e2e.BeFailedToCreate.func1(0xc000040508)
    	/home/prow/go/src/sigs.k8s.io/dra-driver-cpu/test/e2e/e2e_suite_test.go:69 +0x37d
    reflect.Value.call({0x1b93f60?, 0xc00019ef30?, 0x50ac50?}, {0x1ed90e2, 0x4}, {0xc00046d140, 0x1, 0x1b94140?})
    	/usr/local/go/src/reflect/value.go:581 +0xcc6
    reflect.Value.Call({0x1b93f60?, 0xc00019ef30?, 0x1ea6c60?}, {0xc00046d140?, 0x10?, 0xc000126560?})
    	/usr/local/go/src/reflect/value.go:365 +0xb9
    github.com/onsi/gomega/gcustom.MakeMatcher.func1({0xc000010f30?, 0x2?, 0x2?})
    	/home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/gcustom/make_matcher.go:103 +0x22c
    github.com/onsi/gomega/gcustom.CustomGomegaMatcher.Match(...)
    	/home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/gcustom/make_matcher.go:218
    github.com/onsi/gomega/internal.(*AsyncAssertion).pollMatcher(0xc00046d848?, {0x21b54a8?, 0xc00058d0b0?}, {0x1ea6c60?, 0xc000040508?})
    	/home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:387 +0x71
    github.com/onsi/gomega/internal.(*AsyncAssertion).match(0xc00022aa10, {0x21b54a8, 0xc00058d0b0}, 0x1, {0x0, 0x0, 0x0})
    	/home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:570 +0x945
    github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0xc00022aa10, {0x21b54a8, 0xc00058d0b0}, {0x0, 0x0, 0x0})
    	/home/prow/go/pkg/mod/github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:145 +0x85
    github.com/kubernetes-sigs/dra-driver-cpu/test/e2e.init.func3.2.4({0x21bc2a8, 0xc00058c360})
    	/home/prow/go/src/sigs.k8s.io/dra-driver-cpu/test/e2e/sharing_test.go:262 +0x9a6
------------------------------
```
