### PR TITLE
finalize contextual logging support

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/ctxlog"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/driver"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sys/unix"
@@ -36,8 +37,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	nodeutil "k8s.io/component-helpers/node/util"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/textlogger"
 	"k8s.io/utils/cpuset"
 )
 
@@ -113,22 +112,10 @@ func init() {
 }
 
 func main() {
-	config := textlogger.NewConfig()
-	config.AddFlags(flag.CommandLine)
+	ctxlog.AddFlags(flag.CommandLine)
 	flag.Parse()
 
-	logger := textlogger.NewLogger(config)
-	// some key deps still call klog directly, so we need this integration.
-	// TODO: check every time we bump kube libs to a new major version,
-	// as the contextual logging transition to kube libs is still ongoing
-	// k8s.io/client-go
-	// k8s.io/apimachinery
-	// k8s.io/dynamic-resource-allocation
-	// k8s.io/kube-openapi
-	// k8s.io/utils
-	// k8s.io/component-helpers
-	// k8s.io/kubelet
-	klog.SetLoggerWithOptions(logger, klog.ContextualLogger(true))
+	logger := ctxlog.Setup()
 
 	if err := run(logger); err != nil {
 		logger.Error(err, "failed to run")
@@ -201,7 +188,7 @@ func run(logger logr.Logger) error {
 	}
 
 	// trap Ctrl+C and call cancel on the context
-	ctx := klog.NewContext(context.Background(), logger)
+	ctx := ctxlog.NewContext(context.Background(), logger)
 	ctx, cancel := context.WithCancel(ctx)
 
 	// Enable signal handler

--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -9,6 +9,32 @@ V(6): debug messages, very fine details, mostly for developers
 
 V(7) or more is reserved for future usage.
 
+## when to use Error()
+
+Summary: use Error() if we need to log an unrecoverable error which leads
+to a failed state, not to a degraded-but-operational state.
+
+Description: sometimes a code flow returns an error we want to log.
+How to log it depends on what the error means.
+
+If the error is *recoverable*, and the flow can continue,
+the log should represent a non-fatal, handled situation and we prefer to use
+something like
+
+```
+logger.Info("descriptive message", "key", value, "err", error)
+```
+
+note the error is always the last pair.
+
+If the error is *unrecoverable* and represents an actionable failure, then
+first and foremost the flow must fail, then the error should guide
+the log-reader towards resolution. We prefer to use something like
+
+```
+logger.Error(err, "descriptive message")
+```
+
 ## the opID tag
 
 `opID` is a cheap trace identifier similar in spirit to OTEL's

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/containerd/nri v0.11.0
 	github.com/go-logr/logr v1.4.3
+	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZ
 github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
 github.com/gkampitakis/go-snaps v0.5.15 h1:amyJrvM1D33cPHwVrjo9jQxX8g/7E2wYdZ+01KS3zGE=
 github.com/gkampitakis/go-snaps v0.5.15/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/internal/ctxlog/ctxlog.go
+++ b/internal/ctxlog/ctxlog.go
@@ -1,0 +1,116 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ctxlog
+
+import (
+	"context"
+	"flag"
+	"log"
+	"runtime/debug"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
+)
+
+var (
+	fallback = stdr.New(log.Default())
+	cfg      = textlogger.NewConfig()
+	logger   logr.Logger
+	inited   bool
+)
+
+// AddFlags registers the logging flags on the given flag set.
+func AddFlags(fs *flag.FlagSet) {
+	cfg.AddFlags(fs)
+}
+
+func Setup() logr.Logger {
+	if inited {
+		logger.Info("bug: Setup() called more than once", "stack", string(debug.Stack()))
+		return logger
+	}
+	logger = textlogger.NewLogger(cfg)
+	// some key deps still call klog directly, so we need this integration.
+	// TODO: check every time we bump kube libs to a new major version,
+	// as the contextual logging transition to kube libs is still ongoing
+	// k8s.io/client-go
+	// k8s.io/apimachinery
+	// k8s.io/dynamic-resource-allocation
+	// k8s.io/kube-openapi
+	// k8s.io/utils
+	// k8s.io/component-helpers
+	// k8s.io/kubelet
+	klog.SetLoggerWithOptions(logger, klog.ContextualLogger(true))
+	inited = true
+	return logger
+}
+
+func Flush() {
+	klog.Flush()
+}
+
+// NewContext returns a new context derived from ctx that carries the provided logger.
+func NewContext(ctx context.Context, logger logr.Logger) context.Context {
+	return logr.NewContext(ctx, logger)
+}
+
+// FromContext returns the logger stored in ctx. If no logger is found,
+// it falls back to a stdlib-based logger via stdr rather than discarding
+// messages silently.
+// TODO: pending item: enriched context loss
+func FromContext(ctx context.Context) logr.Logger {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return fallback
+	}
+	return logger
+}
+
+// KMetadata is satisfied by Kubernetes objects and NRI protobuf types
+// that expose name and namespace.
+type KMetadata interface {
+	GetName() string
+	GetNamespace() string
+}
+
+// ObjectRef references a kubernetes object.
+type ObjectRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+func (ref ObjectRef) String() string {
+	if ref.Namespace != "" {
+		return ref.Namespace + "/" + ref.Name
+	}
+	return ref.Name
+}
+
+// MarshalLog implements logr.Marshaler.
+func (ref ObjectRef) MarshalLog() interface{} {
+	return ref
+}
+
+// KObj returns an ObjectRef for the given object, for use as a log value.
+func KObj(obj KMetadata) ObjectRef {
+	return ObjectRef{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}

--- a/internal/ctxlog/ctxlog.go
+++ b/internal/ctxlog/ctxlog.go
@@ -73,13 +73,19 @@ func NewContext(ctx context.Context, logger logr.Logger) context.Context {
 // FromContext returns the logger stored in ctx. If no logger is found,
 // it falls back to a stdlib-based logger via stdr rather than discarding
 // messages silently.
-// TODO: pending item: enriched context loss
 func FromContext(ctx context.Context) logr.Logger {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return fallback
 	}
 	return logger
+}
+
+// WithValues extracts the logger from ctx, enriches it with the given
+// key-value pairs, and reinjects it into the returned context.
+func WithValues(ctx context.Context, keysAndValues ...any) (context.Context, logr.Logger) {
+	logger := FromContext(ctx).WithValues(keysAndValues...)
+	return NewContext(ctx, logger), logger
 }
 
 // KMetadata is satisfied by Kubernetes objects and NRI protobuf types

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -19,12 +19,12 @@ package cpuinfo
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/cpuset"
 )
@@ -141,8 +141,8 @@ func NewSystemCPUInfo() *SystemCPUInfo {
 }
 
 // GetCPUTopology returns the CPUTopology of the system.
-func (s *SystemCPUInfo) GetCPUTopology() (*CPUTopology, error) {
-	cpuInfos, err := s.GetCPUInfos()
+func (s *SystemCPUInfo) GetCPUTopology(logger logr.Logger) (*CPUTopology, error) {
+	cpuInfos, err := s.GetCPUInfos(logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CPU infos: %w", err)
 	}
@@ -173,7 +173,7 @@ func (s *SystemCPUInfo) GetCPUTopology() (*CPUTopology, error) {
 
 	smtEnabled, err := s.IsSMTEnabled()
 	if err != nil {
-		log.Printf("Warning: could not determine SMT status from sysfs: %v. Falling back to CPU/Core count.", err)
+		logger.Info("could not determine SMT status from sysfs, falling back to CPU/Core count", "err", err)
 		smtEnabled = len(cpuInfos) > cores.Len()
 	}
 
@@ -206,7 +206,7 @@ func (s *SystemCPUInfo) IsSMTEnabled() (bool, error) {
 }
 
 // GetCPUInfos returns a slice of CPUInfo structs, one for each logical CPU.
-func (s *SystemCPUInfo) GetCPUInfos() ([]CPUInfo, error) {
+func (s *SystemCPUInfo) GetCPUInfos(logger logr.Logger) ([]CPUInfo, error) {
 	// Discover online CPUs from sysfs
 	onlineFilename := hostSys("devices/system/cpu/online")
 	onlineContent, err := ReadFile(onlineFilename)
@@ -258,8 +258,8 @@ func (s *SystemCPUInfo) GetCPUInfos() ([]CPUInfo, error) {
 			cpuInfo.CoreType = CoreTypeStandard
 		}
 
-		if err := populateTopologyInfo(&cpuInfo); err != nil {
-			log.Printf("Warning: skipping CPU %d due to incomplete topology: %v", cpuID, err)
+		if err := populateTopologyInfo(&cpuInfo, logger); err != nil {
+			logger.Info("skipping CPU due to incomplete topology", "cpuID", cpuID, "err", err)
 			continue
 		}
 
@@ -271,7 +271,7 @@ func (s *SystemCPUInfo) GetCPUInfos() ([]CPUInfo, error) {
 	return cpuInfos, nil
 }
 
-func populateTopologyInfo(cpuInfo *CPUInfo) error {
+func populateTopologyInfo(cpuInfo *CPUInfo, logger logr.Logger) error {
 	cpuID := cpuInfo.CpuID
 
 	// Get Socket ID from sysfs
@@ -293,7 +293,7 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 	if err == nil {
 		clusterID, err := strconv.Atoi(strings.TrimSpace(clusterStr))
 		if err != nil {
-			log.Printf("Warning: could not parse cluster_id %q for cpu %d: %v", clusterStr, cpuID, err)
+			logger.V(2).Info("could not parse sysfs data", "clusterID", clusterStr, "cpuID", cpuID, "err", err)
 			cpuInfo.ClusterID = -1
 		} else {
 			// The kernel default for an undefined cluster id is -1.
@@ -333,7 +333,7 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 		if strings.HasPrefix(file.Name(), "node") {
 			nodeID, err := strconv.Atoi(strings.TrimPrefix(file.Name(), "node"))
 			if err != nil {
-				log.Printf("Warning: could not parse NUMA node ID from %s: %v", file.Name(), err)
+				logger.V(2).Info("could not parse sysfs data for NUMA node ID", "entry", file.Name(), "err", err)
 				continue
 			}
 			cpuInfo.NUMANodeID = nodeID
@@ -343,12 +343,12 @@ func populateTopologyInfo(cpuInfo *CPUInfo) error {
 			cpuListPath := hostSys(fmt.Sprintf("devices/system/node/node%d/cpulist", nodeID))
 			cpuListLines, err := ReadLines(cpuListPath)
 			if err != nil || len(cpuListLines) == 0 {
-				log.Printf("Warning: could not read NUMA affinity mask for node %d: %v", nodeID, err)
+				logger.V(2).Info("could not read sysfs data for NUMA affinity mask", "nodeID", nodeID, "err", err)
 				continue
 			}
 			cpuInfo.NumaNodeCPUSet, err = cpuset.Parse(cpuListLines[0])
 			if err != nil {
-				log.Printf("Warning: could not parse NUMA affinity mask for node %d: %v", nodeID, err)
+				logger.V(2).Info("could not parse sysfs data for NUMA affinity mask", "nodeID", nodeID, "err", err)
 				continue
 			}
 			break

--- a/pkg/cpuinfo/cpuinfo_test.go
+++ b/pkg/cpuinfo/cpuinfo_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"k8s.io/utils/cpuset"
 )
 
@@ -198,6 +199,7 @@ func createFakeCPUTopology(t *testing.T, dir string, topo fakeCPUTopology) {
 }
 
 func TestGetCPUInfos(t *testing.T) {
+	logger := testr.New(t)
 	testCases := []struct {
 		name          string
 		topology      fakeCPUTopology
@@ -318,7 +320,7 @@ func TestGetCPUInfos(t *testing.T) {
 			createFakeCPUTopology(t, tmpDir, tc.topology)
 
 			provider := NewSystemCPUInfo()
-			cpuInfos, err := provider.GetCPUInfos()
+			cpuInfos, err := provider.GetCPUInfos(logger)
 			if err != nil {
 				t.Fatalf("GetCPUInfos() failed: %v", err)
 			}
@@ -338,6 +340,7 @@ func TestGetCPUInfos(t *testing.T) {
 }
 
 func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
+	logger := testr.New(t)
 	baseTopo := fakeCPUTopology{
 		numSockets: 1, numNumaNodesPerSocket: 1, numCoresPerNumaNode: 1, cpusPerCore: 1, coresPerL3: 1,
 	}
@@ -427,7 +430,7 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 			tc.setup(t, tmpDir)
 
 			provider := NewSystemCPUInfo()
-			cpuInfos, err := provider.GetCPUInfos()
+			cpuInfos, err := provider.GetCPUInfos(logger)
 			if tc.expectedErrorSubstring != "" {
 				if err == nil {
 					t.Fatal("expected an error, but got none")
@@ -448,6 +451,7 @@ func TestGetCPUInfos_ErrorScenarios(t *testing.T) {
 }
 
 func TestSMTDetection(t *testing.T) {
+	logger := testr.New(t)
 	testCases := []struct {
 		name          string
 		topology      fakeCPUTopology
@@ -544,7 +548,7 @@ func TestSMTDetection(t *testing.T) {
 			}
 
 			provider := NewSystemCPUInfo()
-			topo, err := provider.GetCPUTopology()
+			topo, err := provider.GetCPUTopology(logger)
 			if err != nil {
 				t.Fatalf("GetCPUTopology() failed: %v", err)
 			}
@@ -557,6 +561,7 @@ func TestSMTDetection(t *testing.T) {
 }
 
 func TestGetCPUTopology(t *testing.T) {
+	logger := testr.New(t)
 	testCases := []struct {
 		name          string
 		topology      fakeCPUTopology
@@ -597,7 +602,7 @@ func TestGetCPUTopology(t *testing.T) {
 			createFakeCPUTopology(t, tmpDir, tc.topology)
 
 			provider := NewSystemCPUInfo()
-			topo, err := provider.GetCPUTopology()
+			topo, err := provider.GetCPUTopology(logger)
 			if err != nil {
 				t.Fatalf("GetCPUTopology() failed: %v", err)
 			}

--- a/pkg/cpuinfo/mock_cpuinfo.go
+++ b/pkg/cpuinfo/mock_cpuinfo.go
@@ -18,6 +18,8 @@ package cpuinfo
 
 import (
 	"fmt"
+
+	"github.com/go-logr/logr"
 )
 
 type MockCPUInfoProvider struct {
@@ -25,11 +27,11 @@ type MockCPUInfoProvider struct {
 	Err      error
 }
 
-func (m *MockCPUInfoProvider) GetCPUInfos() ([]CPUInfo, error) {
+func (m *MockCPUInfoProvider) GetCPUInfos(_ logr.Logger) ([]CPUInfo, error) {
 	return m.CPUInfos, m.Err
 }
 
-func (m *MockCPUInfoProvider) GetCPUTopology() (*CPUTopology, error) {
+func (m *MockCPUInfoProvider) GetCPUTopology(_ logr.Logger) (*CPUTopology, error) {
 	cpuDetails := make(CPUDetails)
 	sockets := make(map[int]struct{})
 	numaNodes := make(map[int]struct{})

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -28,6 +28,8 @@ import (
 
 // NOTE: This file is a copy of https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
 // as of commit https://github.com/kubernetes/kubernetes/commit/fd5b2efa76e44c5ef523cd0711f5ed23eb7e6b1a with minor modifications.
+// NOTE: about contextual logging: different from the other parts of the codebase, we *intentionally* keep klog references
+// to minimize the changes wrt the kubernetes codebase till (if) we decide to fully fork it.
 
 func TestCPUAccumulatorFreeSockets(t *testing.T) {
 	logger := klog.Background()

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/ctxlog"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpumanager"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
@@ -34,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
 	"k8s.io/utils/ptr"
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
@@ -224,8 +224,8 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 
 // PublishResources publishes ResourceSlice for CPU resources.
 func (cp *CPUDriver) PublishResources(ctx context.Context) {
-	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
-	ctx = klog.NewContext(ctx, logger)
+	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
+	ctx = ctxlog.NewContext(ctx, logger)
 
 	logger.V(4).Info("begin: publishing resources")
 	defer logger.V(4).Info("end: publishing resources")
@@ -262,7 +262,7 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 
 // PrepareResourceClaims is called by the kubelet to prepare a resource claim.
 func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
-	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
+	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
 
 	logger.V(4).Info("begin: preparing resource claims", "numClaims", len(claims))
 	defer logger.V(4).Info("end: preparing resource claims", "numClaims", len(claims))
@@ -274,7 +274,7 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 	}
 
 	for _, claim := range claims {
-		cLogger := logger.WithValues("claim", klog.KObj(claim), "claimUID", claim.UID)
+		cLogger := logger.WithValues("claim", ctxlog.KObj(claim), "claimUID", claim.UID)
 		if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
 			result[claim.UID] = cp.prepareGroupedResourceClaim(cLogger, claim)
 		} else {
@@ -441,7 +441,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 
 // UnprepareResourceClaims is called by the kubelet to unprepare the resources for a claim.
 func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
-	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
+	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
 
 	logger.V(4).Info("begin: unpreparing resource claims", "numClaims", len(claims))
 	defer logger.V(4).Info("end: unpreparing resource claims", "numClaims", len(claims))
@@ -474,7 +474,7 @@ func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplu
 // HandleError is called by the kubelet plugin framework when an error occurs in the background,
 // for example while publishing ResourceSlices.
 func (cp *CPUDriver) HandleError(ctx context.Context, err error, msg string) {
-	logger := klog.FromContext(ctx)
+	logger := ctxlog.FromContext(ctx)
 
 	// Log the error using the standard Kubernetes error handler
 	runtime.HandleErrorWithContext(ctx, err, msg)
@@ -488,7 +488,7 @@ func (cp *CPUDriver) HandleError(ctx context.Context, err error, msg string) {
 			"node", cp.nodeName,
 			"message", msg,
 		)
-		klog.Flush()
+		ctxlog.Flush()
 		os.Exit(1)
 	}
 }

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -224,8 +224,7 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 
 // PublishResources publishes ResourceSlice for CPU resources.
 func (cp *CPUDriver) PublishResources(ctx context.Context) {
-	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
-	ctx = ctxlog.NewContext(ctx, logger)
+	ctx, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "deviceMode", cp.cpuDeviceMode, "groupBy", cp.cpuDeviceGroupBy)
 
 	logger.V(4).Info("begin: publishing resources")
 	defer logger.V(4).Info("end: publishing resources")
@@ -262,7 +261,7 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 
 // PrepareResourceClaims is called by the kubelet to prepare a resource claim.
 func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resourceapi.ResourceClaim) (map[types.UID]kubeletplugin.PrepareResult, error) {
-	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
+	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen))
 
 	logger.V(4).Info("begin: preparing resource claims", "numClaims", len(claims))
 	defer logger.V(4).Info("end: preparing resource claims", "numClaims", len(claims))
@@ -441,7 +440,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 
 // UnprepareResourceClaims is called by the kubelet to unprepare the resources for a claim.
 func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubeletplugin.NamespacedObject) (map[types.UID]error, error) {
-	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
+	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen))
 
 	logger.V(4).Info("begin: unpreparing resource claims", "numClaims", len(claims))
 	defer logger.V(4).Info("end: unpreparing resource claims", "numClaims", len(claims))

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -169,6 +169,7 @@ var (
 )
 
 func TestPublishResources(t *testing.T) {
+	logger := testr.New(t)
 	testCases := []struct {
 		name                       string
 		cpuInfos                   []cpuinfo.CPUInfo
@@ -297,7 +298,7 @@ func TestPublishResources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockPlugin := &mockKubeletPlugin{publishError: tc.publishError}
 			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: tc.cpuInfos, Err: tc.cpuInfoErr}
-			topo, _ := mockProvider.GetCPUTopology()
+			topo, _ := mockProvider.GetCPUTopology(logger)
 			cp := &CPUDriver{
 				nodeName:          testNodeName,
 				draPlugin:         mockPlugin,
@@ -411,8 +412,9 @@ func TestPublishResources(t *testing.T) {
 }
 
 func TestPrepareResourceClaims(t *testing.T) {
+	logger := testr.New(t)
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
-	topo, _ := mockProvider.GetCPUTopology()
+	topo, _ := mockProvider.GetCPUTopology(logger)
 	baseCPUDriver := func() *CPUDriver {
 		return &CPUDriver{
 			driverName: testDriverName,
@@ -576,7 +578,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 			driver: func() *CPUDriver {
 				d := baseCPUDriver()
 				// Pre-allocate cpudev0 to an existing claim
-				d.cpuAllocationStore.AddResourceClaimAllocation(testr.New(t), "claim0", cpuset.New(0))
+				d.cpuAllocationStore.AddResourceClaimAllocation(logger, "claim0", cpuset.New(0))
 				return d
 			}(),
 			claims: []*resourceapi.ResourceClaim{
@@ -641,13 +643,13 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 		driver.deviceNameToSocketID = make(map[string]int)
 		driver.deviceNameToNUMANodeID = make(map[string]int)
 		mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: cpuInfos}
-		driver.cpuTopology, _ = mockProvider.GetCPUTopology()
+		driver.cpuTopology, _ = mockProvider.GetCPUTopology(logger)
 		driver.cpuAllocationStore = store.NewCPUAllocation(driver.cpuTopology, reservedCPUs)
 		for claimUID, cpus := range initialAllocations {
 			driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, cpus)
 		}
 
-		topo, err := mockProvider.GetCPUTopology()
+		topo, err := mockProvider.GetCPUTopology(logger)
 		require.NoError(t, err) // We don't expect errors in test setup
 
 		switch driver.cpuDeviceGroupBy {
@@ -938,6 +940,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 }
 
 func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
+	logger := testr.New(t)
 	claimUID := types.UID("claim-1")
 	cdiDeviceName := getCDIDeviceName(claimUID)
 
@@ -967,7 +970,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
-			topo, _ := mockProvider.GetCPUTopology()
+			topo, _ := mockProvider.GetCPUTopology(logger)
 			driver := &CPUDriver{
 				driverName: testDriverName,
 				deviceNameToCPUID: map[string]int{
@@ -1019,6 +1022,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 }
 
 func TestUnprepareResourceClaims(t *testing.T) {
+	logger := testr.New(t)
 	claimUID := types.UID("test-claim-uid")
 
 	testCases := []struct {
@@ -1052,7 +1056,7 @@ func TestUnprepareResourceClaims(t *testing.T) {
 			mockCdiMgr := newMockCdiMgr()
 			mockCdiMgr.removeError = tc.cdiRemoveError
 			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
-			topo, _ := mockProvider.GetCPUTopology()
+			topo, _ := mockProvider.GetCPUTopology(logger)
 			cp := &CPUDriver{
 				cdiMgr:             mockCdiMgr,
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -72,8 +72,8 @@ type cdiManager interface {
 // CPUInfoProvider is an interface for getting CPU information.
 // TODO(pravk03): This interface can be simplified. We can export only GetCPUTopology() and remove GetCPUInfos().
 type CPUInfoProvider interface {
-	GetCPUInfos() ([]cpuinfo.CPUInfo, error)
-	GetCPUTopology() (*cpuinfo.CPUTopology, error)
+	GetCPUInfos(logger logr.Logger) ([]cpuinfo.CPUInfo, error)
+	GetCPUTopology(logger logr.Logger) (*cpuinfo.CPUTopology, error)
 }
 
 // CPUDriver is the structure that holds all the driver runtime information.
@@ -120,8 +120,9 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		cpuDeviceGroupBy:       config.CPUDeviceGroupBy,
 		claimTracker:           store.NewClaimTracker(),
 	}
+	logger := klog.FromContext(ctx)
 	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()
-	topo, err := cpuInfoProvider.GetCPUTopology()
+	topo, err := cpuInfoProvider.GetCPUTopology(logger)
 	if err != nil {
 		return nil, asyncErr, fmt.Errorf("failed to get CPU topology: %w", err)
 	}
@@ -158,7 +159,6 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		return nil, asyncErr, err
 	}
 
-	logger := klog.FromContext(ctx)
 	logger = logger.WithValues("driver", config.DriverName)
 	ctx = klog.NewContext(ctx, logger)
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -26,13 +26,13 @@ import (
 
 	"github.com/containerd/nri/pkg/stub"
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/ctxlog"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
 )
 
@@ -120,7 +120,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		cpuDeviceGroupBy:       config.CPUDeviceGroupBy,
 		claimTracker:           store.NewClaimTracker(),
 	}
-	logger := klog.FromContext(ctx)
+	logger := ctxlog.FromContext(ctx)
 	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()
 	topo, err := cpuInfoProvider.GetCPUTopology(logger)
 	if err != nil {
@@ -160,7 +160,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	}
 
 	logger = logger.WithValues("driver", config.DriverName)
-	ctx = klog.NewContext(ctx, logger)
+	ctx = ctxlog.NewContext(ctx, logger)
 
 	cdiMgr, err := NewCdiManager(logger, config.DriverName)
 	if err != nil {
@@ -205,7 +205,7 @@ func (cp *CPUDriver) Stop() {
 
 // Shutdown is called when the runtime is shutting down.
 func (cp *CPUDriver) Shutdown(ctx context.Context) {
-	logger := klog.FromContext(ctx)
+	logger := ctxlog.FromContext(ctx)
 	logger.Info("runtime shutting down")
 }
 
@@ -214,7 +214,7 @@ type nriRunner interface {
 }
 
 func runNRIPluginWithRetry(ctx context.Context, plugin nriRunner, maxAttempts int) error {
-	logger := klog.FromContext(ctx)
+	logger := ctxlog.FromContext(ctx)
 	for i := 0; i < maxAttempts; i++ {
 		err := plugin.Run(ctx)
 		if ctx.Err() != nil {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -159,8 +159,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		return nil, asyncErr, err
 	}
 
-	logger = logger.WithValues("driver", config.DriverName)
-	ctx = ctxlog.NewContext(ctx, logger)
+	ctx, logger = ctxlog.WithValues(ctx, "driver", config.DriverName)
 
 	cdiMgr, err := NewCdiManager(logger, config.DriverName)
 	if err != nil {

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -23,15 +23,15 @@ import (
 
 	"github.com/containerd/nri/pkg/api"
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/ctxlog"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
 )
 
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
 func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
+	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
 
 	// this happens once at startup and it's critical enough that we always want to see it.
 	logger.Info("begin: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
@@ -42,7 +42,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	var containerUpdates []*api.ContainerUpdate
 
 	for _, pod := range pods {
-		pLogger := logger.WithValues("pod", klog.KObj(pod), "podUID", pod.Uid)
+		pLogger := logger.WithValues("pod", ctxlog.KObj(pod), "podUID", pod.Uid)
 		pLogger.V(2).Info("synchronize pod")
 		for _, container := range containers {
 			if container.PodSandboxId != pod.Id {
@@ -150,7 +150,7 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 
 // CreateContainer handles container creation requests from the NRI.
 func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: CreateContainer")
 	defer logger.V(2).Info("end: CreateContainer")
 
@@ -198,7 +198,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 }
 
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
-	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: StopContainer")
 	defer logger.V(2).Info("end: StopContainer")
 
@@ -229,7 +229,7 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 
 // RemoveContainer handles container removal requests from the NRI.
 func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
-	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", klog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: RemoveContainer")
 	defer logger.V(2).Info("end: RemoveContainer")
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -31,7 +31,7 @@ import (
 
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
 func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
-	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
+	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen))
 
 	// this happens once at startup and it's critical enough that we always want to see it.
 	logger.Info("begin: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
@@ -150,7 +150,7 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 
 // CreateContainer handles container creation requests from the NRI.
 func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
-	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: CreateContainer")
 	defer logger.V(2).Info("end: CreateContainer")
 
@@ -198,7 +198,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 }
 
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
-	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: StopContainer")
 	defer logger.V(2).Info("end: StopContainer")
 
@@ -229,7 +229,7 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 
 // RemoveContainer handles container removal requests from the NRI.
 func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
-	logger := ctxlog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
+	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: RemoveContainer")
 	defer logger.V(2).Info("end: RemoveContainer")
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestParseDRAEnvToClaimAllocations(t *testing.T) {
+	logger := testr.New(t)
 	testCases := []struct {
 		name                  string
 		envs                  []string
@@ -80,7 +81,6 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := testr.New(t)
 			allocations, err := parseDRAEnvToClaimAllocations(logger, tc.envs)
 			if tc.expectedErrorContains != "" {
 				require.Error(t, err)
@@ -107,8 +107,9 @@ func TestCreateContainer(t *testing.T) {
 	for _, cpuID := range allCPUs.UnsortedList() {
 		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NUMANodeID: 0})
 	}
+	logger := testr.New(t)
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: infos}
-	topo, _ := mockProvider.GetCPUTopology()
+	topo, _ := mockProvider.GetCPUTopology(logger)
 
 	// newTestContainer is a local helper to simplify test case definitions.
 	newTestContainer := func(claimUID, cpus string) *api.Container {
@@ -165,7 +166,7 @@ func TestCreateContainer(t *testing.T) {
 			}(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				store.AddResourceClaimAllocation(testr.New(t), types.UID(claimUID), cpuset.New(2, 3))
+				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -219,6 +220,7 @@ func TestCreateContainer(t *testing.T) {
 }
 
 func TestStopContainer(t *testing.T) {
+	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	pod1 := &api.PodSandbox{Id: "pod-id-1", Name: "my-pod-1", Namespace: "my-ns", Uid: "pod-uid-1"}
 	ctr1 := &api.Container{Id: "ctr-id-1", PodSandboxId: pod1.Id, Name: "my-ctr-1"}
@@ -230,7 +232,7 @@ func TestStopContainer(t *testing.T) {
 		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NUMANodeID: 0})
 	}
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: infos}
-	topo, _ := mockProvider.GetCPUTopology()
+	topo, _ := mockProvider.GetCPUTopology(logger)
 
 	testCases := []struct {
 		name               string
@@ -280,13 +282,14 @@ func TestStopContainer(t *testing.T) {
 }
 
 func TestNRISynchronize(t *testing.T) {
+	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	var infos []cpuinfo.CPUInfo
 	for _, cpuID := range allCPUs.UnsortedList() {
 		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID})
 	}
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: infos}
-	topo, _ := mockProvider.GetCPUTopology()
+	topo, _ := mockProvider.GetCPUTopology(logger)
 
 	pod1 := &api.PodSandbox{Id: "pod-id-1", Name: "my-pod-1", Namespace: "my-ns", Uid: "pod-uid-1"}
 	pod2 := &api.PodSandbox{Id: "pod-id-2", Name: "my-pod-2", Namespace: "my-ns", Uid: "pod-uid-2"}

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -28,17 +28,18 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
-func newTestCPUAllocation(allCPUs, reserved cpuset.CPUSet) *CPUAllocation {
+func newTestCPUAllocation(logger logr.Logger, allCPUs, reserved cpuset.CPUSet) *CPUAllocation {
 	var infos []cpuinfo.CPUInfo
 	for _, cpuID := range allCPUs.UnsortedList() {
 		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NUMANodeID: 0})
 	}
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: infos}
-	topo, _ := mockProvider.GetCPUTopology()
+	topo, _ := mockProvider.GetCPUTopology(logger)
 	return NewCPUAllocation(topo, reserved)
 }
 
 func TestNewCPUAllocation(t *testing.T) {
+	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	testCases := []struct {
 		name               string
@@ -64,7 +65,7 @@ func TestNewCPUAllocation(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			store := newTestCPUAllocation(tc.allCPUs, tc.reservedCPUs)
+			store := newTestCPUAllocation(logger, tc.allCPUs, tc.reservedCPUs)
 			require.NotNil(t, store)
 			require.True(t, store.availableCPUs.Equals(tc.expectedAvailable))
 			require.True(t, store.GetSharedCPUs().Equals(tc.expectedSharedCPUs))
@@ -75,7 +76,7 @@ func TestNewCPUAllocation(t *testing.T) {
 func TestCPUAllocationResourceClaimAllocation(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
-	store := newTestCPUAllocation(allCPUs, cpuset.New())
+	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 	claimUID := types.UID("claim-uid-1")
 	cpus := cpuset.New(0, 1)
 
@@ -98,7 +99,7 @@ func TestCPUAllocationGetSharedCPUs(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	reserved := cpuset.New(0)
-	store := newTestCPUAllocation(allCPUs, reserved)
+	store := newTestCPUAllocation(logger, allCPUs, reserved)
 	available := allCPUs.Difference(reserved)
 
 	// No allocations
@@ -119,6 +120,7 @@ func TestCPUAllocationGetSharedCPUs(t *testing.T) {
 }
 
 func TestAddResourceClaimAllocationRepeatedCalls(t *testing.T) {
+	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	testCases := []struct {
 		name           string
@@ -151,8 +153,7 @@ func TestAddResourceClaimAllocationRepeatedCalls(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := testr.New(t)
-			store := newTestCPUAllocation(allCPUs, cpuset.New())
+			store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 			claimUID := types.UID("claim-uid-1")
 
 			store.AddResourceClaimAllocation(logger, claimUID, tc.firstCPUs)
@@ -169,7 +170,7 @@ func TestAddResourceClaimAllocationRepeatedCalls(t *testing.T) {
 func TestCPUAllocationStoreCacheConsistency(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
-	store := newTestCPUAllocation(allCPUs, cpuset.New())
+	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 
 	store.AddResourceClaimAllocation(logger, "claim-1", cpuset.New(0, 1))
 	store.AddResourceClaimAllocation(logger, "claim-2", cpuset.New(2, 3))
@@ -215,7 +216,7 @@ func BenchmarkGetSharedCPUs(b *testing.B) {
 			infos = append(infos, cpuinfo.CPUInfo{CpuID: i, CoreID: i, SocketID: 0, NUMANodeID: 0})
 		}
 		mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: infos}
-		topo, _ := mockProvider.GetCPUTopology()
+		topo, _ := mockProvider.GetCPUTopology(logr.Discard())
 
 		allocations := make(map[types.UID]cpuset.CPUSet)
 		for i := 0; i < tc.numAllocations && i*2+1 < tc.numCPUs; i++ {

--- a/test/image/dracpuinfo/app.go
+++ b/test/image/dracpuinfo/app.go
@@ -19,15 +19,18 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 
+	"github.com/go-logr/stdr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 )
 
 func main() {
+	logger := stdr.New(log.Default())
 	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()
-	cpus, err := cpuInfoProvider.GetCPUInfos()
+	cpus, err := cpuInfoProvider.GetCPUInfos(logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error getting cpu info: %v\n", err)
 		os.Exit(1)

--- a/test/image/dracputester/app.go
+++ b/test/image/dracputester/app.go
@@ -19,11 +19,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"golang.org/x/sys/unix"
@@ -82,27 +85,28 @@ func affinityScanBoundFromTopology(topo *cpuinfo.CPUTopology) int {
 	return list[len(list)-1] + 1
 }
 
-func getAffinity() (cpuset.CPUSet, error) {
+func getAffinity(logger logr.Logger) (cpuset.CPUSet, error) {
 	var unixCS unix.CPUSet
 	err := unix.SchedGetaffinity(os.Getpid(), &unixCS)
 	if err != nil {
 		return cpuset.New(), err
 	}
 	maxCPUID := 0
-	if topo, err := cpuinfo.NewSystemCPUInfo().GetCPUTopology(); err == nil {
+	if topo, err := cpuinfo.NewSystemCPUInfo().GetCPUTopology(logger); err == nil {
 		maxCPUID = affinityScanBoundFromTopology(topo)
 	}
 	return affinityFromMask(&unixCS, maxCPUID), nil
 }
 
 func main() {
+	logger := stdr.New(log.Default())
 	for {
 		cpus, err := cpuSet("/sys")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error determining allocated cpus: %v\n", err)
 			os.Exit(1)
 		}
-		cpuAff, err := getAffinity()
+		cpuAff, err := getAffinity(logger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error determining CPU affinity: %v\n", err)
 			os.Exit(2)


### PR DESCRIPTION
Finalizes the port to contextual logging.
Port `cpuinfo` to contextual logging, which missed the previous update train; update the logging guidelines.
Isolate `klog` calls cleanly - our application code should reason in terms of `logr`, and `klog` should only used in plumbing, or where the few and rare exception (documented) warrant.

Finally, address the concern raised in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/137#issuecomment-4470689688 about the footgun of missing the enriched logger.

Builds on top of #129 #137 
Closes: #118 