### PR TITLE
Skip CPU allocation when available CPU pool is empty

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -327,6 +327,11 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			logger.Info("NUMA node CPU availability", "numaNodeID", numaNodeID, "numaCPUs", numaCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 		}
 
+		if availableCPUsForDevice.Size() == 0 {
+			logger.V(2).Info("No available CPUs for device, skipping allocation", "device", alloc.Device)
+			continue
+		}
+
 		cur, err := cpumanager.TakeByTopologyNUMAPacked(logger, topo, availableCPUsForDevice, int(claimCPUCount), cpumanager.CPUSortingStrategyPacked, true)
 		if err != nil {
 			return kubeletplugin.PrepareResult{Err: err}
@@ -336,8 +341,19 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 	}
 
 	if cpuAssignment.Size() == 0 {
-		logger.V(5).Info("claim has no CPU allocations for this driver", "claim", klog.KObj(claim))
-		return kubeletplugin.PrepareResult{}
+		logger.V(2).Info("No CPUs assigned for claim, returning devices without cpuset", "claim", klog.KObj(claim))
+		var preparedDevices []kubeletplugin.Device
+		for _, allocResult := range claim.Status.Allocation.Devices.Results {
+			if allocResult.Driver != cp.driverName {
+				continue
+			}
+			preparedDevices = append(preparedDevices, kubeletplugin.Device{
+				PoolName:   allocResult.Pool,
+				DeviceName: allocResult.Device,
+				Requests:   []string{allocResult.Request},
+			})
+		}
+		return kubeletplugin.PrepareResult{Devices: preparedDevices}
 	}
 
 	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, cpuAssignment)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `cpuManagerPolicy: static` is active, the kubelet CPU manager owns all non-reserved CPUs. The DRA CPU driver's shared pool is empty, causing `TakeByTopologyNUMAPacked` to fail with "not enough cpus available to satisfy request."

This fix:
1. Skips the allocation attempt when `availableCPUsForDevice` is empty
2. When no CPUs are assigned for the entire claim, returns a `PrepareResult` with Device entries (pool, device, request) but no CDI cpuset injection

The NRI `CreateContainer` hook already handles missing DRA cpuset env vars by falling through to the shared CPU pool. The kubelet CPU manager's cgroup cpuset takes precedence for dedicated pods.

This allows the DRA CPU driver to coexist with `cpuManagerPolicy: static` without failing prepare for pods that have DRA CPU claims used purely as topology markers for `matchAttribute` alignment.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes-sigs/dra-driver-cpu/issues/134

#### Does this PR introduce a user-facing change?

```release-note
Fix DRA CPU driver to skip allocation when kubelet CPU manager owns all CPUs (cpuManagerPolicy: static).
```