### PR TITLE
Rebase to Kubernetes v1.36

### DIFF
--- a/.github/workflows/helm-e2e.yaml
+++ b/.github/workflows/helm-e2e.yaml
@@ -28,10 +28,14 @@ jobs:
       - name: Build the image
         run: make build-image
 
+      # Try to parse KIND_K8S_VERSION from the Makefile and use it to build the node image and create the cluster.
       - name: Create kind cluster
         run: |
+          KIND_K8S_VERSION=$(grep -E '^KIND_K8S_VERSION \?=' Makefile | awk '{print $3}')
+          KIND_K8S_VERSION=${KIND_K8S_VERSION:-v1.36.0}
           kind delete cluster --name dra-driver-cpu || true
-          kind create cluster --name dra-driver-cpu --config hack/ci/kind-ci.yaml
+          kind build node-image --image=kindest/node:${KIND_K8S_VERSION} ${KIND_K8S_VERSION}
+          kind create cluster --name dra-driver-cpu --image=kindest/node:${KIND_K8S_VERSION} --config hack/ci/kind-ci.yaml
           kind get kubeconfig --name dra-driver-cpu > /tmp/kubeconfig-dra-driver-cpu
           kubectl --kubeconfig /tmp/kubeconfig-dra-driver-cpu \
             label node dra-driver-cpu-worker node-role.kubernetes.io/worker=''

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ YQ_VERSION ?= 4.47.1
 GOLANGCI_LINT_VERSION ?= 2.7.2
 HELM_DOCS_VERSION ?= 1.14.2
 HELM_SCHEMA_VERSION ?= 2.3.1
+KIND_K8S_VERSION ?= v1.36.0
 # paths
 YQ = $(OUT_DIR)/yq
 GOLANGCI_LINT = $(OUT_DIR)/golangci-lint
@@ -130,8 +131,15 @@ push-image: ## build and push image directly to registry (supports multi-arch)
 		--push
 	-docker buildx rm dracpu-builder
 
-kind-cluster:  ## create kind cluster
-	kind create cluster --name ${CLUSTER_NAME} --config hack/kind.yaml
+# Builds the Kind node image on-the-fly if it is not pre-cached locally.
+ensure-kind-node-image:
+	@if [ -z "$$(docker images -q kindest/node:$(KIND_K8S_VERSION) 2>/dev/null)" ]; then \
+		echo "Building kindest/node:$(KIND_K8S_VERSION) ..."; \
+		kind build node-image --image=kindest/node:$(KIND_K8S_VERSION) $(KIND_K8S_VERSION); \
+	fi
+
+kind-cluster: ensure-kind-node-image ## create kind cluster
+	kind create cluster --name ${CLUSTER_NAME} --image=kindest/node:$(KIND_K8S_VERSION) --config hack/kind.yaml
 
 kind-load-image: build-image  ## load the current container image into kind
 	kind load docker-image ${IMAGE} ${IMAGE_LATEST} --name ${CLUSTER_NAME}
@@ -146,7 +154,7 @@ delete-kind-cluster: ## delete kind cluster
 	kind delete cluster --name ${CLUSTER_NAME}
 
 define kind_setup
-	kind create cluster --name ${CLUSTER_NAME} --config hack/ci/kind-ci.yaml
+	kind create cluster --name ${CLUSTER_NAME} --image=kindest/node:$(KIND_K8S_VERSION) --config hack/ci/kind-ci.yaml
 	kubectl label node ${CLUSTER_NAME}-worker node-role.kubernetes.io/worker=''
 	kind load docker-image --name ${CLUSTER_NAME} ${IMAGE_CI} ${IMAGE_TEST}
 	kubectl create -f $(1)
@@ -195,7 +203,7 @@ ifneq ($(DRACPU_E2E_VERBOSE),)
 endif
 	$(call generate_ci_manifest,$(CI_MANIFEST_FILE),.spec.template.spec.containers[0].args |= (del(.[] | select(. == "--cpu-device-mode=*")) | . + ["--cpu-device-mode=$(DRACPU_E2E_CPU_DEVICE_MODE)", "--reserved-cpus=$(DRACPU_E2E_RESERVED_CPUS)"]))
 
-ci-kind-setup: ci-manifests build-image build-test-image ## setup a CI cluster from scratch using reserved CPUs
+ci-kind-setup: ensure-kind-node-image ci-manifests build-image build-test-image ## setup a CI cluster from scratch using reserved CPUs
 ifneq ($(DRACPU_E2E_VERBOSE),)
 	@echo "creating a kind cluster for mode=$(DRACPU_E2E_CPU_DEVICE_MODE)"
 endif

--- a/hack/ci/kind-ci.yaml
+++ b/hack/ci/kind-ci.yaml
@@ -19,7 +19,7 @@ featureGates:
   DRAConsumableCapacity: true
 nodes:
 - role: control-plane
-  image: kindest/node:v1.35.0
+  image: kindest/node:v1.36.0
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
@@ -36,7 +36,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.35.0
+  image: kindest/node:v1.36.0
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -19,7 +19,7 @@ featureGates:
   DRAConsumableCapacity: true
 nodes:
 - role: control-plane
-  image: kindest/node:v1.35.0
+  image: kindest/node:v1.36.0
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
@@ -36,7 +36,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.35.0
+  image: kindest/node:v1.36.0
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
@@ -44,7 +44,7 @@ nodes:
       kubeletExtraArgs:
         v: "5"
 - role: worker
-  image: kindest/node:v1.35.0
+  image: kindest/node:v1.36.0
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration


### PR DESCRIPTION
Rebasing on top of Kubernetes 1.36 to get the new DRA changes. This unblocks experimentation with https://github.com/kubernetes-sigs/dra-driver-cpu/pull/68 and [KEP-5517](https://github.com/kubernetes/enhancements/pull/5755).

Currently, we rely on pulling precompiled kind node image from docker hub. In this PR, we switch to building the node image locally. This decouples our test infrastructure from Docker Hub release delays (like we are having with 1.36)  and enables early testing against new Kubernetes releases.