### PR TITLE
e2e: extract node selection helper

### DIFF
--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
-	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
+	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -106,22 +106,8 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 		gomega.Expect(dsReservedCPUs.Equals(reservedCPUs)).To(gomega.BeTrue(), "daemonset reserved cpus %v do not match test reserved cpus %v", dsReservedCPUs.String(), reservedCPUs.String())
 		rootFxt.Log.Info("daemonset --cpu-device-mode configuration", "mode", cpuDeviceMode)
 
-		if targetNodeName := os.Getenv("DRACPU_E2E_TARGET_NODE"); len(targetNodeName) > 0 {
-			targetNode, err = rootFxt.K8SClientset.CoreV1().Nodes().Get(ctx, targetNodeName, metav1.GetOptions{})
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get worker node %q: %v", targetNodeName, err)
-		} else {
-			gomega.Eventually(func() error {
-				workerNodes, err := node.FindWorkers(ctx, infraFxt.K8SClientset)
-				if err != nil {
-					return err
-				}
-				if len(workerNodes) == 0 {
-					return fmt.Errorf("no worker nodes detected")
-				}
-				targetNode = workerNodes[0] // pick random one, this is the simplest random pick
-				return nil
-			}).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(gomega.Succeed(), "failed to find any worker node")
-		}
+		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
 
 		infoPod := discovery.MakePod(infraFxt.Namespace.Name, dracpuTesterImage)

--- a/test/e2e/nri_reconciliation_test.go
+++ b/test/e2e/nri_reconciliation_test.go
@@ -19,13 +19,12 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
-	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
+	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -83,22 +82,9 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 		}
 
 		// Find target node
-		if targetNodeName := os.Getenv("DRACPU_E2E_TARGET_NODE"); len(targetNodeName) > 0 {
-			targetNode, err = rootFxt.K8SClientset.CoreV1().Nodes().Get(ctx, targetNodeName, metav1.GetOptions{})
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		} else {
-			gomega.Eventually(func() error {
-				workerNodes, err := node.FindWorkers(ctx, infraFxt.K8SClientset)
-				if err != nil {
-					return err
-				}
-				if len(workerNodes) == 0 {
-					return fmt.Errorf("no worker nodes detected")
-				}
-				targetNode = workerNodes[0]
-				return nil
-			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
-		}
+		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
 
 		// Discover topology
 		infoPod := discovery.MakePod(infraFxt.Namespace.Name, dracpuTesterImage)

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -19,13 +19,12 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
-	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
+	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -84,22 +83,8 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 
 		rootFxt.Log.Info("daemonset configuration", "reservedCPUs", dsReservedCPUs.String(), "deviceMode", cpuDeviceMode)
 
-		if targetNodeName := os.Getenv("DRACPU_E2E_TARGET_NODE"); len(targetNodeName) > 0 {
-			targetNode, err = rootFxt.K8SClientset.CoreV1().Nodes().Get(ctx, targetNodeName, metav1.GetOptions{})
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get worker node %q: %v", targetNodeName, err)
-		} else {
-			gomega.Eventually(func() error {
-				workerNodes, err := node.FindWorkers(ctx, infraFxt.K8SClientset)
-				if err != nil {
-					return err
-				}
-				if len(workerNodes) == 0 {
-					return fmt.Errorf("no worker nodes detected")
-				}
-				targetNode = workerNodes[0] // pick random one, this is the simplest random pick
-				return nil
-			}).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(gomega.Succeed(), "failed to find any worker node")
-		}
+		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
 
 		infoPod := discovery.MakePod(infraFxt.Namespace.Name, dracpuTesterImage)

--- a/test/pkg/node/node.go
+++ b/test/pkg/node/node.go
@@ -18,10 +18,15 @@ package node
 
 import (
 	"context"
+	"math/rand/v2"
+	"os"
+	"time"
 
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -49,4 +54,34 @@ func IsReady(node *v1.Node) bool {
 		}
 	}
 	return false
+}
+
+// PickWorker returns a worker Node object to work with; if the environment variable DRACPU_E2E_TARGET_NODE is set,
+// fetches the node with that name or fails; otherwise pick a random worker node.
+// The random selection algorithm is an implementation detail, and is not guaranteed to be crypto strong.
+func PickWorker(ctx context.Context, cs kubernetes.Interface, interval, timeout time.Duration, logger logr.Logger) (*v1.Node, error) {
+	// explicit user choice
+	if targetNodeName := os.Getenv("DRACPU_E2E_TARGET_NODE"); len(targetNodeName) > 0 {
+		return cs.CoreV1().Nodes().Get(ctx, targetNodeName, metav1.GetOptions{})
+	}
+
+	// random pick
+	var node *v1.Node
+	immediate := false // shortcut to make the call more readable
+	err := k8swait.PollUntilContextTimeout(ctx, interval, timeout, immediate, func(ctx context.Context) (bool, error) {
+		workerNodes, err := FindWorkers(ctx, cs)
+		if err != nil {
+			// in CI, especially using kind clusters, it may happen that worker nodes are slow to be
+			// added to the cluster. Let's not give up immediately.
+			logger.Info("failed to find worker nodes, will retry", "error", err)
+			return false, nil
+		}
+		if len(workerNodes) == 0 {
+			// may happen if no nodes are ready yet, which is especially true in CI
+			return false, nil
+		}
+		node = workerNodes[rand.IntN(len(workerNodes))] // nolint:gosec
+		return true, nil
+	})
+	return node, err
 }


### PR DESCRIPTION
We are starting to have boilerplate proliferation in three calls sites, so it's time to evaluate code extraction.

Production code wants to be DRY, and same applies for test *infrastructure*, not test *logic*. This commit wants to consolidate the setup plumbing, which should be shared and ginkgo agnostic.

OTOH, test assertions or test scenarios still should actually prefer duplication for readability and independence. Coupling test logic through abstractions and DRYness often turns out to be painful in the long term.

Bonus: fix a TODO in the old node selection logic: the worker node pick is actually random now, even though the random choice is not crypto strong by design, which makes little sense in this test context.