### PR TITLE
Check for overlapping device allocation in individual mode

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -399,6 +399,14 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 	}
 
 	claimCPUSet := cpuset.New(claimCPUIDs...)
+	// All the CPUs allocated to a claim should currently be in the shared pool.
+	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
+	if !claimCPUSet.IsSubsetOf(sharedCPUs) {
+		return kubeletplugin.PrepareResult{
+			Err: fmt.Errorf("claim %s/%s has overlapping device assignment with other claims", claim.Namespace, claim.Name),
+		}
+	}
+
 	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, claimCPUSet)
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, claimCPUSet.String())

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -571,6 +571,31 @@ func TestPrepareResourceClaims(t *testing.T) {
 				{PoolName: testNodeName, DeviceName: "cpudev0", CDIDeviceIDs: []string{cdiQualifiedName}},
 			},
 		},
+		{
+			name: "error - overlapping device assignment",
+			driver: func() *CPUDriver {
+				d := baseCPUDriver()
+				// Pre-allocate cpudev0 to an existing claim
+				d.cpuAllocationStore.AddResourceClaimAllocation(testr.New(t), "claim0", cpuset.New(0))
+				return d
+			}(),
+			claims: []*resourceapi.ResourceClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{UID: "claim1", Name: "claim1", Namespace: "default"},
+					Status: resourceapi.ResourceClaimStatus{
+						Allocation: &resourceapi.AllocationResult{
+							Devices: resourceapi.DeviceAllocationResult{
+								Results: []resourceapi.DeviceRequestAllocationResult{
+									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev0"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResultsCount: 1,
+			expectedError:        true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Adds a check to ensure that CPUs requested in individual mode are not already allocated to an existing claim

Fixes: #44 