### PR TITLE
implement contextual logging

### DIFF
--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -3,7 +3,7 @@
 ## picking a verbosity level
 
 V(0): high-signal operational logs and errors always visible at default verbosity
-V(2): normal operation, important decisions, summary
+V(2): normal operation, important decisions, summary, container lifecycle
 V(4): allocation internals, fine details about decisions
 V(6): debug messages, very fine details, mostly for developers
 

--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -1,0 +1,46 @@
+# logging guidelines
+
+## picking a verbosity level
+
+V(0): high-signal operational logs and errors always visible at default verbosity
+V(2): normal operation, important decisions, summary
+V(4): allocation internals, fine details about decisions
+V(6): debug messages, very fine details, mostly for developers
+
+V(7) or more is reserved for future usage.
+
+## the opID tag
+
+`opID` is a cheap trace identifier similar in spirit to OTEL's
+(OTEL=OpenTelemetry) `trace_id`. Same concept, applied to logs:
+a unique identifier constantly
+logged in all the entries pertaining a flow, which trivially
+enable to extract all the logs with `grep`.
+
+Other examples sit in `test/e2e/contextual_logging_test.go`
+and in `test/pkg/logcheck/`.
+
+We reimplement because the concept is super cheap and super useful
+for logs, even without telemetry implementation.
+
+If in the future we integrate with OTEL, we will add OTEL's
+identifier in addition to the current opID for a transitional
+period, then we will remove our homegrown solution.
+
+### sizing opID
+
+Since we use it everywhere, we need to minimize the log noise,
+so we set the value of `opIDLen` to "only" 8 hex char.
+We evaluate this value to still provide plenty of
+randomness for a *local only* (not distributed) identifier.
+
+Here's the back-of-envelope math:
+
+- 12 hex chars = 48 bits → ~281 trillion values
+- 8 hex chars = 32 bits → ~4.3 billion values
+
+The probability of at least one collision among n operations is roughly n\*\*2/(2N).
+With 8 chars:
+
+- 1000 operations: ~0.01% collision probability.
+- 10000 operations: ~1.2% collision probability.

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -57,7 +57,7 @@ const (
 
 // createGroupedCPUDeviceSlices creates Device objects based on the CPU topology, grouped by a specific criteria.
 func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resourceapi.Device {
-	logger.Info("creating grouped CPU devices", "groupBy", cp.cpuDeviceGroupBy)
+	logger.Info("creating grouped CPU devices")
 	var devices []resourceapi.Device
 
 	topo := cp.cpuTopology
@@ -224,7 +224,8 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 
 // PublishResources publishes ResourceSlice for CPU resources.
 func (cp *CPUDriver) PublishResources(ctx context.Context) {
-	logger := klog.FromContext(ctx)
+	logger := klog.FromContext(ctx).WithValues("deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
+	ctx = klog.NewContext(ctx, logger)
 	logger.Info("publishing resources")
 
 	var deviceChunks [][]resourceapi.Device
@@ -269,12 +270,13 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 	}
 
 	for _, claim := range claims {
+		cLogger := logger.WithValues("claim", klog.KObj(claim), "claimUID", claim.UID)
 		if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
-			logger.Info("claim is for a grouped resource", "claim", klog.KObj(claim))
-			result[claim.UID] = cp.prepareGroupedResourceClaim(logger, claim)
+			cLogger.Info("claim is for a grouped resource")
+			result[claim.UID] = cp.prepareGroupedResourceClaim(cLogger, claim)
 		} else {
-			logger.Info("claim is for an individual resource", "claim", klog.KObj(claim))
-			result[claim.UID] = cp.prepareResourceClaim(logger, claim)
+			cLogger.Info("claim is for an individual resource")
+			result[claim.UID] = cp.prepareResourceClaim(cLogger, claim)
 		}
 	}
 	return result, nil
@@ -285,7 +287,7 @@ func getCDIDeviceName(uid types.UID) string {
 }
 
 func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger.Info("preparing grouped resource claim", "claim", klog.KObj(claim))
+	logger.Info("preparing grouped resource claim")
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -303,7 +305,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		if quantity, ok := alloc.ConsumedCapacity[cpuResourceQualifiedName]; ok {
 			count := quantity.Value()
 			claimCPUCount = count
-			logger.Info("found CPU request", "numCPUs", count, "device", alloc.Device, "claim", klog.KObj(claim))
+			logger.Info("found CPU request", "numCPUs", count, "device", alloc.Device)
 		}
 
 		topo := cp.cpuTopology
@@ -336,7 +338,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 	}
 
 	if cpuAssignment.Size() == 0 {
-		logger.V(5).Info("claim has no CPU allocations for this driver", "claim", klog.KObj(claim))
+		logger.V(5).Info("claim has no CPU allocations for this driver")
 		return kubeletplugin.PrepareResult{}
 	}
 
@@ -371,7 +373,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 }
 
 func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger.Info("preparing individual resource claim", "claim", klog.KObj(claim))
+	logger.Info("preparing individual resource claim")
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -394,7 +396,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 	}
 
 	if len(claimCPUIDs) == 0 {
-		logger.V(5).Info("claim has no CPU allocations for this driver", "claim", klog.KObj(claim))
+		logger.V(5).Info("claim has no CPU allocations for this driver")
 		return kubeletplugin.PrepareResult{}
 	}
 
@@ -446,11 +448,13 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 	}
 
 	for _, claim := range claims {
-		logger.Info("unpreparing resource claim", "claim", claim)
-		err := cp.unprepareResourceClaim(logger, claim)
+		// note kubeletplugin.NamespacedObject doesn't implement KMetadata
+		cLogger := logger.WithValues("claim", claim.String(), "claimUID", claim.UID)
+		cLogger.Info("unpreparing resource claim")
+		err := cp.unprepareResourceClaim(cLogger, claim)
 		result[claim.UID] = err
 		if err != nil {
-			logger.Error(err, "error unpreparing resources for claim", "namespace", claim.Namespace, "name", claim.Name)
+			cLogger.Error(err, "error unpreparing resources for claim")
 		}
 	}
 	return result, nil

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -227,7 +227,8 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 	logger := klog.FromContext(ctx).WithValues("deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
 	ctx = klog.NewContext(ctx, logger)
 
-	logger.Info("publishing resources")
+	logger.V(4).Info("begin: publishing resources")
+	defer logger.V(4).Info("end: publishing resources")
 
 	var deviceChunks [][]resourceapi.Device
 	if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
@@ -263,7 +264,8 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
 	logger := klog.FromContext(ctx).WithValues("batchID", generateShortID(batchIDLen))
 
-	logger.Info("preparing resource claims", "numClaims", len(claims))
+	logger.V(4).Info("begin: preparing resource claims", "numClaims", len(claims))
+	defer logger.V(4).Info("end: preparing resource claims", "numClaims", len(claims))
 
 	result := make(map[types.UID]kubeletplugin.PrepareResult)
 
@@ -442,7 +444,8 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
 	logger := klog.FromContext(ctx).WithValues("batchID", generateShortID(batchIDLen))
 
-	logger.Info("unpreparing resource claims", "numClaims", len(claims))
+	logger.V(4).Info("begin: unpreparing resource claims", "numClaims", len(claims))
+	defer logger.V(4).Info("end: unpreparing resource claims", "numClaims", len(claims))
 
 	result := make(map[types.UID]error)
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -289,7 +289,7 @@ func getCDIDeviceName(uid types.UID) string {
 }
 
 func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger.V(2).Info("preparing grouped resource claim")
+	logger.V(4).Info("preparing grouped resource claim")
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -336,7 +336,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			return kubeletplugin.PrepareResult{Err: err}
 		}
 		cpuAssignment = cpuAssignment.Union(cur)
-		logger.V(4).Info("CPU assignment for device", "device", alloc.Device, "assigned", cur.String(), "allAssigned", cpuAssignment.String())
+		logger.V(2).Info("CPU assignment for device", "device", alloc.Device, "assigned", cur.String(), "allAssigned", cpuAssignment.String())
 	}
 
 	if cpuAssignment.Size() == 0 {
@@ -368,14 +368,14 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		preparedDevices = append(preparedDevices, preparedDevice)
 	}
 
-	logger.V(4).Info("prepared devices for claim", "preparedDevices", preparedDevices)
+	logger.V(4).Info("prepared devices for grouped resource claim", "preparedDevices", preparedDevices)
 	return kubeletplugin.PrepareResult{
 		Devices: preparedDevices,
 	}
 }
 
 func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger.V(2).Info("preparing individual resource claim")
+	logger.V(4).Info("preparing individual resource claim")
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -433,6 +433,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		preparedDevices = append(preparedDevices, preparedDevice)
 	}
 
+	logger.V(4).Info("prepared devices for individual resource claim", "preparedDevices", preparedDevices)
 	return kubeletplugin.PrepareResult{
 		Devices: preparedDevices,
 	}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -57,7 +57,7 @@ const (
 
 // createGroupedCPUDeviceSlices creates Device objects based on the CPU topology, grouped by a specific criteria.
 func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resourceapi.Device {
-	logger.Info("creating grouped CPU devices")
+	logger.V(4).Info("creating grouped CPU devices")
 	var devices []resourceapi.Device
 
 	topo := cp.cpuTopology
@@ -276,10 +276,8 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 	for _, claim := range claims {
 		cLogger := logger.WithValues("claim", klog.KObj(claim), "claimUID", claim.UID)
 		if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
-			cLogger.Info("claim is for a grouped resource")
 			result[claim.UID] = cp.prepareGroupedResourceClaim(cLogger, claim)
 		} else {
-			cLogger.Info("claim is for an individual resource")
 			result[claim.UID] = cp.prepareResourceClaim(cLogger, claim)
 		}
 	}
@@ -291,7 +289,7 @@ func getCDIDeviceName(uid types.UID) string {
 }
 
 func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger.Info("preparing grouped resource claim")
+	logger.V(2).Info("preparing grouped resource claim")
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -309,7 +307,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		if quantity, ok := alloc.ConsumedCapacity[cpuResourceQualifiedName]; ok {
 			count := quantity.Value()
 			claimCPUCount = count
-			logger.Info("found CPU request", "numCPUs", count, "device", alloc.Device)
+			logger.V(4).Info("found CPU request", "numCPUs", count, "device", alloc.Device)
 		}
 
 		topo := cp.cpuTopology
@@ -322,7 +320,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			}
 			socketCPUs := topo.CPUDetails.CPUsInSockets(socketID)
 			availableCPUsForDevice = sharedCPUs.Difference(cpuAssignment).Intersection(socketCPUs)
-			logger.Info("socket CPU availability", "socketID", socketID, "socketCPUs", socketCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
+			logger.V(4).Info("socket CPU availability", "socketID", socketID, "socketCPUs", socketCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 		} else { // numanode
 			numaNodeID, ok := cp.deviceNameToNUMANodeID[alloc.Device]
 			if !ok {
@@ -330,7 +328,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			}
 			numaCPUs := topo.CPUDetails.CPUsInNUMANodes(numaNodeID)
 			availableCPUsForDevice = sharedCPUs.Difference(cpuAssignment).Intersection(numaCPUs)
-			logger.Info("NUMA node CPU availability", "numaNodeID", numaNodeID, "numaCPUs", numaCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
+			logger.V(4).Info("NUMA node CPU availability", "numaNodeID", numaNodeID, "numaCPUs", numaCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 		}
 
 		cur, err := cpumanager.TakeByTopologyNUMAPacked(logger, topo, availableCPUsForDevice, int(claimCPUCount), cpumanager.CPUSortingStrategyPacked, true)
@@ -338,11 +336,11 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			return kubeletplugin.PrepareResult{Err: err}
 		}
 		cpuAssignment = cpuAssignment.Union(cur)
-		logger.Info("CPU assignment for device", "device", alloc.Device, "assigned", cur.String(), "allAssigned", cpuAssignment.String())
+		logger.V(4).Info("CPU assignment for device", "device", alloc.Device, "assigned", cur.String(), "allAssigned", cpuAssignment.String())
 	}
 
 	if cpuAssignment.Size() == 0 {
-		logger.V(5).Info("claim has no CPU allocations for this driver")
+		logger.V(6).Info("claim has no CPU allocations for this driver")
 		return kubeletplugin.PrepareResult{}
 	}
 
@@ -355,7 +353,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 	}
 
 	qualifiedName := cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName)
-	logger.Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
+	logger.V(6).Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
 	preparedDevices := []kubeletplugin.Device{}
 	for _, allocResult := range claim.Status.Allocation.Devices.Results {
 		if allocResult.Driver != cp.driverName {
@@ -370,14 +368,14 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		preparedDevices = append(preparedDevices, preparedDevice)
 	}
 
-	logger.Info("prepared devices for claim", "preparedDevices", preparedDevices)
+	logger.V(4).Info("prepared devices for claim", "preparedDevices", preparedDevices)
 	return kubeletplugin.PrepareResult{
 		Devices: preparedDevices,
 	}
 }
 
 func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
-	logger.Info("preparing individual resource claim")
+	logger.V(2).Info("preparing individual resource claim")
 
 	if claim.Status.Allocation == nil {
 		return kubeletplugin.PrepareResult{
@@ -400,7 +398,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 	}
 
 	if len(claimCPUIDs) == 0 {
-		logger.V(5).Info("claim has no CPU allocations for this driver")
+		logger.V(6).Info("claim has no CPU allocations for this driver")
 		return kubeletplugin.PrepareResult{}
 	}
 
@@ -421,7 +419,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 	}
 
 	qualifiedName := cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName)
-	logger.Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
+	logger.V(6).Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
 	preparedDevices := []kubeletplugin.Device{}
 	for _, allocResult := range claim.Status.Allocation.Devices.Results {
 		if allocResult.Driver != cp.driverName {
@@ -456,7 +454,7 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 	for _, claim := range claims {
 		// note kubeletplugin.NamespacedObject doesn't implement KMetadata
 		cLogger := logger.WithValues("claim", claim.String(), "claimUID", claim.UID)
-		cLogger.Info("unpreparing resource claim")
+		cLogger.V(2).Info("unpreparing resource claim")
 		err := cp.unprepareResourceClaim(cLogger, claim)
 		result[claim.UID] = err
 		if err != nil {

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -224,7 +224,7 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 
 // PublishResources publishes ResourceSlice for CPU resources.
 func (cp *CPUDriver) PublishResources(ctx context.Context) {
-	logger := klog.FromContext(ctx).WithValues("deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
+	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
 	ctx = klog.NewContext(ctx, logger)
 
 	logger.V(4).Info("begin: publishing resources")
@@ -262,7 +262,7 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 
 // PrepareResourceClaims is called by the kubelet to prepare a resource claim.
 func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
-	logger := klog.FromContext(ctx).WithValues("batchID", generateShortID(batchIDLen))
+	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
 
 	logger.V(4).Info("begin: preparing resource claims", "numClaims", len(claims))
 	defer logger.V(4).Info("end: preparing resource claims", "numClaims", len(claims))
@@ -440,7 +440,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 
 // UnprepareResourceClaims is called by the kubelet to unprepare the resources for a claim.
 func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
-	logger := klog.FromContext(ctx).WithValues("batchID", generateShortID(batchIDLen))
+	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
 
 	logger.V(4).Info("begin: unpreparing resource claims", "numClaims", len(claims))
 	defer logger.V(4).Info("end: unpreparing resource claims", "numClaims", len(claims))

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -226,6 +226,7 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 func (cp *CPUDriver) PublishResources(ctx context.Context) {
 	logger := klog.FromContext(ctx).WithValues("deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
 	ctx = klog.NewContext(ctx, logger)
+
 	logger.Info("publishing resources")
 
 	var deviceChunks [][]resourceapi.Device
@@ -260,7 +261,8 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 
 // PrepareResourceClaims is called by the kubelet to prepare a resource claim.
 func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
-	logger := klog.FromContext(ctx)
+	logger := klog.FromContext(ctx).WithValues("batchID", generateShortID(batchIDLen))
+
 	logger.Info("preparing resource claims", "numClaims", len(claims))
 
 	result := make(map[types.UID]kubeletplugin.PrepareResult)
@@ -438,7 +440,8 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 
 // UnprepareResourceClaims is called by the kubelet to unprepare the resources for a claim.
 func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
-	logger := klog.FromContext(ctx)
+	logger := klog.FromContext(ctx).WithValues("batchID", generateShortID(batchIDLen))
+
 	logger.Info("unpreparing resource claims", "numClaims", len(claims))
 
 	result := make(map[types.UID]error)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -156,6 +156,8 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	}
 
 	logger := klog.FromContext(ctx)
+	logger = logger.WithValues("driver", config.DriverName)
+	ctx = klog.NewContext(ctx, logger)
 
 	cdiMgr, err := NewCdiManager(logger, config.DriverName)
 	if err != nil {
@@ -170,7 +172,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		// https://github.com/containerd/nri/pull/173
 		// Otherwise it silently exits the program
 		stub.WithOnClose(func() {
-			logger.Info("NRI plugin closed", "driver", config.DriverName)
+			logger.Info("NRI plugin closed")
 		}),
 	}
 	stub, err := stub.New(plugin, nriOpts...)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"time"
@@ -54,6 +55,8 @@ const (
 	// maxAttempts indicates the number of times the driver will try to recover itself before failing
 	maxAttempts = 5
 )
+
+const batchIDLen = 12
 
 // KubeletPlugin is an interface that describes the methods used from kubeletplugin.Helper.
 type KubeletPlugin interface {
@@ -223,4 +226,14 @@ func runNRIPluginWithRetry(ctx context.Context, plugin nriRunner, maxAttempts in
 		}
 	}
 	return fmt.Errorf("NRI plugin failed for %d times to be restarted", maxAttempts)
+}
+
+// generateShortID generates a non-crypto safe unique ID in cases on which a full UUID would be a overkill.
+func generateShortID(length int) string {
+	const hexDigits = "0123456789abcdef"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = hexDigits[rand.IntN(len(hexDigits))] //nolint:gosec
+	}
+	return string(b)
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -56,7 +56,7 @@ const (
 	maxAttempts = 5
 )
 
-const batchIDLen = 12
+const opIDLen = 8
 
 // KubeletPlugin is an interface that describes the methods used from kubeletplugin.Helper.
 type KubeletPlugin interface {

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -98,4 +99,45 @@ func TestRunNRIPluginWithRetry_SuccessfulRunNoRetry(t *testing.T) {
 	err := runNRIPluginWithRetry(ctx, runner, maxAttempts)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Equal(t, int32(1), runner.calls.Load())
+}
+
+func TestGenerateShortID(t *testing.T) {
+	testCases := []struct {
+		name   string
+		length int
+	}{
+		{name: "zero length", length: 0},
+		{name: "single char", length: 1},
+		{name: "batchIDLen", length: batchIDLen},
+		{name: "large", length: 64},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := generateShortID(tc.length)
+			require.Len(t, id, tc.length)
+			if tc.length == 0 {
+				return
+			}
+			require.True(t, isHex(id))
+		})
+	}
+}
+
+func TestGenerateShortIDUnique(t *testing.T) {
+	a := generateShortID(batchIDLen)
+	b := generateShortID(batchIDLen)
+	require.NotEqual(t, a, b)
+}
+
+func isHex(s string) bool {
+	s = strings.ToLower(s)
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b-'0' < 10 || b-'a' < 6 {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -108,7 +108,7 @@ func TestGenerateShortID(t *testing.T) {
 	}{
 		{name: "zero length", length: 0},
 		{name: "single char", length: 1},
-		{name: "batchIDLen", length: batchIDLen},
+		{name: "opIDLen", length: opIDLen},
 		{name: "large", length: 64},
 	}
 
@@ -125,8 +125,8 @@ func TestGenerateShortID(t *testing.T) {
 }
 
 func TestGenerateShortIDUnique(t *testing.T) {
-	a := generateShortID(batchIDLen)
-	b := generateShortID(batchIDLen)
+	a := generateShortID(opIDLen)
+	b := generateShortID(opIDLen)
 	require.NotEqual(t, a, b)
 }
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -39,14 +39,17 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	var containerUpdates []*api.ContainerUpdate
 
 	for _, pod := range pods {
-		logger.Info("synchronize pod", "pod", klog.KObj(pod), "podUID", pod.Uid)
+		pLogger := logger.WithValues("pod", klog.KObj(pod), "podUID", pod.Uid)
+		pLogger.Info("synchronize pod")
 		for _, container := range containers {
 			if container.PodSandboxId != pod.Id {
 				continue
 			}
-			claimAllocations, err := parseDRAEnvToClaimAllocations(logger, container.Env)
+			cLogger := pLogger.WithValues("container", container.Name)
+
+			claimAllocations, err := parseDRAEnvToClaimAllocations(cLogger, container.Env)
 			if err != nil {
-				logger.Error(err, "error parsing DRA env for container", "pod", klog.KObj(pod), "container", container.Name)
+				cLogger.Error(err, "error parsing DRA env for container")
 				continue
 			}
 			containerUID := types.UID(container.GetId())
@@ -57,16 +60,17 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 			} else {
 				allGuaranteedCPUs := cpuset.New()
 				for uid, cpus := range claimAllocations {
-					err := cp.claimTracker.SetOwner(logger, uid, types.UID(pod.Uid), container.Name)
+					caLogger := cLogger.WithValues("claimUID", uid)
+					err := cp.claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
 					if err != nil {
 						return nil, err
 					}
 
 					allGuaranteedCPUs = allGuaranteedCPUs.Union(cpus)
 					claimUIDs = append(claimUIDs, uid)
-					cpuAllocationStore.AddResourceClaimAllocation(logger, uid, cpus)
+					cpuAllocationStore.AddResourceClaimAllocation(caLogger, uid, cpus)
 				}
-				logger.Info("found guaranteed CPUs", "pod", klog.KObj(pod), "container", container.Name, "cpus", allGuaranteedCPUs.String())
+				cLogger.Info("found guaranteed CPUs", "cpus", allGuaranteedCPUs.String())
 				state = store.NewContainerState(container.GetName(), containerUID, claimUIDs...)
 
 				// Reconcile guaranteed container CPU mask.
@@ -143,14 +147,14 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 
 // CreateContainer handles container creation requests from the NRI.
 func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx)
-	logger.Info("CreateContainer", "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger.Info("CreateContainer")
 	adjust := &api.ContainerAdjustment{}
 	var updates []*api.ContainerUpdate
 
 	claimAllocations, err := parseDRAEnvToClaimAllocations(logger, ctr.Env)
 	if err != nil {
-		logger.Error(err, "error parsing DRA env for container", "pod", klog.KObj(pod), "container", ctr.Name)
+		logger.Error(err, "error parsing DRA env for container")
 	}
 
 	containerId := types.UID(ctr.GetId())
@@ -162,13 +166,14 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		cp.podConfigStore.SetContainerState(podUID, state)
 
 		sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
-		logger.Info("no guaranteed CPUs found, using shared CPUs", "pod", klog.KObj(pod), "container", ctr.Name, "sharedCPUs", sharedCPUs.String())
+		logger.Info("no guaranteed CPUs found, using shared CPUs", "sharedCPUs", sharedCPUs.String())
 		adjust.SetLinuxCPUSetCPUs(sharedCPUs.String())
 	} else {
 		guaranteedCPUs := cpuset.New()
 		claimUIDs := []types.UID{}
 		for uid, cpus := range claimAllocations {
-			err := cp.claimTracker.SetOwner(logger, uid, types.UID(pod.Uid), ctr.Name)
+			cLogger := logger.WithValues("claimUID", uid)
+			err := cp.claimTracker.SetOwner(cLogger, uid, types.UID(pod.Uid), ctr.Name)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -176,7 +181,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 			guaranteedCPUs = guaranteedCPUs.Union(cpus)
 			claimUIDs = append(claimUIDs, uid)
 		}
-		logger.Info("guaranteed CPUs found", "pod", klog.KObj(pod), "container", ctr.Name, "cpus", guaranteedCPUs.String())
+		logger.Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
 		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
 		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
 		cp.podConfigStore.SetContainerState(podUID, state)
@@ -188,8 +193,8 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 }
 
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx)
-	logger.Info("StopContainer", "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger.Info("StopContainer")
 	updates := []*api.ContainerUpdate{}
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	entries := "none"
@@ -203,7 +208,8 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 		// TODO: This workaround assumes that ResourceClaims are NOT shared across pods/containers. If claim sharing
 		// is supported in the future, this early release of CPUS will need an update.
 		for _, claimUID := range claimUIDs {
-			cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claimUID)
+			cLogger := logger.WithValues("claimUID", claimUID)
+			cp.cpuAllocationStore.RemoveResourceClaimAllocation(cLogger, claimUID)
 		}
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
 		updates = cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))
@@ -216,8 +222,8 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 
 // RemoveContainer handles container removal requests from the NRI.
 func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
-	logger := klog.FromContext(ctx)
-	logger.Info("RemoveContainer", "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger.Info("RemoveContainer")
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	if len(claimUIDs) > 0 {
 		// this serves only for debugging purposes. We should never get here

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -151,8 +151,8 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 // CreateContainer handles container creation requests from the NRI.
 func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
-	logger.V(4).Info("begin: CreateContainer")
-	defer logger.V(4).Info("end: CreateContainer")
+	logger.V(2).Info("begin: CreateContainer")
+	defer logger.V(2).Info("end: CreateContainer")
 
 	adjust := &api.ContainerAdjustment{}
 	var updates []*api.ContainerUpdate
@@ -199,8 +199,8 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
-	logger.V(4).Info("begin: StopContainer")
-	defer logger.V(4).Info("end: StopContainer")
+	logger.V(2).Info("begin: StopContainer")
+	defer logger.V(2).Info("end: StopContainer")
 
 	updates := []*api.ContainerUpdate{}
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
@@ -230,8 +230,8 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 // RemoveContainer handles container removal requests from the NRI.
 func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
-	logger.V(4).Info("begin: RemoveContainer")
-	defer logger.V(4).Info("end: RemoveContainer")
+	logger.V(2).Info("begin: RemoveContainer")
+	defer logger.V(2).Info("end: RemoveContainer")
 
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	if len(claimUIDs) > 0 {

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -42,7 +42,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 
 	for _, pod := range pods {
 		pLogger := logger.WithValues("pod", klog.KObj(pod), "podUID", pod.Uid)
-		pLogger.Info("synchronize pod")
+		pLogger.V(2).Info("synchronize pod")
 		for _, container := range containers {
 			if container.PodSandboxId != pod.Id {
 				continue
@@ -72,7 +72,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 					claimUIDs = append(claimUIDs, uid)
 					cpuAllocationStore.AddResourceClaimAllocation(caLogger, uid, cpus)
 				}
-				cLogger.Info("found guaranteed CPUs", "cpus", allGuaranteedCPUs.String())
+				cLogger.V(2).Info("found guaranteed CPUs", "cpus", allGuaranteedCPUs.String())
 				state = store.NewContainerState(container.GetName(), containerUID, claimUIDs...)
 
 				// Reconcile guaranteed container CPU mask.
@@ -131,7 +131,7 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 	updates := []*api.ContainerUpdate{}
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	sharedCPUContainers := cp.podConfigStore.GetContainersWithSharedCPUs()
-	logger.Info("updating CPU allocation for containers without guaranteed CPUs", "sharedCPUs", sharedCPUs.String())
+	logger.V(2).Info("updating CPU allocation for containers without guaranteed CPUs", "sharedCPUs", sharedCPUs.String())
 	for _, containerUID := range sharedCPUContainers {
 		if containerUID == excludeID {
 			// Skip the container being created as it is already covered in the container adjustment.
@@ -170,7 +170,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		cp.podConfigStore.SetContainerState(podUID, state)
 
 		sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
-		logger.Info("no guaranteed CPUs found, using shared CPUs", "sharedCPUs", sharedCPUs.String())
+		logger.V(2).Info("no guaranteed CPUs found, using shared CPUs", "sharedCPUs", sharedCPUs.String())
 		adjust.SetLinuxCPUSetCPUs(sharedCPUs.String())
 	} else {
 		guaranteedCPUs := cpuset.New()
@@ -185,7 +185,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 			guaranteedCPUs = guaranteedCPUs.Union(cpus)
 			claimUIDs = append(claimUIDs, uid)
 		}
-		logger.Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
+		logger.V(2).Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
 		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
 		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
 		cp.podConfigStore.SetContainerState(podUID, state)
@@ -222,7 +222,7 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 		cp.claimTracker.Cleanup(claimUIDs...)
 		entries = fmt.Sprintf("%d entries", len(updates))
 	}
-	logger.Info("StopContainer updates needed", "entries", entries)
+	logger.V(2).Info("StopContainer updates needed", "entries", entries)
 	return updates, nil
 }
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -31,7 +31,8 @@ import (
 
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
 func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx)
+	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
+
 	// this happens once at startup and it's critical enough that we always want to see it.
 	logger.Info("begin: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
 	defer logger.Info("end: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
@@ -149,7 +150,7 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 
 // CreateContainer handles container creation requests from the NRI.
 func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(4).Info("begin: CreateContainer")
 	defer logger.V(4).Info("end: CreateContainer")
 
@@ -197,7 +198,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 }
 
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(4).Info("begin: StopContainer")
 	defer logger.V(4).Info("end: StopContainer")
 
@@ -228,7 +229,7 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 
 // RemoveContainer handles container removal requests from the NRI.
 func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
-	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(4).Info("begin: RemoveContainer")
 	defer logger.V(4).Info("end: RemoveContainer")
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -32,7 +32,9 @@ import (
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
 func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	logger := klog.FromContext(ctx)
-	logger.Info("synchronized state with the runtime", "numPods", len(pods), "numContainers", len(containers))
+	// this happens once at startup and it's critical enough that we always want to see it.
+	logger.Info("begin: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
+	defer logger.Info("end: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
 
 	cpuAllocationStore := store.NewCPUAllocation(cp.cpuTopology, cp.reservedCPUs)
 	podConfigStore := store.NewPodConfig()
@@ -148,7 +150,9 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 // CreateContainer handles container creation requests from the NRI.
 func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
-	logger.Info("CreateContainer")
+	logger.V(4).Info("begin: CreateContainer")
+	defer logger.V(4).Info("end: CreateContainer")
+
 	adjust := &api.ContainerAdjustment{}
 	var updates []*api.ContainerUpdate
 
@@ -194,7 +198,9 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
-	logger.Info("StopContainer")
+	logger.V(4).Info("begin: StopContainer")
+	defer logger.V(4).Info("end: StopContainer")
+
 	updates := []*api.ContainerUpdate{}
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	entries := "none"
@@ -223,7 +229,9 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 // RemoveContainer handles container removal requests from the NRI.
 func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	logger := klog.FromContext(ctx).WithValues("pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
-	logger.Info("RemoveContainer")
+	logger.V(4).Info("begin: RemoveContainer")
+	defer logger.V(4).Info("end: RemoveContainer")
+
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	if len(claimUIDs) > 0 {
 		// this serves only for debugging purposes. We should never get here

--- a/pkg/store/claim_tracker.go
+++ b/pkg/store/claim_tracker.go
@@ -66,7 +66,7 @@ func (ctk *ClaimTracker) SetOwner(logger logr.Logger, claimUID, podUID k8stypes.
 	owner, ok := ctk.ownerByClaimUID[claimUID]
 	if ok {
 		if owner.Equal(curIdent) {
-			logger.V(2).Info("claim bound again to the same owner", "claimUID", claimUID, "podUID", podUID, "containerName", containerName)
+			logger.V(2).Info("claim bound again to the same owner")
 			return nil // not wrong, not suspicious enough to bail out
 		}
 		return AlreadyOwned{
@@ -75,7 +75,7 @@ func (ctk *ClaimTracker) SetOwner(logger logr.Logger, claimUID, podUID k8stypes.
 		}
 	}
 	ctk.ownerByClaimUID[claimUID] = curIdent
-	logger.V(4).Info("claim bound", "claimUID", claimUID, "podUID", podUID, "containerName", containerName)
+	logger.V(4).Info("claim bound")
 	return nil
 }
 

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -60,7 +60,7 @@ func (s *CPUAllocation) AddResourceClaimAllocation(logger logr.Logger, claimUID 
 	}
 	s.resourceClaimAllocations[claimUID] = cpus
 	s.allocatedCPUs = s.allocatedCPUs.Union(cpus)
-	logger.Info("added allocation for resource claim", "claimUID", claimUID, "cpus", cpus.String())
+	logger.Info("added allocation for resource claim", "cpus", cpus.String())
 }
 
 // RemoveResourceClaimAllocation removes a resource claim allocation from the store.
@@ -70,7 +70,7 @@ func (s *CPUAllocation) RemoveResourceClaimAllocation(logger logr.Logger, claimU
 	if cpus, ok := s.resourceClaimAllocations[claimUID]; ok {
 		delete(s.resourceClaimAllocations, claimUID)
 		s.allocatedCPUs = s.allocatedCPUs.Difference(cpus)
-		logger.Info("removed allocation for resource claim", "claimUID", claimUID)
+		logger.Info("removed allocation for resource claim")
 	}
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -50,3 +50,7 @@ honor these settings, where applicable.
   NOTE: the Makefile defaults to "grouped" if not set, because a nonempty value is needed internally.
   NOTE: Likewise the e2e tests, the Makefile also behaves differently depending on this setting.
   It is recommended to set it before to run targets like `make ci-manifests`.
+- `DRACPU_E2E_DUMP_RAW_LOGS`: (optional): if set to any value which is true-ish (e.g. `1`, `true`...)
+  makes the tests which verify the contextual logging integrity dump the full raw captured logs
+  before to run any actual test. Useful for troubleshooting and test fixing/tuning.
+  NOTE: setting this value will make the test output significantly larger.

--- a/test/e2e/contextual_logging_test.go
+++ b/test/e2e/contextual_logging_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
+	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/logcheck"
+	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
+	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// ReportAfterSuite runs after all specs in the suite have completed,
+// giving us access to the driver logs produced by the real e2e workload.
+// This lets us validate contextual logging invariants (batchID consistency,
+// claimUID presence, etc.) against actual log output.
+// The alternative would be using a dedicated spec that must be ordered last,
+// which seems more fragile and cumbersome.
+var _ = ginkgo.ReportAfterSuite("contextual logging", func(report ginkgo.Report) {
+	if !report.SuiteSucceeded {
+		return
+	}
+
+	ctx := context.Background()
+
+	rootFxt, err := fixture.ForGinkgo()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture: %v", err)
+	ctxlogFxt := rootFxt.WithPrefix("ctxlog")
+	gomega.Expect(ctxlogFxt.Setup(ctx)).To(gomega.Succeed())
+	defer func() { gomega.Expect(ctxlogFxt.Teardown(ctx)).To(gomega.Succeed()) }()
+
+	targetNode, err := e2enode.PickWorker(ctx, ctxlogFxt.K8SClientset, 5*time.Second, 1*time.Minute, ctxlogFxt.Log)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	ctxlogFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
+
+	dracpuPod, err := e2epod.GetDRACPUPod(ctx, ctxlogFxt.K8SClientset, targetNode.Name)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	logs, err := e2epod.GetLogs(ctx, ctxlogFxt.K8SClientset, dracpuPod)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from the dracpu pod: %v", err)
+
+	if envVal, ok := os.LookupEnv("DRACPU_E2E_DUMP_RAW_LOGS"); ok {
+		if val, err := strconv.ParseBool(envVal); err == nil && val {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "logs:\n%s", logs)
+		}
+	}
+
+	parsedLog := logcheck.NewParsedLog(logs)
+	ctxlogFxt.Log.Info("ingested log lines", "count", parsedLog.Len())
+
+	dupKeys := logcheck.DuplicateKeys(parsedLog)
+	if len(dupKeys) > 0 {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "lines with duplicated keys:\n%s", logcheck.FormatDuplicateKeyResult(parsedLog, dupKeys...))
+	}
+	gomega.Expect(dupKeys).To(gomega.BeEmpty(), "found %d lines with duplicated keys", len(dupKeys))
+
+	imbalances := logcheck.ImbalancedFlowTags(parsedLog)
+	if len(imbalances) > 0 {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "begin/end imbalances:\n%s", logcheck.FormatOperationFlowTagSummary(imbalances...))
+	}
+	gomega.Expect(imbalances).To(gomega.BeEmpty(), "found %d operations with begin/end imbalance", len(imbalances))
+
+	operations, anomalies := parsedLog.DemuxFlows()
+	if len(anomalies) > 0 {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "lines with anomalies:\n%s", formatAnomalies(parsedLog, anomalies))
+	}
+	gomega.Expect(anomalies).To(gomega.BeEmpty(), "found %d lines with invalid opID", len(anomalies))
+	ctxlogFxt.Log.Info("detected operations", "count", len(operations))
+
+	for opID, opLines := range operations {
+		gomega.Expect(opLines.Indexes).ToNot(gomega.BeEmpty(), "no log entries for operation %q", opID)
+
+		beginMessage, _ := parsedLog.MessageAt(opLines.First())
+		gomega.Expect(beginMessage).To(gomega.HavePrefix("begin: "), "operation %q does not start with begin:", opID)
+
+		endMessage, _ := parsedLog.MessageAt(opLines.Last())
+		gomega.Expect(endMessage).To(gomega.HavePrefix("end: "), "operation %q does not end with end:", opID)
+	}
+})
+
+func formatAnomalies(parsedLog logcheck.ParsedLog, anomalies map[int]error) string {
+	lineNums := make([]int, 0, len(anomalies))
+	for idx := range anomalies {
+		lineNums = append(lineNums, idx)
+	}
+	sort.Ints(lineNums)
+
+	var sb strings.Builder
+	for i, idx := range lineNums {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		line, _ := parsedLog.LineAt(idx)
+		fmt.Fprintf(&sb, "line %d: %v [%s]", idx, anomalies[idx], line)
+	}
+	return sb.String()
+}

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 		infoPod = e2epod.PinToNode(infoPod, targetNode.Name)
 		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create discovery pod: %v", err)
-		data, err := e2epod.GetLogs(infraFxt.K8SClientset, ctx, infoPod.Namespace, infoPod.Name, infoPod.Spec.Containers[0].Name)
+		data, err := e2epod.GetLogs(ctx, infraFxt.K8SClientset, infoPod)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from discovery pod: %v", err)
 		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -104,7 +104,7 @@ type CPUAllocation struct {
 func getTesterPodCPUAllocation(cs kubernetes.Interface, ctx context.Context, pod *v1.Pod) CPUAllocation {
 	ginkgo.GinkgoHelper()
 
-	data, err := e2epod.GetLogs(cs, ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
+	data, err := e2epod.GetLogs(ctx, cs, pod)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs for %s/%s/%s", pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
 
 	// Split logs by newline and find the last non-empty line

--- a/test/e2e/nri_reconciliation_test.go
+++ b/test/e2e/nri_reconciliation_test.go
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 		infoPod = e2epod.PinToNode(infoPod, targetNode.Name)
 		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		data, err := e2epod.GetLogs(infraFxt.K8SClientset, ctx, infoPod.Namespace, infoPod.Name, infoPod.Spec.Containers[0].Name)
+		data, err := e2epod.GetLogs(ctx, infraFxt.K8SClientset, infoPod)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
 		allocatableCPUs = makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
 
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create discovery pod: %v", err)
-		data, err := e2epod.GetLogs(infraFxt.K8SClientset, ctx, infoPod.Namespace, infoPod.Name, infoPod.Spec.Containers[0].Name)
+		data, err := e2epod.GetLogs(ctx, infraFxt.K8SClientset, infoPod)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from discovery pod: %v", err)
 		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
 

--- a/test/pkg/logcheck/ctxlog.go
+++ b/test/pkg/logcheck/ctxlog.go
@@ -1,0 +1,288 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logcheck
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	kvPairRE    = regexp.MustCompile(`(\w+)=("([^"]*)"|(\S+))`)
+	validOPIDRE = regexp.MustCompile(`^[0-9a-f]+$`)
+)
+
+const (
+	logUnknown = "unknown"
+	logInfo    = "info"
+	logError   = "error"
+)
+
+const (
+	tagBegin = "begin: "
+	tagEnd   = "end: "
+	tagOPID  = "opID"
+)
+
+type parsedLogLine struct {
+	// log severity
+	severity string
+	// the log message (first quoted string after the klog header)
+	message string
+	// serialized key=value pairs (everything after the quoted message)
+	kvPairs string
+}
+
+func logSeverityFromRawLine(rawLine string) string {
+	if rawLine == "" {
+		return logUnknown
+	}
+	switch rawLine[0] {
+	case 'I':
+		return logInfo
+	case 'E':
+		return logError
+	// with contextual logging through logr we don't get anything else
+	default:
+		return logUnknown
+	}
+}
+
+type ParsedLog struct {
+	lines []parsedLogLine
+}
+
+// parseTextloggerPayload splits a payload line in message and kvPairs.
+func parseTextLoggerPayload(data string) (string, string) {
+	// I0505 17:29:25.356513 112267 dra_hooks.go:269] "begin: preparing resource claims" numClaims=2 batchID="a9ff17853d90"
+	// |<---------removed by preprocessor ---------->|<-------------message----------->|<----------kvPairs--------------->|
+	if len(data) < 2 || data[0] != '"' {
+		return "", data
+	}
+	end := strings.Index(data[1:], `"`)
+	if end < 0 {
+		return "", data
+	}
+	message := data[1 : end+1]
+	kvPairs := strings.TrimSpace(data[end+2:])
+	return message, kvPairs
+}
+
+// ParsedLog holds preprocessed lines emitted by a klog/textlogger
+// the header format is stripped (date/time, file...) and we
+// retain only the messages payload.
+func NewParsedLog(rawLogs string) ParsedLog {
+	var lines []parsedLogLine
+	sc := bufio.NewScanner(strings.NewReader(rawLogs))
+	for sc.Scan() {
+		rawLine := sc.Text()
+		parts := strings.SplitN(rawLine, "] ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		message, kvPairs := parseTextLoggerPayload(parts[1])
+		lines = append(lines, parsedLogLine{
+			severity: logSeverityFromRawLine(rawLine),
+			message:  message,
+			kvPairs:  kvPairs,
+		})
+	}
+	return ParsedLog{
+		lines: lines,
+	}
+}
+
+func (pl ParsedLog) Len() int {
+	return len(pl.lines)
+}
+
+func (pl ParsedLog) LineAt(idx int) (string, bool) {
+	if idx < 0 || idx >= len(pl.lines) {
+		return "", false
+	}
+	line := pl.lines[idx]
+	if line.kvPairs == "" {
+		return line.message, true
+	}
+	return line.message + " " + line.kvPairs, true
+}
+
+func (pl ParsedLog) MessageAt(idx int) (string, bool) {
+	if idx < 0 || idx >= len(pl.lines) {
+		return "", false
+	}
+	return pl.lines[idx].message, true
+}
+
+func (pl ParsedLog) KVPairsAt(idx int) [][]string {
+	if idx < 0 || idx >= len(pl.lines) {
+		return nil
+	}
+	// differently from other *At() method, we do lazily because
+	// this is a relatively expensive operation
+	return kvPairRE.FindAllStringSubmatch(pl.lines[idx].kvPairs, -1)
+}
+
+type FlowEntries struct {
+	Indexes []int
+}
+
+func (fe FlowEntries) First() int {
+	return fe.Indexes[0]
+}
+
+func (fe FlowEntries) Last() int {
+	return fe.Indexes[len(fe.Indexes)-1]
+}
+
+// DemuxFlows groups all the lines pertaining to an operation,
+// grouped by opID. Returns a opID->FlowLineIndexes mapping,
+// and a linenumber -> error mapping should it encounter
+// any anomaly be detected during processing
+func (pl ParsedLog) DemuxFlows() (map[string]*FlowEntries, map[int]error) {
+	// lineNum -> error
+	errs := make(map[int]error)
+	// opID -> FlowEntries
+	res := make(map[string]*FlowEntries)
+	for idx := range pl.lines {
+		for _, match := range pl.KVPairsAt(idx) {
+			key := match[1]
+			if key != tagOPID {
+				continue
+			}
+			val := match[3] // clean unquoted string
+			if !IsValidOPID(val) {
+				errs[idx] = fmt.Errorf("invalid %s %q at line %d", tagOPID, val, idx)
+				continue
+			}
+			fe, ok := res[val]
+			if !ok {
+				fe = &FlowEntries{}
+				res[val] = fe
+			}
+			fe.Indexes = append(fe.Indexes, idx)
+			break
+		}
+	}
+	return res, errs
+}
+
+func IsValidOPID(opID string) bool {
+	return len(opID) > 0 && validOPIDRE.MatchString(opID)
+}
+
+type OperationFlowTagSummary struct {
+	Operation  string
+	BeginCount int
+	EndCount   int
+}
+
+// ImbalancedFlowTags counts begin/end markers per operation name across all lines.
+// Returns imbalances where the counts differ.
+func ImbalancedFlowTags(pl ParsedLog) []OperationFlowTagSummary {
+	begins := make(map[string]int)
+	ends := make(map[string]int)
+	for _, line := range pl.lines {
+		if op, ok := strings.CutPrefix(line.message, tagBegin); ok {
+			begins[op]++
+			continue
+		}
+		if op, ok := strings.CutPrefix(line.message, tagEnd); ok {
+			ends[op]++
+			continue
+		}
+	}
+	ops := sets.New[string]()
+	ops.Insert(sets.KeySet(begins).UnsortedList()...)
+	ops.Insert(sets.KeySet(ends).UnsortedList()...)
+
+	var res []OperationFlowTagSummary
+	for _, op := range sets.List(ops) {
+		b, e := begins[op], ends[op]
+		if b == e {
+			continue
+		}
+		res = append(res, OperationFlowTagSummary{
+			Operation:  op,
+			BeginCount: b,
+			EndCount:   e,
+		})
+	}
+	return res
+}
+
+func FormatOperationFlowTagSummary(imbalances ...OperationFlowTagSummary) string {
+	if len(imbalances) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, imb := range imbalances {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		fmt.Fprintf(&sb, "operation=%q begin=%d end=%d", imb.Operation, imb.BeginCount, imb.EndCount)
+	}
+	return sb.String()
+}
+
+type DuplicateKeyResult struct {
+	Index      int
+	Duplicates []string
+}
+
+// DuplicateKeys returns lines that have the same KV key appearing more than once.
+func DuplicateKeys(pl ParsedLog) []DuplicateKeyResult {
+	var res []DuplicateKeyResult
+	for idx := range pl.lines {
+		dupes := []string{}
+		keysPerLine := sets.New[string]()
+		for _, match := range pl.KVPairsAt(idx) {
+			key := match[1]
+			if keysPerLine.Has(key) {
+				dupes = append(dupes, key)
+			} else {
+				keysPerLine.Insert(key)
+			}
+		}
+		if len(dupes) == 0 {
+			continue
+		}
+		res = append(res, DuplicateKeyResult{
+			Index:      idx,
+			Duplicates: dupes,
+		})
+	}
+	return res
+}
+
+func FormatDuplicateKeyResult(parsedLog ParsedLog, dupKeys ...DuplicateKeyResult) string {
+	if len(dupKeys) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	rawLine, _ := parsedLog.LineAt(dupKeys[0].Index)
+	fmt.Fprintf(&sb, "line=[%s] duplicated keys=<%s>", rawLine, strings.Join(dupKeys[0].Duplicates, ","))
+	for _, dupKey := range dupKeys[1:] {
+		rawLine, _ := parsedLog.LineAt(dupKey.Index)
+		fmt.Fprintf(&sb, "\nline=[%s] duplicated keys=<%s>", rawLine, strings.Join(dupKey.Duplicates, ","))
+	}
+	return sb.String()
+}

--- a/test/pkg/pod/pod.go
+++ b/test/pkg/pod/pod.go
@@ -145,3 +145,29 @@ func PinToNode(pod *v1.Pod, nodeName string) *v1.Pod {
 func Identify(pod *v1.Pod) string {
 	return pod.Namespace + "/" + pod.Name + "@" + pod.Spec.NodeName
 }
+
+func GetDRACPUPod(ctx context.Context, cs kubernetes.Interface, nodeName string) (*v1.Pod, error) {
+	const (
+		// TODO: these should be common constants or introspected
+		dracpuNamespace = "kube-system"
+		dracpuName      = "dracpu"
+	)
+
+	daemonSet, err := cs.AppsV1().DaemonSets(dracpuNamespace).Get(ctx, dracpuName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get dracpu daemonset: %w", err)
+	}
+
+	labelSelector := metav1.FormatLabelSelector(daemonSet.Spec.Selector)
+	pods, err := cs.CoreV1().Pods(daemonSet.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get dracpu pods: %w", err)
+	}
+	if len(pods.Items) != 1 {
+		return nil, fmt.Errorf("found unexpected amount of dracpu pods: %d", len(pods.Items))
+	}
+	return &pods.Items[0], nil
+}

--- a/test/pkg/pod/pod.go
+++ b/test/pkg/pod/pod.go
@@ -116,7 +116,13 @@ func WaitForPhase(ctx context.Context, cs kubernetes.Interface, podNamespace, po
 	return podPhase, err
 }
 
-func GetLogs(cs kubernetes.Interface, ctx context.Context, podNamespace, podName, containerName string) (string, error) {
+// GetLogs gets the logs for the default (aka the first) container of a pod.
+// If you need full control over the container to grab logs from, use GetLogsForContainer
+func GetLogs(ctx context.Context, cs kubernetes.Interface, pod *v1.Pod) (string, error) {
+	return GetLogsForContainer(ctx, cs, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name)
+}
+
+func GetLogsForContainer(ctx context.Context, cs kubernetes.Interface, podNamespace, podName, containerName string) (string, error) {
 	previous := false
 	request := cs.CoreV1().RESTClient().Get().Resource("pods").Namespace(podNamespace).Name(podName).SubResource("log").Param("container", containerName).Param("previous", strconv.FormatBool(previous))
 	logs, err := request.Do(ctx).Raw()


### PR DESCRIPTION
Implement the actual contextual logging for all our major flows, which map to driver startup/management and DRA and NRI callbacks.
At the topmost level of each flow, we augment the logger with key-value pairs relevant to the flow which will be automatically logged in every function down the call chain.
Therefore, every message downstream will always get these KV pairs, making easier to track the flow in the logs.
    
To ensure consistency, we intentionally override the context to include the augmented logger, so functions fetching the logger from the context get a consistent logger.

Some DRA flows, most notably PrepareResourceClaim and UnprepareResourceClaim, are designed to work on a batch of claims.
We added enough contextual log to be able to follow the flow of each claim, but we lack a way to easily correlate claims within a batch.
Therefore we introduce a custom short ID to group the claims pertaining to a batch. 
Another option could have been to use a UUID, but the UUID identifiers are long and add noise to the logs and we don't really need yet such uniqueness guiaranties.
Therefore, we start with a custom hexadecimal short id.

Turns out this `batchID` concept can be useful in general, so we generalize it into a opID and use it everywhere in out main operation (aka DRA and NRI callback implementations).
This allows to trivially demux the interleaved logs into in high concurrency scenarios at a very cheap cost.
When (if?) we integrate OTEL we will replace this with OTEL trace_id/span_id, perhaps with a transitional period.

We mark begin and end of each callback so it's possible to  de-entangle massively concurrent logs.
We intentionally use minimal delimiters without extra data like elapsed time, result, and so forth because the intent is to make easy to parse log to understand the component behavior aka the "why", not to replace telemetry.
The fact we add pseudo-span delimiters is an artifact of how log are emitted - an interleaved streams rather than an attempt to reimplement e.g. OTEL spans poorly.
Likewise the `opID` concept, this is another concept we borrow from telemetry because makes sense in the logs; it's lightweight, useful and improves across a different dimension.
Pending further review, when (if?) we integrate OTEL this concept should remain.

Finally, we add e2e tests to ensure basic coverage of the log properties introduced here.
We use ReportAfterSuite, which runs after all specs in the suite have completed.
The alternative would be using a dedicated spec that must be ordered last, which seems more fragile and cumbersome. We may re-evaluate in the future depending on how the e2e suite evolves.

Builds on top of #129
