### PR TITLE
contextual logging: initial plumbing

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -218,7 +218,7 @@ func run(logger logr.Logger) error {
 		CpuDeviceMode:    cpuDeviceMode,
 		CPUDeviceGroupBy: groupBy,
 	}
-	dracpu, err := driver.Start(ctx, clientset, driverConfig)
+	dracpu, asyncErr, err := driver.Start(ctx, clientset, driverConfig)
 	if err != nil {
 		return fmt.Errorf("driver failed to start: %w", err)
 	}
@@ -232,6 +232,9 @@ func run(logger logr.Logger) error {
 		cancel()
 	case <-ctx.Done():
 		logger.Info("exiting", "reason", "context cancelled")
+	case err := <-asyncErr:
+		cancel()
+		return fmt.Errorf("fatal NRI driver error: %w", err)
 	}
 
 	// Gracefully shutdown HTTP server

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -226,6 +227,8 @@ func run(logger logr.Logger) error {
 	ready.Store(true)
 	logger.Info("driver started")
 
+	var fatalErr error
+
 	select {
 	case <-signalCh:
 		logger.Info("exiting", "reason", "received signal")
@@ -234,17 +237,16 @@ func run(logger logr.Logger) error {
 		logger.Info("exiting", "reason", "context cancelled")
 	case err := <-asyncErr:
 		cancel()
-		return fmt.Errorf("fatal NRI driver error: %w", err)
+		fatalErr = fmt.Errorf("NRI driver error: %w", err)
 	}
 
 	// Gracefully shutdown HTTP server
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
-	if err := server.Shutdown(shutdownCtx); err != nil {
-		// we prefer to carry on
-		logger.Error(err, "HTTP server shutdown failed")
+	if serverErr := server.Shutdown(shutdownCtx); serverErr != nil {
+		fatalErr = errors.Join(fatalErr, fmt.Errorf("HTTP server shutdown error: %w", serverErr))
 	}
-	return nil
+	return fatalErr
 }
 
 func printVersion(logger logr.Logger) {

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/driver"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sys/unix"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
 	"k8s.io/utils/cpuset"
 )
 
@@ -110,18 +112,33 @@ func init() {
 }
 
 func main() {
-	klog.InitFlags(nil)
+	config := textlogger.NewConfig()
+	config.AddFlags(flag.CommandLine)
 	flag.Parse()
 
-	if err := run(); err != nil {
-		klog.Fatalf("%v", err)
+	logger := textlogger.NewLogger(config)
+	// some key deps still call klog directly, so we need this integration.
+	// TODO: check every time we bump kube libs to a new major version,
+	// as the contextual logging transition to kube libs is still ongoing
+	// k8s.io/client-go
+	// k8s.io/apimachinery
+	// k8s.io/dynamic-resource-allocation
+	// k8s.io/kube-openapi
+	// k8s.io/utils
+	// k8s.io/component-helpers
+	// k8s.io/kubelet
+	klog.SetLoggerWithOptions(logger, klog.ContextualLogger(true))
+
+	if err := run(logger); err != nil {
+		logger.Error(err, "failed to run")
+		os.Exit(1)
 	}
 }
 
-func run() error {
-	printVersion()
+func run(logger logr.Logger) error {
+	printVersion(logger)
 	flag.VisitAll(func(f *flag.Flag) {
-		klog.Infof("FLAG: --%s=%q", f.Name, f.Value)
+		logger.Info("FLAG", "name", f.Name, "value", f.Value.String())
 	})
 
 	reservedCPUSet, err := cpuset.Parse(reservedCPUs)
@@ -151,16 +168,16 @@ func run() error {
 
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			klog.Errorf("HTTP server failed: %v", err)
+			logger.Error(err, "HTTP server failed")
 		}
 	}()
 
-	var config *rest.Config
+	var restConfig *rest.Config
 	if kubeconfig != "" {
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	} else {
 		// creates the in-cluster config
-		config, err = rest.InClusterConfig()
+		restConfig, err = rest.InClusterConfig()
 	}
 	if err != nil {
 		return fmt.Errorf("can not create client-go configuration: %w", err)
@@ -168,11 +185,11 @@ func run() error {
 
 	// use protobuf for better performance at scale
 	// https://kubernetes.io/docs/reference/using-api/api-concepts/#alternate-representations-of-resources
-	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	config.ContentType = "application/vnd.kubernetes.protobuf"
+	restConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	restConfig.ContentType = "application/vnd.kubernetes.protobuf"
 
 	// creates the clientset
-	clientset, err := kubernetes.NewForConfig(config)
+	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return fmt.Errorf("can not create client-go client: %w", err)
 	}
@@ -183,7 +200,7 @@ func run() error {
 	}
 
 	// trap Ctrl+C and call cancel on the context
-	ctx := context.Background()
+	ctx := klog.NewContext(context.Background(), logger)
 	ctx, cancel := context.WithCancel(ctx)
 
 	// Enable signal handler
@@ -207,26 +224,27 @@ func run() error {
 	}
 	defer dracpu.Stop()
 	ready.Store(true)
-	klog.Info("driver started")
+	logger.Info("driver started")
 
 	select {
 	case <-signalCh:
-		klog.Infof("Exiting: received signal")
+		logger.Info("exiting", "reason", "received signal")
 		cancel()
 	case <-ctx.Done():
-		klog.Infof("Exiting: context cancelled")
+		logger.Info("exiting", "reason", "context cancelled")
 	}
 
 	// Gracefully shutdown HTTP server
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
 	if err := server.Shutdown(shutdownCtx); err != nil {
-		klog.Errorf("HTTP server shutdown failed: %v", err)
+		// we prefer to carry on
+		logger.Error(err, "HTTP server shutdown failed")
 	}
 	return nil
 }
 
-func printVersion() {
+func printVersion(logger logr.Logger) {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return
@@ -240,5 +258,5 @@ func printVersion() {
 			vcsTime = f.Value
 		}
 	}
-	klog.Infof("dracpu go %s build: %s time: %s", info.GoVersion, vcsRevision, vcsTime)
+	logger.Info("dracpu", "goVersion", info.GoVersion, "build", vcsRevision, "time", vcsTime)
 }

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -113,6 +113,12 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
+	if err := run(); err != nil {
+		klog.Fatalf("%v", err)
+	}
+}
+
+func run() error {
 	printVersion()
 	flag.VisitAll(func(f *flag.Flag) {
 		klog.Infof("FLAG: --%s=%q", f.Name, f.Value)
@@ -120,7 +126,7 @@ func main() {
 
 	reservedCPUSet, err := cpuset.Parse(reservedCPUs)
 	if err != nil {
-		klog.Fatalf("failed to parse reserved CPUs: %v", err)
+		return fmt.Errorf("failed to parse reserved CPUs: %w", err)
 	}
 
 	mux := http.NewServeMux()
@@ -157,7 +163,7 @@ func main() {
 		config, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		klog.Fatalf("can not create client-go configuration: %v", err)
+		return fmt.Errorf("can not create client-go configuration: %w", err)
 	}
 
 	// use protobuf for better performance at scale
@@ -168,12 +174,12 @@ func main() {
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		klog.Fatalf("can not create client-go client: %v", err)
+		return fmt.Errorf("can not create client-go client: %w", err)
 	}
 
 	nodeName, err := nodeutil.GetHostname(hostnameOverride)
 	if err != nil {
-		klog.Fatalf("can not obtain the node name, use the hostname-override flag if you want to set it to a specific value: %v", err)
+		return fmt.Errorf("can not obtain the node name, use the hostname-override flag if you want to set it to a specific value: %w", err)
 	}
 
 	// trap Ctrl+C and call cancel on the context
@@ -197,7 +203,7 @@ func main() {
 	}
 	dracpu, err := driver.Start(ctx, clientset, driverConfig)
 	if err != nil {
-		klog.Fatalf("driver failed to start: %v", err)
+		return fmt.Errorf("driver failed to start: %w", err)
 	}
 	defer dracpu.Stop()
 	ready.Store(true)
@@ -217,6 +223,7 @@ func main() {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		klog.Errorf("HTTP server shutdown failed: %v", err)
 	}
+	return nil
 }
 
 func printVersion() {

--- a/pkg/driver/cdi.go
+++ b/pkg/driver/cdi.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"k8s.io/klog/v2"
+	"github.com/go-logr/logr"
 	cdiSpec "tags.cncf.io/container-device-interface/specs-go"
 )
 
@@ -46,7 +46,7 @@ type CdiManager struct {
 }
 
 // NewCdiManager creates a manager for the driver's CDI spec file.
-func NewCdiManager(driverName string) (*CdiManager, error) {
+func NewCdiManager(logger logr.Logger, driverName string) (*CdiManager, error) {
 	path := filepath.Join(cdiSpecDir, fmt.Sprintf("%s.json", driverName))
 
 	if err := os.MkdirAll(cdiSpecDir, 0755); err != nil {
@@ -66,23 +66,23 @@ func NewCdiManager(driverName string) (*CdiManager, error) {
 			Kind:    cdiKind,
 			Devices: []cdiSpec.Device{},
 		}
-		if err := c.writeSpecToFile(initialSpec); err != nil {
+		if err := c.writeSpecToFile(logger, initialSpec); err != nil {
 			return nil, err
 		}
 	} else if err != nil {
 		return nil, fmt.Errorf("error accessing CDI spec file %q: %w", path, err)
 	}
 
-	klog.Infof("Initialized CDI file manager for %q", path)
+	logger.Info("initialized CDI file manager", "path", path)
 	return c, nil
 }
 
 // AddDevice adds a device to the CDI spec file.
-func (c *CdiManager) AddDevice(deviceName string, envVar string) error {
+func (c *CdiManager) AddDevice(logger logr.Logger, deviceName string, envVar string) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	spec, err := c.readSpecFromFile()
+	spec, err := c.readSpecFromFile(logger)
 	if err != nil {
 		return err
 	}
@@ -99,15 +99,15 @@ func (c *CdiManager) AddDevice(deviceName string, envVar string) error {
 	}
 
 	spec.Devices = append(spec.Devices, newDevice)
-	return c.writeSpecToFile(spec)
+	return c.writeSpecToFile(logger, spec)
 }
 
 // RemoveDevice removes a device from the CDI spec file.
-func (c *CdiManager) RemoveDevice(deviceName string) error {
+func (c *CdiManager) RemoveDevice(logger logr.Logger, deviceName string) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	spec, err := c.readSpecFromFile()
+	spec, err := c.readSpecFromFile(logger)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil // File already gone, nothing to do.
@@ -116,14 +116,14 @@ func (c *CdiManager) RemoveDevice(deviceName string) error {
 	}
 
 	if removeDeviceFromSpec(spec, deviceName) {
-		return c.writeSpecToFile(spec)
+		return c.writeSpecToFile(logger, spec)
 	}
 
 	return nil
 }
 
-func (c *CdiManager) GetSpec() (*cdiSpec.Spec, error) {
-	return c.readSpecFromFile()
+func (c *CdiManager) GetSpec(logger logr.Logger) (*cdiSpec.Spec, error) {
+	return c.readSpecFromFile(logger)
 }
 
 func removeDeviceFromSpec(spec *cdiSpec.Spec, deviceName string) bool {
@@ -140,7 +140,7 @@ func removeDeviceFromSpec(spec *cdiSpec.Spec, deviceName string) bool {
 	return deviceFound
 }
 
-func (c *CdiManager) readSpecFromFile() (*cdiSpec.Spec, error) {
+func (c *CdiManager) readSpecFromFile(logger logr.Logger) (*cdiSpec.Spec, error) {
 	data, err := os.ReadFile(c.path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading CDI spec file %q: %w", c.path, err)
@@ -158,11 +158,11 @@ func (c *CdiManager) readSpecFromFile() (*cdiSpec.Spec, error) {
 	if err := json.Unmarshal(data, spec); err != nil {
 		return nil, fmt.Errorf("error unmarshaling CDI spec from %q: %w", c.path, err)
 	}
-	klog.Infof("Read CDI spec from %q spec:%+v", c.path, spec)
+	logger.V(4).Info("read CDI spec", "path", c.path, "spec", spec)
 	return spec, nil
 }
 
-func (c *CdiManager) writeSpecToFile(spec *cdiSpec.Spec) (err error) {
+func (c *CdiManager) writeSpecToFile(logger logr.Logger, spec *cdiSpec.Spec) (err error) {
 	tmpFile, err := os.CreateTemp(cdiSpecDir, c.driverName)
 	if err != nil {
 		return fmt.Errorf("failed to create temporary CDI spec: %w", err)
@@ -198,6 +198,6 @@ func (c *CdiManager) writeSpecToFile(spec *cdiSpec.Spec) (err error) {
 		return fmt.Errorf("failed to rename temporary CDI spec: %w", err)
 	}
 
-	klog.Infof("Successfully updated and synced CDI spec file %q", c.path)
+	logger.V(4).Info("updated and synced CDI spec file", "path", c.path)
 	return nil
 }

--- a/pkg/driver/cdi_test.go
+++ b/pkg/driver/cdi_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	cdiSpec "tags.cncf.io/container-device-interface/specs-go"
@@ -74,24 +75,25 @@ func TestAddDevice(t *testing.T) {
 
 	for _, tcase := range testcases {
 		t.Run(tcase.name, func(t *testing.T) {
+			logger := testr.New(t)
 			saveCDIDir := cdiSpecDir
 			t.Cleanup(func() {
 				cdiSpecDir = saveCDIDir
 			})
 			cdiSpecDir = t.TempDir()
 
-			mgr, err := NewCdiManager(testDriverName)
+			mgr, err := NewCdiManager(logger, testDriverName)
 			require.NoError(t, err)
 
 			_, err = os.Stat(filepath.Join(cdiSpecDir, testDriverName+".json"))
 			require.NoError(t, err)
 
 			for _, dev := range tcase.devices {
-				err = mgr.AddDevice(dev.name, dev.env)
+				err = mgr.AddDevice(logger, dev.name, dev.env)
 				require.NoError(t, err)
 			}
 
-			got, err := mgr.GetSpec()
+			got, err := mgr.GetSpec(logger)
 			require.NoError(t, err)
 			if diff := cmp.Diff(got, tcase.expectedSpec); diff != "" {
 				t.Errorf("unexpected spec from empty: %v", diff)
@@ -157,24 +159,25 @@ func TestRemoveDevice(t *testing.T) {
 
 	for _, tcase := range testcases {
 		t.Run(tcase.name, func(t *testing.T) {
+			logger := testr.New(t)
 			saveCDIDir := cdiSpecDir
 			t.Cleanup(func() {
 				cdiSpecDir = saveCDIDir
 			})
 			cdiSpecDir = t.TempDir()
 
-			mgr, err := NewCdiManager(testDriverName)
+			mgr, err := NewCdiManager(logger, testDriverName)
 			require.NoError(t, err)
 			for _, dev := range tcase.initial {
-				err = mgr.AddDevice(dev.name, dev.env)
+				err = mgr.AddDevice(logger, dev.name, dev.env)
 				require.NoError(t, err)
 			}
 			for _, dev := range tcase.toRemove {
-				err = mgr.RemoveDevice(dev.name)
+				err = mgr.RemoveDevice(logger, dev.name)
 				require.NoError(t, err)
 			}
 
-			got, err := mgr.GetSpec()
+			got, err := mgr.GetSpec(logger)
 			require.NoError(t, err)
 			if diff := cmp.Diff(got, tcase.expectedSpec); diff != "" {
 				t.Errorf("unexpected spec from empty: %v", diff)

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -345,7 +345,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, cpuAssignment.String())
-	if err := cp.cdiMgr.AddDevice(deviceName, envVar); err != nil {
+	if err := cp.cdiMgr.AddDevice(logger, deviceName, envVar); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
 	}
 
@@ -404,7 +404,7 @@ func (cp *CPUDriver) prepareResourceClaim(ctx context.Context, claim *resourceap
 	cp.cpuAllocationStore.AddResourceClaimAllocation(claim.UID, claimCPUSet)
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, claimCPUSet.String())
-	if err := cp.cdiMgr.AddDevice(deviceName, envVar); err != nil {
+	if err := cp.cdiMgr.AddDevice(logger, deviceName, envVar); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
 	}
 
@@ -451,9 +451,10 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 }
 
 func (cp *CPUDriver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin.NamespacedObject) error {
+	logger := klog.FromContext(ctx)
 	cp.cpuAllocationStore.RemoveResourceClaimAllocation(claim.UID)
 	// Remove the device from the CDI spec file using the manager.
-	return cp.cdiMgr.RemoveDevice(getCDIDeviceName(claim.UID))
+	return cp.cdiMgr.RemoveDevice(logger, getCDIDeviceName(claim.UID))
 }
 
 // HandleError is called by the kubelet plugin framework when an error occurs in the background,

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -271,10 +271,10 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 	for _, claim := range claims {
 		if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
 			logger.Info("claim is for a grouped resource", "claim", klog.KObj(claim))
-			result[claim.UID] = cp.prepareGroupedResourceClaim(ctx, claim)
+			result[claim.UID] = cp.prepareGroupedResourceClaim(logger, claim)
 		} else {
 			logger.Info("claim is for an individual resource", "claim", klog.KObj(claim))
-			result[claim.UID] = cp.prepareResourceClaim(ctx, claim)
+			result[claim.UID] = cp.prepareResourceClaim(logger, claim)
 		}
 	}
 	return result, nil
@@ -284,8 +284,7 @@ func getCDIDeviceName(uid types.UID) string {
 	return fmt.Sprintf("claim-%s", uid)
 }
 
-func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger := klog.FromContext(ctx)
+func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
 	logger.Info("preparing grouped resource claim", "claim", klog.KObj(claim))
 
 	if claim.Status.Allocation == nil {
@@ -341,7 +340,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 		return kubeletplugin.PrepareResult{}
 	}
 
-	cp.cpuAllocationStore.AddResourceClaimAllocation(claim.UID, cpuAssignment)
+	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, cpuAssignment)
 
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, cpuAssignment.String())
@@ -371,8 +370,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 	}
 }
 
-func (cp *CPUDriver) prepareResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger := klog.FromContext(ctx)
+func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
 	logger.Info("preparing individual resource claim", "claim", klog.KObj(claim))
 
 	if claim.Status.Allocation == nil {
@@ -401,7 +399,7 @@ func (cp *CPUDriver) prepareResourceClaim(ctx context.Context, claim *resourceap
 	}
 
 	claimCPUSet := cpuset.New(claimCPUIDs...)
-	cp.cpuAllocationStore.AddResourceClaimAllocation(claim.UID, claimCPUSet)
+	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, claimCPUSet)
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, claimCPUSet.String())
 	if err := cp.cdiMgr.AddDevice(logger, deviceName, envVar); err != nil {
@@ -441,7 +439,7 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 
 	for _, claim := range claims {
 		logger.Info("unpreparing resource claim", "claim", claim)
-		err := cp.unprepareResourceClaim(ctx, claim)
+		err := cp.unprepareResourceClaim(logger, claim)
 		result[claim.UID] = err
 		if err != nil {
 			logger.Error(err, "error unpreparing resources for claim", "namespace", claim.Namespace, "name", claim.Name)
@@ -450,9 +448,8 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 	return result, nil
 }
 
-func (cp *CPUDriver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin.NamespacedObject) error {
-	logger := klog.FromContext(ctx)
-	cp.cpuAllocationStore.RemoveResourceClaimAllocation(claim.UID)
+func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplugin.NamespacedObject) error {
+	cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
 	// Remove the device from the CDI spec file using the manager.
 	return cp.cdiMgr.RemoveDevice(logger, getCDIDeviceName(claim.UID))
 }

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpumanager"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
@@ -55,8 +56,8 @@ const (
 )
 
 // createGroupedCPUDeviceSlices creates Device objects based on the CPU topology, grouped by a specific criteria.
-func (cp *CPUDriver) createGroupedCPUDeviceSlices() [][]resourceapi.Device {
-	klog.Info("Creating grouped CPU devices", "groupBy", cp.cpuDeviceGroupBy)
+func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resourceapi.Device {
+	logger.Info("creating grouped CPU devices", "groupBy", cp.cpuDeviceGroupBy)
 	var devices []resourceapi.Device
 
 	topo := cp.cpuTopology
@@ -223,17 +224,18 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 
 // PublishResources publishes ResourceSlice for CPU resources.
 func (cp *CPUDriver) PublishResources(ctx context.Context) {
-	klog.Infof("Publishing resources")
+	logger := klog.FromContext(ctx)
+	logger.Info("publishing resources")
 
 	var deviceChunks [][]resourceapi.Device
 	if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
-		deviceChunks = cp.createGroupedCPUDeviceSlices()
+		deviceChunks = cp.createGroupedCPUDeviceSlices(logger)
 	} else {
 		deviceChunks = cp.createCPUDeviceSlices()
 	}
 
 	if deviceChunks == nil {
-		klog.Infof("No devices to publish or error occurred.")
+		logger.Info("no devices to publish or error occurred")
 		return
 	}
 
@@ -251,13 +253,14 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 
 	err := cp.draPlugin.PublishResources(ctx, resources)
 	if err != nil {
-		klog.Errorf("error publishing resources: %v", err)
+		logger.Error(err, "error publishing resources")
 	}
 }
 
 // PrepareResourceClaims is called by the kubelet to prepare a resource claim.
 func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
-	klog.Infof("PrepareResourceClaims is called: number of claims: %d", len(claims))
+	logger := klog.FromContext(ctx)
+	logger.Info("preparing resource claims", "numClaims", len(claims))
 
 	result := make(map[types.UID]kubeletplugin.PrepareResult)
 
@@ -267,10 +270,10 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 
 	for _, claim := range claims {
 		if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
-			klog.Infof("Claim %s/%s is for a grouped resource", claim.Namespace, claim.Name)
+			logger.Info("claim is for a grouped resource", "claim", klog.KObj(claim))
 			result[claim.UID] = cp.prepareGroupedResourceClaim(ctx, claim)
 		} else {
-			klog.Infof("Claim %s/%s is for an individual resource", claim.Namespace, claim.Name)
+			logger.Info("claim is for an individual resource", "claim", klog.KObj(claim))
 			result[claim.UID] = cp.prepareResourceClaim(ctx, claim)
 		}
 	}
@@ -282,7 +285,8 @@ func getCDIDeviceName(uid types.UID) string {
 }
 
 func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	klog.Infof("prepareResourceClaim claim:%s/%s", claim.Namespace, claim.Name)
+	logger := klog.FromContext(ctx)
+	logger.Info("preparing grouped resource claim", "claim", klog.KObj(claim))
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -300,7 +304,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 		if quantity, ok := alloc.ConsumedCapacity[cpuResourceQualifiedName]; ok {
 			count := quantity.Value()
 			claimCPUCount = count
-			klog.Infof("Found request for %d CPUs in device %s for claim %s", count, alloc.Device, claim.Name)
+			logger.Info("found CPU request", "numCPUs", count, "device", alloc.Device, "claim", klog.KObj(claim))
 		}
 
 		topo := cp.cpuTopology
@@ -313,7 +317,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 			}
 			socketCPUs := topo.CPUDetails.CPUsInSockets(socketID)
 			availableCPUsForDevice = sharedCPUs.Difference(cpuAssignment).Intersection(socketCPUs)
-			klog.Infof("Socket %d CPUs:%s available CPUs: %s", socketID, socketCPUs.String(), availableCPUsForDevice.String())
+			logger.Info("socket CPU availability", "socketID", socketID, "socketCPUs", socketCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 		} else { // numanode
 			numaNodeID, ok := cp.deviceNameToNUMANodeID[alloc.Device]
 			if !ok {
@@ -321,20 +325,19 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 			}
 			numaCPUs := topo.CPUDetails.CPUsInNUMANodes(numaNodeID)
 			availableCPUsForDevice = sharedCPUs.Difference(cpuAssignment).Intersection(numaCPUs)
-			klog.Infof("NUMA node %d CPUs:%s available CPUs: %s", numaNodeID, numaCPUs.String(), availableCPUsForDevice.String())
+			logger.Info("NUMA node CPU availability", "numaNodeID", numaNodeID, "numaCPUs", numaCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 		}
 
-		logger := klog.FromContext(ctx)
 		cur, err := cpumanager.TakeByTopologyNUMAPacked(logger, topo, availableCPUsForDevice, int(claimCPUCount), cpumanager.CPUSortingStrategyPacked, true)
 		if err != nil {
 			return kubeletplugin.PrepareResult{Err: err}
 		}
 		cpuAssignment = cpuAssignment.Union(cur)
-		klog.Infof("CPU assignment for device %s: %s. All cpus assigned:%s", alloc.Device, cur.String(), cpuAssignment.String())
+		logger.Info("CPU assignment for device", "device", alloc.Device, "assigned", cur.String(), "allAssigned", cpuAssignment.String())
 	}
 
 	if cpuAssignment.Size() == 0 {
-		klog.V(5).Infof("prepareResourceClaim claim:%s/%s has no CPU allocations for this driver", claim.Namespace, claim.Name)
+		logger.V(5).Info("claim has no CPU allocations for this driver", "claim", klog.KObj(claim))
 		return kubeletplugin.PrepareResult{}
 	}
 
@@ -347,7 +350,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 	}
 
 	qualifiedName := cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName)
-	klog.Infof("prepareResourceClaim CDIDeviceName:%s envVar:%s qualifiedName:%v", deviceName, envVar, qualifiedName)
+	logger.Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
 	preparedDevices := []kubeletplugin.Device{}
 	for _, allocResult := range claim.Status.Allocation.Devices.Results {
 		if allocResult.Driver != cp.driverName {
@@ -362,14 +365,15 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(ctx context.Context, claim *res
 		preparedDevices = append(preparedDevices, preparedDevice)
 	}
 
-	klog.Infof("prepareResourceClaim preparedDevices:%+v", preparedDevices)
+	logger.Info("prepared devices for claim", "preparedDevices", preparedDevices)
 	return kubeletplugin.PrepareResult{
 		Devices: preparedDevices,
 	}
 }
 
-func (cp *CPUDriver) prepareResourceClaim(_ context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	klog.Infof("prepareResourceClaim claim:%s/%s", claim.Namespace, claim.Name)
+func (cp *CPUDriver) prepareResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
+	logger := klog.FromContext(ctx)
+	logger.Info("preparing individual resource claim", "claim", klog.KObj(claim))
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -392,7 +396,7 @@ func (cp *CPUDriver) prepareResourceClaim(_ context.Context, claim *resourceapi.
 	}
 
 	if len(claimCPUIDs) == 0 {
-		klog.V(5).Infof("prepareResourceClaim claim:%s/%s has no CPU allocations for this driver", claim.Namespace, claim.Name)
+		logger.V(5).Info("claim has no CPU allocations for this driver", "claim", klog.KObj(claim))
 		return kubeletplugin.PrepareResult{}
 	}
 
@@ -405,7 +409,7 @@ func (cp *CPUDriver) prepareResourceClaim(_ context.Context, claim *resourceapi.
 	}
 
 	qualifiedName := cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName)
-	klog.Infof("prepareResourceClaim CDIDeviceName:%s envVar:%s qualifiedName:%v", deviceName, envVar, qualifiedName)
+	logger.Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
 	preparedDevices := []kubeletplugin.Device{}
 	for _, allocResult := range claim.Status.Allocation.Devices.Results {
 		if allocResult.Driver != cp.driverName {
@@ -426,7 +430,8 @@ func (cp *CPUDriver) prepareResourceClaim(_ context.Context, claim *resourceapi.
 
 // UnprepareResourceClaims is called by the kubelet to unprepare the resources for a claim.
 func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
-	klog.Infof("UnprepareResourceClaims is called: number of claims: %d", len(claims))
+	logger := klog.FromContext(ctx)
+	logger.Info("unpreparing resource claims", "numClaims", len(claims))
 
 	result := make(map[types.UID]error)
 
@@ -435,17 +440,17 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 	}
 
 	for _, claim := range claims {
-		klog.Infof("UnprepareResourceClaims claim:%+v", claim)
+		logger.Info("unpreparing resource claim", "claim", claim)
 		err := cp.unprepareResourceClaim(ctx, claim)
 		result[claim.UID] = err
 		if err != nil {
-			klog.Infof("error unpreparing resources for claim %s/%s : %v", claim.Namespace, claim.Name, err)
+			logger.Error(err, "error unpreparing resources for claim", "namespace", claim.Namespace, "name", claim.Name)
 		}
 	}
 	return result, nil
 }
 
-func (cp *CPUDriver) unprepareResourceClaim(_ context.Context, claim kubeletplugin.NamespacedObject) error {
+func (cp *CPUDriver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin.NamespacedObject) error {
 	cp.cpuAllocationStore.RemoveResourceClaimAllocation(claim.UID)
 	// Remove the device from the CDI spec file using the manager.
 	return cp.cdiMgr.RemoveDevice(getCDIDeviceName(claim.UID))
@@ -454,6 +459,8 @@ func (cp *CPUDriver) unprepareResourceClaim(_ context.Context, claim kubeletplug
 // HandleError is called by the kubelet plugin framework when an error occurs in the background,
 // for example while publishing ResourceSlices.
 func (cp *CPUDriver) HandleError(ctx context.Context, err error, msg string) {
+	logger := klog.FromContext(ctx)
+
 	// Log the error using the standard Kubernetes error handler
 	runtime.HandleErrorWithContext(ctx, err, msg)
 
@@ -461,7 +468,7 @@ func (cp *CPUDriver) HandleError(ctx context.Context, err error, msg string) {
 	// This fail-fast behavior is intentional for early project maturity to surface
 	// issues quickly rather than silently continuing in a broken state.
 	if !errors.Is(err, kubeletplugin.ErrRecoverable) {
-		klog.ErrorS(err, "Fatal unrecoverable error in DRA driver, exiting",
+		logger.Error(err, "fatal unrecoverable error in DRA driver, exiting",
 			"driver", cp.driverName,
 			"node", cp.nodeName,
 			"message", msg,

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"github.com/stretchr/testify/require"
@@ -605,6 +606,8 @@ func TestPrepareResourceClaims(t *testing.T) {
 }
 
 func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
+	logger := testr.New(t)
+
 	baseCPUDriver := func(groupBy string, cpuInfos []cpuinfo.CPUInfo, initialAllocations map[types.UID]cpuset.CPUSet, reservedCPUs cpuset.CPUSet) *CPUDriver {
 		driver := &CPUDriver{}
 		driver.driverName = testDriverName
@@ -616,7 +619,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 		driver.cpuTopology, _ = mockProvider.GetCPUTopology()
 		driver.cpuAllocationStore = store.NewCPUAllocation(driver.cpuTopology, reservedCPUs)
 		for claimUID, cpus := range initialAllocations {
-			driver.cpuAllocationStore.AddResourceClaimAllocation(claimUID, cpus)
+			driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, cpus)
 		}
 
 		topo, err := mockProvider.GetCPUTopology()

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func newMockCdiMgr() *mockCdiMgr {
 	}
 }
 
-func (m *mockCdiMgr) AddDevice(deviceName, envVar string) error {
+func (m *mockCdiMgr) AddDevice(_ logr.Logger, deviceName, envVar string) error {
 	if m.addError != nil {
 		return m.addError
 	}
@@ -75,7 +76,7 @@ func (m *mockCdiMgr) AddDevice(deviceName, envVar string) error {
 	return nil
 }
 
-func (m *mockCdiMgr) RemoveDevice(deviceName string) error {
+func (m *mockCdiMgr) RemoveDevice(_ logr.Logger, deviceName string) error {
 	if m.removeError != nil {
 		return m.removeError
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -159,6 +159,8 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	}
 	plugin.cdiMgr = cdiMgr
 
+	logger := klog.FromContext(ctx)
+
 	// register the NRI plugin
 	nriOpts := []stub.Option{
 		stub.WithPluginName(config.DriverName),
@@ -166,7 +168,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		// https://github.com/containerd/nri/pull/173
 		// Otherwise it silently exits the program
 		stub.WithOnClose(func() {
-			klog.Infof("%s NRI plugin closed", config.DriverName)
+			logger.Info("NRI plugin closed", "driver", config.DriverName)
 		}),
 	}
 	stub, err := stub.New(plugin, nriOpts...)
@@ -177,7 +179,8 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 
 	go func() {
 		if err := runNRIPluginWithRetry(ctx, plugin.nriPlugin, maxAttempts); err != nil && ctx.Err() == nil {
-			klog.Fatalf("NRI plugin failed for %d times to be restarted", maxAttempts)
+			logger.Error(err, "NRI plugin failed to be restarted", "maxAttempts", maxAttempts)
+			os.Exit(1)
 		}
 	}()
 
@@ -194,8 +197,9 @@ func (cp *CPUDriver) Stop() {
 }
 
 // Shutdown is called when the runtime is shutting down.
-func (cp *CPUDriver) Shutdown(_ context.Context) {
-	klog.Info("Runtime shutting down...")
+func (cp *CPUDriver) Shutdown(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger.Info("runtime shutting down")
 }
 
 type nriRunner interface {
@@ -203,14 +207,15 @@ type nriRunner interface {
 }
 
 func runNRIPluginWithRetry(ctx context.Context, plugin nriRunner, maxAttempts int) error {
+	logger := klog.FromContext(ctx)
 	for i := 0; i < maxAttempts; i++ {
 		err := plugin.Run(ctx)
 		if ctx.Err() != nil {
-			klog.Infof("NRI plugin stopped: context cancelled")
+			logger.Info("NRI plugin stopped", "reason", "context cancelled")
 			return ctx.Err()
 		}
 		if err != nil {
-			klog.Infof("NRI plugin failed with error %v, restarting %d out of %d", err, i+1, maxAttempts)
+			logger.Error(err, "NRI plugin failed, restarting", "attempt", i+1, "maxAttempts", maxAttempts)
 		}
 	}
 	return fmt.Errorf("NRI plugin failed for %d times to be restarted", maxAttempts)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/containerd/nri/pkg/stub"
+	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -61,8 +62,8 @@ type KubeletPlugin interface {
 }
 
 type cdiManager interface {
-	AddDevice(deviceName string, envVar string) error
-	RemoveDevice(deviceName string) error
+	AddDevice(logger logr.Logger, deviceName string, envVar string) error
+	RemoveDevice(logger logr.Logger, deviceName string) error
 }
 
 // CPUInfoProvider is an interface for getting CPU information.
@@ -154,13 +155,13 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		return nil, asyncErr, err
 	}
 
-	cdiMgr, err := NewCdiManager(config.DriverName)
+	logger := klog.FromContext(ctx)
+
+	cdiMgr, err := NewCdiManager(logger, config.DriverName)
 	if err != nil {
 		return nil, asyncErr, fmt.Errorf("failed to create CDI manager: %w", err)
 	}
 	plugin.cdiMgr = cdiMgr
-
-	logger := klog.FromContext(ctx)
 
 	// register the NRI plugin
 	nriOpts := []stub.Option{

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -102,7 +102,8 @@ type Config struct {
 }
 
 // Start creates and starts a new CPUDriver.
-func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) (*CPUDriver, error) {
+func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) (*CPUDriver, <-chan error, error) {
+	asyncErr := make(chan error, 1)
 	plugin := &CPUDriver{
 		driverName:             config.DriverName,
 		nodeName:               config.NodeName,
@@ -118,10 +119,10 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()
 	topo, err := cpuInfoProvider.GetCPUTopology()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get CPU topology: %w", err)
+		return nil, asyncErr, fmt.Errorf("failed to get CPU topology: %w", err)
 	}
 	if topo == nil {
-		return nil, fmt.Errorf("failed to get CPU topology: topology is nil")
+		return nil, asyncErr, fmt.Errorf("failed to get CPU topology: topology is nil")
 	}
 	plugin.cpuTopology = topo
 	plugin.cpuAllocationStore = store.NewCPUAllocation(plugin.cpuTopology, config.ReservedCPUs)
@@ -129,7 +130,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 
 	driverPluginPath := filepath.Join(kubeletPluginPath, config.DriverName)
 	if err := os.MkdirAll(driverPluginPath, 0750); err != nil {
-		return nil, fmt.Errorf("failed to create plugin path %s: %w", driverPluginPath, err)
+		return nil, asyncErr, fmt.Errorf("failed to create plugin path %s: %w", driverPluginPath, err)
 	}
 
 	kubeletOpts := []kubeletplugin.Option{
@@ -139,7 +140,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	}
 	d, err := kubeletplugin.Start(ctx, plugin, kubeletOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("start kubelet plugin: %w", err)
+		return nil, asyncErr, fmt.Errorf("start kubelet plugin: %w", err)
 	}
 	plugin.draPlugin = d
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
@@ -150,12 +151,12 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		return status.PluginRegistered, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, asyncErr, err
 	}
 
 	cdiMgr, err := NewCdiManager(config.DriverName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CDI manager: %w", err)
+		return nil, asyncErr, fmt.Errorf("failed to create CDI manager: %w", err)
 	}
 	plugin.cdiMgr = cdiMgr
 
@@ -173,21 +174,21 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	}
 	stub, err := stub.New(plugin, nriOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create plugin stub: %w", err)
+		return nil, asyncErr, fmt.Errorf("failed to create plugin stub: %w", err)
 	}
 	plugin.nriPlugin = stub
 
 	go func() {
 		if err := runNRIPluginWithRetry(ctx, plugin.nriPlugin, maxAttempts); err != nil && ctx.Err() == nil {
 			logger.Error(err, "NRI plugin failed to be restarted", "maxAttempts", maxAttempts)
-			os.Exit(1)
+			asyncErr <- err
 		}
 	}()
 
 	// publish available resources
 	go plugin.PublishResources(ctx)
 
-	return plugin, nil
+	return plugin, asyncErr, nil
 }
 
 // Stop stops the CPUDriver.

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -207,7 +207,7 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 		}
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
 		updates = cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))
-		cp.claimTracker.Cleanup(logger, claimUIDs...)
+		cp.claimTracker.Cleanup(claimUIDs...)
 		entries = fmt.Sprintf("%d entries", len(updates))
 	}
 	logger.Info("StopContainer updates needed", "entries", entries)

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -64,7 +64,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 
 					allGuaranteedCPUs = allGuaranteedCPUs.Union(cpus)
 					claimUIDs = append(claimUIDs, uid)
-					cpuAllocationStore.AddResourceClaimAllocation(uid, cpus)
+					cpuAllocationStore.AddResourceClaimAllocation(logger, uid, cpus)
 				}
 				logger.Info("found guaranteed CPUs", "pod", klog.KObj(pod), "container", container.Name, "cpus", allGuaranteedCPUs.String())
 				state = store.NewContainerState(container.GetName(), containerUID, claimUIDs...)
@@ -203,7 +203,7 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 		// TODO: This workaround assumes that ResourceClaims are NOT shared across pods/containers. If claim sharing
 		// is supported in the future, this early release of CPUS will need an update.
 		for _, claimUID := range claimUIDs {
-			cp.cpuAllocationStore.RemoveResourceClaimAllocation(claimUID)
+			cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claimUID)
 		}
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
 		updates = cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -218,7 +218,7 @@ func (cp *CPUDriver) RemoveContainer(_ context.Context, pod *api.PodSandbox, ctr
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	if len(claimUIDs) > 0 {
 		// this serves only for debugging purposes. We should never get here
-		klog.Errorf("RemoveContainer spurious updates needed (unexpected, please file a bug): %v", cp.getSharedContainerUpdates(types.UID(ctr.GetId())))
+		klog.Infof("RemoveContainer spurious updates needed (unexpected, please file a bug): %v", cp.getSharedContainerUpdates(types.UID(ctr.GetId())))
 	}
 	return nil
 }

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/containerd/nri/pkg/api"
+	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -30,23 +31,22 @@ import (
 
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
 func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
-	klog.Infof("Synchronized state with the runtime (%d pods, %d containers)...",
-		len(pods), len(containers))
+	logger := klog.FromContext(ctx)
+	logger.Info("synchronized state with the runtime", "numPods", len(pods), "numContainers", len(containers))
 
 	cpuAllocationStore := store.NewCPUAllocation(cp.cpuTopology, cp.reservedCPUs)
 	podConfigStore := store.NewPodConfig()
 	var containerUpdates []*api.ContainerUpdate
 
-	logger := klog.FromContext(ctx)
 	for _, pod := range pods {
-		klog.Infof("Synchronize pod %s/%s UID %s", pod.Namespace, pod.Name, pod.Uid)
+		logger.Info("synchronize pod", "pod", klog.KObj(pod), "podUID", pod.Uid)
 		for _, container := range containers {
 			if container.PodSandboxId != pod.Id {
 				continue
 			}
-			claimAllocations, err := parseDRAEnvToClaimAllocations(container.Env)
+			claimAllocations, err := parseDRAEnvToClaimAllocations(logger, container.Env)
 			if err != nil {
-				klog.Errorf("Error parsing DRA env for container %s in pod %s/%s: %v", container.Name, pod.Namespace, pod.Name, err)
+				logger.Error(err, "error parsing DRA env for container", "pod", klog.KObj(pod), "container", container.Name)
 				continue
 			}
 			containerUID := types.UID(container.GetId())
@@ -66,7 +66,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 					claimUIDs = append(claimUIDs, uid)
 					cpuAllocationStore.AddResourceClaimAllocation(uid, cpus)
 				}
-				klog.Infof("Synchronize: Found guaranteed CPUs for pod %s/%s container %s with cpus: %v", pod.Namespace, pod.Name, container.Name, allGuaranteedCPUs.String())
+				logger.Info("found guaranteed CPUs", "pod", klog.KObj(pod), "container", container.Name, "cpus", allGuaranteedCPUs.String())
 				state = store.NewContainerState(container.GetName(), containerUID, claimUIDs...)
 
 				// Reconcile guaranteed container CPU mask.
@@ -86,18 +86,18 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	// Reconcile container CPU masks to handle cases where the NRI plugin might have crashed
 	// or restarted and missed updating the cgroup settings.
 	// See: https://github.com/containerd/nri/issues/282
-	sharedContainerUpdates := cp.getSharedContainerUpdates(types.UID(""))
+	sharedContainerUpdates := cp.getSharedContainerUpdates(logger, types.UID(""))
 	containerUpdates = append(containerUpdates, sharedContainerUpdates...)
 	return containerUpdates, nil
 }
 
-func parseDRAEnvToClaimAllocations(envs []string) (map[types.UID]cpuset.CPUSet, error) {
+func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types.UID]cpuset.CPUSet, error) {
 	allocations := make(map[types.UID]cpuset.CPUSet)
 	for _, env := range envs {
 		if !strings.HasPrefix(env, cdiEnvVarPrefix) {
 			continue
 		}
-		klog.Infof("Parsing DRA env entry: %q", env)
+		logger.V(4).Info("parsing DRA env entry", "env", env)
 		parts := strings.SplitN(env, "=", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("malformed DRA env entry %q", env)
@@ -121,11 +121,11 @@ func parseDRAEnvToClaimAllocations(envs []string) (map[types.UID]cpuset.CPUSet, 
 	return allocations, nil
 }
 
-func (cp *CPUDriver) getSharedContainerUpdates(excludeID types.UID) []*api.ContainerUpdate {
+func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) []*api.ContainerUpdate {
 	updates := []*api.ContainerUpdate{}
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	sharedCPUContainers := cp.podConfigStore.GetContainersWithSharedCPUs()
-	klog.Infof("Updating CPU allocation to: %v for containers without guaranteed CPUs", sharedCPUs.String())
+	logger.Info("updating CPU allocation for containers without guaranteed CPUs", "sharedCPUs", sharedCPUs.String())
 	for _, containerUID := range sharedCPUContainers {
 		if containerUID == excludeID {
 			// Skip the container being created as it is already covered in the container adjustment.
@@ -143,13 +143,14 @@ func (cp *CPUDriver) getSharedContainerUpdates(excludeID types.UID) []*api.Conta
 
 // CreateContainer handles container creation requests from the NRI.
 func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
-	klog.Infof("CreateContainer Pod:%s/%s PodUID:%s Container:%s ContainerID:%s", pod.Namespace, pod.Name, pod.Uid, ctr.Name, ctr.Id)
+	logger := klog.FromContext(ctx)
+	logger.Info("CreateContainer", "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	adjust := &api.ContainerAdjustment{}
 	var updates []*api.ContainerUpdate
 
-	claimAllocations, err := parseDRAEnvToClaimAllocations(ctr.Env)
+	claimAllocations, err := parseDRAEnvToClaimAllocations(logger, ctr.Env)
 	if err != nil {
-		klog.Errorf("Error parsing DRA env for container %s in pod %s/%s: %v", ctr.Name, pod.Namespace, pod.Name, err)
+		logger.Error(err, "error parsing DRA env for container", "pod", klog.KObj(pod), "container", ctr.Name)
 	}
 
 	containerId := types.UID(ctr.GetId())
@@ -161,13 +162,13 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		cp.podConfigStore.SetContainerState(podUID, state)
 
 		sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
-		klog.Infof("No guaranteed CPUs found in DRA env for pod %s/%s container %s. Using shared CPUs %s", pod.Namespace, pod.Name, ctr.Name, sharedCPUs.String())
+		logger.Info("no guaranteed CPUs found, using shared CPUs", "pod", klog.KObj(pod), "container", ctr.Name, "sharedCPUs", sharedCPUs.String())
 		adjust.SetLinuxCPUSetCPUs(sharedCPUs.String())
 	} else {
 		guaranteedCPUs := cpuset.New()
 		claimUIDs := []types.UID{}
 		for uid, cpus := range claimAllocations {
-			err := cp.claimTracker.SetOwner(klog.FromContext(ctx), uid, types.UID(pod.Uid), ctr.Name)
+			err := cp.claimTracker.SetOwner(logger, uid, types.UID(pod.Uid), ctr.Name)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -175,19 +176,20 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 			guaranteedCPUs = guaranteedCPUs.Union(cpus)
 			claimUIDs = append(claimUIDs, uid)
 		}
-		klog.Infof("Guaranteed CPUs found for pod:%s container:%s with cpus:%v", pod.Name, ctr.Name, guaranteedCPUs.String())
+		logger.Info("guaranteed CPUs found", "pod", klog.KObj(pod), "container", ctr.Name, "cpus", guaranteedCPUs.String())
 		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
 		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
 		cp.podConfigStore.SetContainerState(podUID, state)
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
-		updates = cp.getSharedContainerUpdates(containerId)
+		updates = cp.getSharedContainerUpdates(logger, containerId)
 	}
 
 	return adjust, updates, nil
 }
 
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
-	klog.Infof("StopContainer Pod:%s/%s PodUID:%s Container:%s ContainerID:%s", pod.Namespace, pod.Name, pod.Uid, ctr.Name, ctr.Id)
+	logger := klog.FromContext(ctx)
+	logger.Info("StopContainer", "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	updates := []*api.ContainerUpdate{}
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	entries := "none"
@@ -204,21 +206,22 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 			cp.cpuAllocationStore.RemoveResourceClaimAllocation(claimUID)
 		}
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
-		updates = cp.getSharedContainerUpdates(types.UID(ctr.GetId()))
-		cp.claimTracker.Cleanup(klog.FromContext(ctx), claimUIDs...)
+		updates = cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))
+		cp.claimTracker.Cleanup(logger, claimUIDs...)
 		entries = fmt.Sprintf("%d entries", len(updates))
 	}
-	klog.Infof("StopContainer updates needed: %s", entries)
+	logger.Info("StopContainer updates needed", "entries", entries)
 	return updates, nil
 }
 
 // RemoveContainer handles container removal requests from the NRI.
-func (cp *CPUDriver) RemoveContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) error {
-	klog.Infof("RemoveContainer Pod:%s/%s PodUID:%s Container:%s ContainerID:%s", pod.Namespace, pod.Name, pod.Uid, ctr.Name, ctr.Id)
+func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
+	logger := klog.FromContext(ctx)
+	logger.Info("RemoveContainer", "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	if len(claimUIDs) > 0 {
 		// this serves only for debugging purposes. We should never get here
-		klog.Infof("RemoveContainer spurious updates needed (unexpected, please file a bug): %v", cp.getSharedContainerUpdates(types.UID(ctr.GetId())))
+		logger.Info("RemoveContainer spurious updates needed (unexpected, please file a bug)", "updates", cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId())))
 	}
 	return nil
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/containerd/nri/pkg/api"
+	"github.com/go-logr/logr/testr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"github.com/stretchr/testify/require"
@@ -79,7 +80,8 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			allocations, err := parseDRAEnvToClaimAllocations(tc.envs)
+			logger := testr.New(t)
+			allocations, err := parseDRAEnvToClaimAllocations(logger, tc.envs)
 			if tc.expectedErrorContains != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectedErrorContains)

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -165,7 +165,7 @@ func TestCreateContainer(t *testing.T) {
 			}(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				store.AddResourceClaimAllocation(types.UID(claimUID), cpuset.New(2, 3))
+				store.AddResourceClaimAllocation(testr.New(t), types.UID(claimUID), cpuset.New(2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),

--- a/pkg/store/claim_tracker.go
+++ b/pkg/store/claim_tracker.go
@@ -79,13 +79,6 @@ func (ctk *ClaimTracker) SetOwner(lh logr.Logger, claimUID, podUID k8stypes.UID,
 	return nil
 }
 
-func (ctk *ClaimTracker) FindOwner(lh logr.Logger, claimUID k8stypes.UID) (OwnerIdent, bool) {
-	ctk.mu.Lock()
-	defer ctk.mu.Unlock()
-	owner, ok := ctk.ownerByClaimUID[claimUID]
-	return owner, ok
-}
-
 func (ctk *ClaimTracker) Cleanup(lh logr.Logger, claimUIDs ...k8stypes.UID) {
 	ctk.mu.Lock()
 	defer ctk.mu.Unlock()

--- a/pkg/store/claim_tracker.go
+++ b/pkg/store/claim_tracker.go
@@ -79,7 +79,7 @@ func (ctk *ClaimTracker) SetOwner(lh logr.Logger, claimUID, podUID k8stypes.UID,
 	return nil
 }
 
-func (ctk *ClaimTracker) Cleanup(lh logr.Logger, claimUIDs ...k8stypes.UID) {
+func (ctk *ClaimTracker) Cleanup(claimUIDs ...k8stypes.UID) {
 	ctk.mu.Lock()
 	defer ctk.mu.Unlock()
 	for _, claimUID := range claimUIDs {

--- a/pkg/store/claim_tracker.go
+++ b/pkg/store/claim_tracker.go
@@ -56,7 +56,7 @@ func NewClaimTracker() *ClaimTracker {
 	}
 }
 
-func (ctk *ClaimTracker) SetOwner(lh logr.Logger, claimUID, podUID k8stypes.UID, containerName string) error {
+func (ctk *ClaimTracker) SetOwner(logger logr.Logger, claimUID, podUID k8stypes.UID, containerName string) error {
 	curIdent := OwnerIdent{
 		PodUID:        podUID,
 		ContainerName: containerName,
@@ -66,7 +66,7 @@ func (ctk *ClaimTracker) SetOwner(lh logr.Logger, claimUID, podUID k8stypes.UID,
 	owner, ok := ctk.ownerByClaimUID[claimUID]
 	if ok {
 		if owner.Equal(curIdent) {
-			lh.V(2).Info("claim bound again to the same owner", "claimUID", claimUID, "podUID", podUID, "containerName", containerName)
+			logger.V(2).Info("claim bound again to the same owner", "claimUID", claimUID, "podUID", podUID, "containerName", containerName)
 			return nil // not wrong, not suspicious enough to bail out
 		}
 		return AlreadyOwned{
@@ -75,7 +75,7 @@ func (ctk *ClaimTracker) SetOwner(lh logr.Logger, claimUID, podUID k8stypes.UID,
 		}
 	}
 	ctk.ownerByClaimUID[claimUID] = curIdent
-	lh.V(4).Info("claim bound", "claimUID", claimUID, "podUID", podUID, "containerName", containerName)
+	logger.V(4).Info("claim bound", "claimUID", claimUID, "podUID", podUID, "containerName", containerName)
 	return nil
 }
 

--- a/pkg/store/claim_tracker_test.go
+++ b/pkg/store/claim_tracker_test.go
@@ -185,6 +185,6 @@ func TestLen(t *testing.T) {
 	}
 	require.Equal(t, bnd.Len(), len(bindings))
 
-	bnd.Cleanup(logger, "claim-123", "claim-456", "claim-789")
+	bnd.Cleanup("claim-123", "claim-456", "claim-789")
 	require.Equal(t, bnd.Len(), 0)
 }

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -19,9 +19,9 @@ package store
 import (
 	"sync"
 
+	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
 )
 
@@ -52,7 +52,7 @@ func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUS
 }
 
 // AddResourceClaimAllocation adds a new resource claim allocation to the store.
-func (s *CPUAllocation) AddResourceClaimAllocation(claimUID types.UID, cpus cpuset.CPUSet) {
+func (s *CPUAllocation) AddResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if old, ok := s.resourceClaimAllocations[claimUID]; ok {
@@ -60,17 +60,17 @@ func (s *CPUAllocation) AddResourceClaimAllocation(claimUID types.UID, cpus cpus
 	}
 	s.resourceClaimAllocations[claimUID] = cpus
 	s.allocatedCPUs = s.allocatedCPUs.Union(cpus)
-	klog.Infof("Added allocation for resource claim %s: CPUs %s", claimUID, cpus.String())
+	logger.Info("added allocation for resource claim", "claimUID", claimUID, "cpus", cpus.String())
 }
 
 // RemoveResourceClaimAllocation removes a resource claim allocation from the store.
-func (s *CPUAllocation) RemoveResourceClaimAllocation(claimUID types.UID) {
+func (s *CPUAllocation) RemoveResourceClaimAllocation(logger logr.Logger, claimUID types.UID) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if cpus, ok := s.resourceClaimAllocations[claimUID]; ok {
 		delete(s.resourceClaimAllocations, claimUID)
 		s.allocatedCPUs = s.allocatedCPUs.Difference(cpus)
-		klog.Infof("Removed allocation for resource claim %s", claimUID)
+		logger.Info("removed allocation for resource claim", "claimUID", claimUID)
 	}
 }
 

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -71,27 +73,29 @@ func TestNewCPUAllocation(t *testing.T) {
 }
 
 func TestCPUAllocationResourceClaimAllocation(t *testing.T) {
+	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	store := newTestCPUAllocation(allCPUs, cpuset.New())
 	claimUID := types.UID("claim-uid-1")
 	cpus := cpuset.New(0, 1)
 
 	// Add allocation
-	store.AddResourceClaimAllocation(claimUID, cpus)
+	store.AddResourceClaimAllocation(logger, claimUID, cpus)
 	gotCPUs, ok := store.GetResourceClaimAllocation(claimUID)
 	require.True(t, ok)
 	require.True(t, cpus.Equals(gotCPUs))
 
 	// Remove allocation
-	store.RemoveResourceClaimAllocation(claimUID)
+	store.RemoveResourceClaimAllocation(logger, claimUID)
 	_, ok = store.GetResourceClaimAllocation(claimUID)
 	require.False(t, ok)
 
 	// Remove non-existent allocation
-	store.RemoveResourceClaimAllocation(types.UID("non-existent"))
+	store.RemoveResourceClaimAllocation(logger, types.UID("non-existent"))
 }
 
 func TestCPUAllocationGetSharedCPUs(t *testing.T) {
+	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	reserved := cpuset.New(0)
 	store := newTestCPUAllocation(allCPUs, reserved)
@@ -103,13 +107,13 @@ func TestCPUAllocationGetSharedCPUs(t *testing.T) {
 	// With allocations
 	claimUID1 := types.UID("claim-uid-1")
 	cpus1 := cpuset.New(1, 2)
-	store.AddResourceClaimAllocation(claimUID1, cpus1)
+	store.AddResourceClaimAllocation(logger, claimUID1, cpus1)
 	expectedShared := available.Difference(cpus1)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 
 	claimUID2 := types.UID("claim-uid-2")
 	cpus2 := cpuset.New(3, 4)
-	store.AddResourceClaimAllocation(claimUID2, cpus2)
+	store.AddResourceClaimAllocation(logger, claimUID2, cpus2)
 	expectedShared = expectedShared.Difference(cpus2)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 }
@@ -147,11 +151,12 @@ func TestAddResourceClaimAllocationRepeatedCalls(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			logger := testr.New(t)
 			store := newTestCPUAllocation(allCPUs, cpuset.New())
 			claimUID := types.UID("claim-uid-1")
 
-			store.AddResourceClaimAllocation(claimUID, tc.firstCPUs)
-			store.AddResourceClaimAllocation(claimUID, tc.secondCPUs)
+			store.AddResourceClaimAllocation(logger, claimUID, tc.firstCPUs)
+			store.AddResourceClaimAllocation(logger, claimUID, tc.secondCPUs)
 
 			gotCPUs, ok := store.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
@@ -162,25 +167,26 @@ func TestAddResourceClaimAllocationRepeatedCalls(t *testing.T) {
 }
 
 func TestCPUAllocationStoreCacheConsistency(t *testing.T) {
+	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	store := newTestCPUAllocation(allCPUs, cpuset.New())
 
-	store.AddResourceClaimAllocation("claim-1", cpuset.New(0, 1))
-	store.AddResourceClaimAllocation("claim-2", cpuset.New(2, 3))
-	store.AddResourceClaimAllocation("claim-3", cpuset.New(4, 5))
+	store.AddResourceClaimAllocation(logger, "claim-1", cpuset.New(0, 1))
+	store.AddResourceClaimAllocation(logger, "claim-2", cpuset.New(2, 3))
+	store.AddResourceClaimAllocation(logger, "claim-3", cpuset.New(4, 5))
 
 	expectedShared := cpuset.New(6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 
-	store.RemoveResourceClaimAllocation("claim-2")
+	store.RemoveResourceClaimAllocation(logger, "claim-2")
 	expectedShared = cpuset.New(2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 
-	store.RemoveResourceClaimAllocation("claim-1")
+	store.RemoveResourceClaimAllocation(logger, "claim-1")
 	expectedShared = cpuset.New(0, 1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 
-	store.RemoveResourceClaimAllocation("claim-3")
+	store.RemoveResourceClaimAllocation(logger, "claim-3")
 	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
 }
 
@@ -231,7 +237,7 @@ func BenchmarkGetSharedCPUs(b *testing.B) {
 		b.Run(tc.name+"/optimized", func(b *testing.B) {
 			store := NewCPUAllocation(topo, cpuset.New())
 			for claimUID, cpus := range allocations {
-				store.AddResourceClaimAllocation(claimUID, cpus)
+				store.AddResourceClaimAllocation(logr.Discard(), claimUID, cpus)
 			}
 
 			b.ResetTimer()

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -35,11 +35,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
 	"k8s.io/utils/ptr"
 )
 
 func TestE2E(t *testing.T) {
+	klog.SetLoggerWithOptions(ginkgo.GinkgoLogr, klog.ContextualLogger(true))
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "DRA CPU Driver E2E Suite")
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -57,21 +57,21 @@ func BeFailedToCreate(fxt *fixture.Fixture) types.GomegaMatcher {
 		if actual == nil {
 			return false, errors.New("nil Pod")
 		}
-		lh := fxt.Log.WithValues("podUID", actual.UID, "namespace", actual.Namespace, "name", actual.Name)
+		logger := fxt.Log.WithValues("podUID", actual.UID, "namespace", actual.Namespace, "name", actual.Name)
 		if actual.Status.Phase != v1.PodPending {
-			lh.Info("unexpected phase", "phase", actual.Status.Phase)
+			logger.Info("unexpected phase", "phase", actual.Status.Phase)
 			return false, nil
 		}
 		cntSt := findWaitingContainerStatus(actual.Status.ContainerStatuses)
 		if cntSt == nil {
-			lh.Info("no container in waiting state")
+			logger.Info("no container in waiting state")
 			return false, nil
 		}
 		if cntSt.State.Waiting.Reason != reasonCreateContainerError {
-			lh.Info("container waiting for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Waiting.Reason)
+			logger.Info("container waiting for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Waiting.Reason)
 			return false, nil
 		}
-		lh.Info("container creation error", "containerName", cntSt.Name)
+		logger.Info("container creation error", "containerName", cntSt.Name)
 		return true, nil
 	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} was not in failed phase")
 }


### PR DESCRIPTION
Begin plumbing of contextual logging support. In this PR, we set up the initial plumbing:

- port from unstructured logging to structured logging
- get loggers from the context, respecting the call trees. Functions which don't obviously need a context get a logger instance instead; we don't add a context just to carry a logger
- use testr.New (https://github.com/go-logr/logr/tree/master/testr) in unit tests, to reroute the logging uniformly
- if tests use ginkgo, integrate GinkgoLogr instead
- preserve as much as possible the log structure and content, but there's no 1:1 translation from unstructured logging
- except for egregious cases (klog.Error(nil, ...)) never mutate logging verbosity
- don't remove log lines

NOTE: we don't really exploit the "contextual" part just yet. This will come in a followup PR
NOTE: we don't have means to prevent future PRs accidentally reintroduce unstructured logging; we will explore options (borrowing from k/k) in a followup PR