### PR TITLE
helm: add necessary bits for chart packaging and releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ install-yq: $(OUT_DIR)  ## make sure the yq tool is available locally
 install-golangci-lint: $(OUT_DIR) ## make sure the golangci-lint tool is available locally
 	@hack/fetch-golangci-lint.sh $(OUT_DIR) $(GOLANGCI_LINT_VERSION)
 
-helm-lint:
+helm-lint: ## lint helm chart with strict mode
 	helm lint --strict deployment/helm/dra-driver-cpu
 
 .PHONY: helm-docs
@@ -259,3 +259,23 @@ helm-schema: ## regenerate values.schema.json from values.yaml @schema annotatio
 helm-schema-check: helm-schema ## verify values.schema.json is up to date; fails if regeneration produces a diff
 	@git diff --exit-code deployment/helm/dra-driver-cpu/values.schema.json || \
 		(echo "ERROR: values.schema.json is out of date. Run 'make helm-schema' to update it." && exit 1)
+CHART_REGISTRY?=$(REGISTRY)/$(STAGING_REPO_NAME)/charts
+HELM_VERSION_SHA?=a2369ca71c0ef633bf6e4fccd66d634eb379b371 # v3.20.1
+
+.PHONY: ensure-helm
+ensure-helm:
+	@if ! helm version >/dev/null 2>&1; then \
+		echo "Helm not found, installing helm@$(HELM_VERSION_SHA) ..."; \
+		go install helm.sh/helm/v3/cmd/helm@$(HELM_VERSION_SHA); \
+	fi
+
+.PHONY: helm-package
+helm-package: ensure-helm ## package helm chart for release
+	helm package deployment/helm/dra-driver-cpu \
+		--version "$(CHART_VERSION)" \
+		--app-version "$(TAG)" \
+		--destination $(OUT_DIR)
+
+.PHONY: helm-push
+helm-push: helm-package ## push helm chart to OCI registry
+	helm push $(OUT_DIR)/dra-driver-cpu-$(CHART_VERSION).tgz oci://$(CHART_REGISTRY)

--- a/scripts/build-and-publish-image.sh
+++ b/scripts/build-and-publish-image.sh
@@ -32,8 +32,20 @@ if [[ -z ${IMG_TAG:-} ]]; then
 fi
 echo "Using IMG_TAG=${IMG_TAG}"
 
+CHART_VERSION="${IMG_TAG#v}"
+if [[ -z ${CHART_VERSION} ]]; then
+	echo "CHART_VERSION is empty (IMG_TAG=${IMG_TAG})"
+	exit 1
+fi
+echo "Using CHART_VERSION=${CHART_VERSION}"
+
 # Pass the Cloud Build variables to the Makefile and enable multi-arch
 make push-image \
 	STAGING_IMAGE_NAME="${IMG_PREFIX}/dra-driver-cpu" \
 	TAG="${IMG_TAG}" \
 	PLATFORMS="linux/amd64,linux/arm64"
+
+make helm-push \
+	CHART_REGISTRY="${IMG_PREFIX}/charts" \
+	CHART_VERSION="${CHART_VERSION}" \
+	TAG="${IMG_TAG}"


### PR DESCRIPTION
Add the required targets so we can package and release the Helm charts as OCI artifacts alongside the container image. This means that whenever a new promotion PR is submitted to kubernetes/k8s.io, we only need to add one additional line for the chart. In other words,
```YAML
- name: charts/dra-driver-cpu
  dmap:
    "sha256:xyz": ["0.2.0"]
```


This should go after https://github.com/kubernetes-sigs/dra-driver-cpu/pull/83, since it depends on the existing directory structure and related files there.