### PR TITLE
chore: drop the initContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,61 @@ This discrepancy is a known issue being addressed by [KEP-5517: Native Resource 
 
 **1-to-1 Claim to Container:** This driver enforces that a specific CPU `ResourceClaim` can only be used by *one* container within or across pods. See [Sharing resource claims](#sharing-resource-claims).
 
+## Prerequisites
+
+The driver relies on [NRI (Node Resource Interface)](https://github.com/containerd/nri) to pin containers to their
+allocated CPUs, and on [CDI (Container Device Interface)](https://github.com/cncf-tags/container-device-interface) to
+inject the allocated cpuset into the container environment.
+
+### Minimum Runtime Requirements
+
+Both NRI and CDI are enabled by default in modern container runtimes:
+
+| Runtime    | NRI enabled by default | CDI enabled by default |
+| ---------- | ---------------------- | ---------------------- |
+| containerd | 2.0+                   | 2.0+                   |
+| CRI-O      | 1.30+                  | always                 |
+
+Both runtimes also ship with the following CDI spec directories configured by default:
+
+```toml
+cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+```
+
+No manual runtime configuration is needed if you are running one of the versions above or newer.
+
+### Manual Configuration for Older Runtimes
+
+If you are running an older version of containerd (pre-2.0), you need to manually enable CDI and NRI in the containerd
+configuration (typically `/etc/containerd/config.toml`) and restart containerd.
+
+#### Enable CDI
+
+```toml
+[plugins."io.containerd.grpc.v1.cri"]
+  enable_cdi = true
+  cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+```
+
+#### Enable NRI
+
+```toml
+[plugins."io.containerd.nri.v1.nri"]
+  disable = false
+  disable_connections = false
+  plugin_config_path = "/etc/nri/conf.d"
+  plugin_path = "/opt/nri/plugins"
+  plugin_registration_timeout = "5s"
+  plugin_request_timeout = "5s"
+  socket_path = "/var/run/nri/nri.sock"
+```
+
+After editing the config, restart containerd:
+
+```bash
+systemctl restart containerd
+```
+
 ## Getting Started
 
 ### Installation

--- a/manifests/base/daemonset-dracpu.part.yaml
+++ b/manifests/base/daemonset-dracpu.part.yaml
@@ -24,58 +24,6 @@ spec:
       - operator: Exists
         effect: NoSchedule
       serviceAccountName: dracpu
-      hostPID: true
-      initContainers:
-      - name: enable-nri-and-cdi
-        image: busybox:stable
-        volumeMounts:
-        - mountPath: /etc
-          name: etc
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-        command:
-        - /bin/sh
-        - -c
-        - |
-          set -o errexit
-          set -o pipefail
-          set -o nounset
-          set -x
-          CONFIG_CHANGED=false
-          CONTAINERD_CONFIG_PATH="/etc/containerd/config.toml"
-          # --- Enable CDI ---
-          if grep -q '^\s*enable_cdi\s*=\s*true' "$CONTAINERD_CONFIG_PATH"; then
-            echo "containerd config already has CDI enabled; taking no action"
-          else
-            echo "containerd config does not have CDI enabled, thus enabling it";
-            sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\]/a \  enable_cdi = true' "$CONTAINERD_CONFIG_PATH"
-            CONFIG_CHANGED=true
-          fi
-          # --- CDI Spec Dirs Configuration ---
-          if grep -q '^\s*cdi_spec_dirs\s*=' "$CONTAINERD_CONFIG_PATH"; then
-            echo "containerd config already configures cdi_spec_dirs; taking no action"
-          else
-            echo "containerd config does not configure cdi_spec_dirs, thus setting it";
-            sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\]/a \  cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]' "$CONTAINERD_CONFIG_PATH"
-            CONFIG_CHANGED=true
-          fi
-          # --- Enable NRI ---
-          if grep -q "io.containerd.nri.v1.nri" "$CONTAINERD_CONFIG_PATH"
-          then
-             echo "containerd config contains NRI reference already; taking no action"
-          else
-             echo "containerd config does not mention NRI, thus enabling it";
-             printf '%s\n' "[plugins.\"io.containerd.nri.v1.nri\"]" "  disable = false" "  disable_connections = false" "  plugin_config_path = \"/etc/nri/conf.d\"" "  plugin_path = \"/opt/nri/plugins\"" "  plugin_registration_timeout = \"5s\"" "  plugin_request_timeout = \"5s\"" "  socket_path = \"/var/run/nri/nri.sock\"" >> "$CONTAINERD_CONFIG_PATH"
-             CONFIG_CHANGED=true
-          fi
-          if [ "$CONFIG_CHANGED" = true ]; then
-            echo "restarting containerd"
-            nsenter -t 1 -m -u -i -n -p -- systemctl restart containerd
-          fi
       containers:
       - name: dracpu
         args:
@@ -123,9 +71,6 @@ spec:
       - name: nri-plugin
         hostPath:
           path: /var/run/nri
-      - name: etc
-        hostPath:
-          path: /etc
       - name: cdi-dir
         hostPath:
           path: /var/run/cdi


### PR DESCRIPTION
It’s been a while since runtimes CRI-O (1.30+) and containerd (2.0+) started enabling NRI by default. Cases where it is not enabled seem rare, so it may not be worth requiring extra config changes for everyone during install. Right now, there is also no way to opt out of this behavior. That said, I added an option in the [Helm chart](https://github.com/kubernetes-sigs/dra-driver-cpu/pull/83) to enable NRI for containerd if a user explicitly wants it (although, I would prefer to drop there too). Also, it feels like enabling NRI should be handled by the cluster admin. Runtime config is more of a cluster concern and not something an app should enforce.

Fixes: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/94