### PR TITLE
[Do Not Merge] POC for Mixed CPU Allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The driver can be configured with the following command-line flags:
   - `"numanode"` (default): Groups CPUs by NUMA node.
   - `"socket"`: Groups CPUs by socket.
 - `--reserved-cpus`: Specifies a set of CPUs to be reserved for system and kubelet processes. These CPUs will not be allocatable by the DRA driver and would be excluded from the `ResourceSlice`. The value is a cpuset, e.g., `0-1`. This semantic is the same as the one the kubelet applies with its `static` CPU Manager policy and enabling [`strict-cpu-reservation`](https://kubernetes.io/blog/2024/12/16/cpumanager-strict-cpu-reservation/) flag and specifying the CPUs with the [`reservedSystemCPUs`](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list) to be reserved for system daemons. For correct CPU accounting, the number of CPUs reserved with this flag should match the sum of the kubelet's `kubeReserved` and `systemReserved` settings. This ensures the kubelet subtracts the correct number of CPUs from `Node.Status.Allocatable`.
+- `--disable-node-allocatable-mapping`: Disables the native NodeAllocatable resource mapping in the `ResourceSlice` (per [KEP-5517: DRA: Node Allocatable Resources](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5517-dra-node-allocatable-resources/README.md), tracked in [enhancements issue #5517](https://github.com/kubernetes/enhancements/issues/5517)).
+  - **How it works**: By default (`false`), the driver automatically adds a native resource mapping entry to the exposed CPU devices in its `ResourceSlice` objects. This allows the `kube-scheduler` to perform **Unified Accounting** across standard resources and DRA resources (`DynamicResources` plugin). The scheduler natively subtracts the CPU capacity allocated to DRA `ResourceClaims` directly from the Node's total Allocatable CPU capacity. This avoids resource overcommit/double-counting when running a mix of DRA and non-DRA workloads on the node, and removes the need to duplicate resource requests in the standard container `resources.requests.cpu` block.
+  - **When to disable**: Set this flag to `true` if you are relying on the duplicate/mirror resource declaration workarounds in the Pod spec to perform scheduler accounting manually (as described in [With KEP-5517 Disabled](#with-kep-5517-disabled-or-on-older-kubernetes-control-planes-131)), or if your Kubernetes control plane is older than 1.37 and does not support KEP-5517.
+- `--mixed-allocation-mode`: Enables hybrid "mixed allocation" mode for workloads.
+  - **How it works**: When enabled, a single container can simultaneously request dedicated exclusive CPUs via DRA resource claims (for low-latency, performance-critical tasks) and standard shared CPU resources via `resources.requests.cpu` in the standard Pod spec (to run background helper threads, sidecars, or bursty standard tasks). The driver's NRI plugin dynamically detects this hybrid request by inspecting the container's runtime CGroup CPU shares (which Kubelet configures to `shares > MinCPUShares` only if the container has explicit standard CPU requests). It then adjusts the container's CPU affinity to the union of its dedicated exclusive CPUs and the general shared CPU pool, while dynamically shrinking the shared CPU pool of other containers by subtracting those exclusive CPUs. (Default: `false`).
 
 ## How it Works
 
@@ -53,10 +58,11 @@ The driver is deployed as a DaemonSet which contains two core components:
 
 - **NRI Plugin**: This component integrates with the container runtime via the Node Resource Interface (NRI).
 
-  - For containers with **guaranteed CPUs** (those with a DRA ResourceClaim), the plugin reads the environment variable injected via CDI and pins the container to its exclusive CPU set using the cgroup cpuset controller.
+  - For containers with **guaranteed CPUs** (those with a DRA ResourceClaim and no standard CPU requests), the plugin reads the environment variable injected via CDI and pins the container strictly to its exclusive CPU set using the cgroup cpuset controller.
+  - For containers running in **mixed allocation mode** (those with both DRA ResourceClaims and standard CPU requests), the plugin detects this by inspecting the container's CGroup CPU shares (where Kubelet configures `shares > 2` when a container has explicit CPU requests). It pins the container to the union of its dedicated exclusive CPUs and the shared CPU pool.
   - For all other containers, it confines them to a **shared pool** of CPUs, which consists of all allocatable CPUs not exclusively assigned to any guaranteed container.
-  - It dynamically updates the shared pool cpuset for all shared containers whenever guaranteed allocations change (containers are created or removed).
-  - On restart, the NRI plugin can synchronize its state by inspecting existing containers and their environment variables to rebuild the current CPU allocations.
+  - It dynamically updates the shared pool cpuset for all shared and mixed containers whenever exclusive allocations change (exclusive containers are created, modified, or removed).
+  - On restart, the NRI plugin synchronizes its state by inspecting existing containers, their CGroup shares, and environment variables to fully rebuild CPU allocations.
 
 ## Feature Support
 
@@ -74,6 +80,8 @@ The driver is deployed as a DaemonSet which contains two core components:
 - **Multiple Device Exposure Modes**:
   - **Individual Mode**: Each CPU is a device, allowing for selection based on attributes like CPU ID, core type, NUMA node, etc. This mode is ideal for workloads requiring fine-grained control over CPU placement, common in HPC or performance-critical applications.
   - **Grouped Mode**: CPUs are grouped (e.g., by NUMA node or socket) and treated as a consumable capacity within that group. This helps in reducing the number of devices exposed to the API server, especially on systems with a large number of CPUs, thus improving scalability. This mode is suitable for workloads needing alignment with other DRA resources within the same group (e.g., NUMA node) or where the exact CPU IDs are less critical than the quantity.
+- **NodeAllocatable Resource Mapping (KEP-5517)**: Enables natively mapping exposed CPU devices in the `ResourceSlice` to node-allocatable capacities. This allows the kube-scheduler to track and subtract DRA allocations natively, guaranteeing coordinated scheduling with standard CPU workloads on the same node without double-booking.
+- **Mixed Allocation Mode**: Allows hybrid workloads where a single container can be allocated dedicated exclusive CPUs via DRA claims while simultaneously using the shared CPU pool for standard/bursty workloads, detected automatically via CGroup shares.
 
 ### Not Supported
 
@@ -95,6 +103,85 @@ and DRA-managed core resources.
 This gap is meant to be addressed by KEP-5517 (Native Resource Management). However, until
 that KEP progresses and gets traction, the safest approach for this driver is to prevent
 any resource claim sharing.
+
+### Mixed Allocation Mode
+
+Mixed Allocation Mode allows a hybrid execution model where a single container can simultaneously access dedicated exclusive CPUs (allocated via DRA claims for low-latency tasks) and standard shared CPU capacity (for sidecars, helper threads, or background tasks).
+
+#### When is Mixed Allocation Mode Enabled?
+
+Mixed Allocation Mode is enabled for a workload only when both of the following conditions are met:
+
+1. **Driver Flag**: The driver is run with the `--mixed-allocation-mode` command-line flag set to `true` (default: `false`).
+1. **Container Spec**: The target container requests *both* standard CPU resources (via `resources.requests.cpu`) and a DRA CPU claim (via `resources.claims`).
+
+> [!IMPORTANT]
+> **Container CPU Shares**: Kubelet configures a container's runtime CPU cgroup shares strictly based on its standard `resources.requests.cpu` block. If standard CPU requests are omitted, Kubelet defaults the container's shares to `2`. The driver's NRI plugin relies on this behavior and only enables mixed mode for containers with shares strictly greater than `2` (i.e. when standard CPU requests exist). Therefore, you **must** specify standard CPU requests in the container spec alongside your claims to trigger mixed allocation.
+
+##### Example Workload Snippet
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-cpu-mixed-mode
+spec:
+  containers:
+    - name: main-application
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        requests:
+          cpu: "2" # Requests 2 shared CPUs for background tasks (triggers mixed mode)
+        claims:
+          - name: "dedicated-cpu-claim-ref" # Requests 4 exclusive CPUs
+  resourceClaims:
+    - name: "dedicated-cpu-claim-ref"
+      resourceClaimName: claim-cpu-capacity-4 # Requests 4 CPUs
+```
+
+#### Falling Back to Guaranteed-Only Mode
+
+If the driver's `--mixed-allocation-mode` flag is set to `true`, but the target container does *not* request standard CPU resources in its spec, the container **automatically defaults to strictly Guaranteed-only mode**.
+
+Under this mode:
+
+- The container is pinned **exclusively** to its assigned dedicated CPUs.
+- The container is **denied access** to the node's general shared CPU pool.
+- The CPU affinity mask set by the NRI plugin will contain *only* the exclusive cores.
+
+##### Example Guaranteed-Only Snippet
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-cpu-guaranteed-only
+spec:
+  containers:
+    - name: high-perf-application
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        # Omit standard requests.cpu (CPU shares will default to 2)
+        claims:
+          - name: "dedicated-cpu-claim-ref" # Requests 4 exclusive CPUs
+  resourceClaims:
+    - name: "dedicated-cpu-claim-ref"
+      resourceClaimName: claim-cpu-capacity-4 # Requests 4 CPUs
+```
+
+#### Thread Pinning and Workload Responsibility
+
+When Mixed Allocation Mode is active, the NRI plugin configures the container's overall CPU affinity mask to be the **union** of its dedicated exclusive CPUs and the node's shared CPU pool.
+
+While this ensures the container can access both resource pools, please note:
+
+- **OS Scheduler Behavior**: By default, the OS scheduler may run *any* thread in the container on *any* CPU in the union cpuset.
+- **Workload Responsibility**: **It is the workload's responsibility** to programmatically pin its performance-critical, low-latency threads to the dedicated exclusive CPUs, leaving the shared pool for background or non-critical threads.
+
+##### How to Pin Threads Programmatically
+
+1. **Discover Exclusive CPUs**: The driver automatically injects environment variables starting with the `DRA_CPUSET_` prefix into the container (e.g., `DRA_CPUSET_<claim-uid>=0,1`). The value contains the specific exclusive cpuset assigned to that DRA claim.
+1. **Set Thread Affinity**: Workloads should programmatically parse these environment variables within their application code and use standard OS system calls (such as `sched_setaffinity` on Linux) to bind high-priority processing threads directly to that exclusive cpuset.
 
 ### Matching CPU Manager functionality
 
@@ -157,67 +244,100 @@ Currently, Kubernetes has two separate systems for requesting CPU resources: sta
 
 This discrepancy is a known issue being addressed by [KEP-5517: Native Resource Management for DRA](https://github.com/kubernetes/enhancements/issues/5517). Until KEP-5517 is implemented, you MUST configure your pods using one of the following methods to ensure correct behavior and resource accounting:
 
-- **Option A (Preferred): Pod Level Resources (`pod.spec.resources`)**
+### With KEP-5517 Enabled (Default, Recommended)
 
-  - This approach is generally preferred as it more clearly defines the pod's total CPU budget and works well for pods with a mix of containers, some needing exclusive CPUs (requested via DRA) and others using shared CPUs.
-  - Set `pod.spec.resources.requests.cpu` and `pod.spec.resources.limits.cpu` to the *sum* of all CPUs requested across all DRA claims used by containers in this pod, PLUS any additional CPUs for containers NOT using DRA claims.
-  - Containers using DRA claims may omit `cpu` from their `resources.requests` and `resources.limits`. The Pod Level Resources will govern the QoS class and set cgroup limits at the pod level.
+When KEP-5517 is active (meaning `--disable-node-allocatable-mapping` is set to `false`), the `kube-scheduler` performs **Unified Accounting**. It automatically tracks and subtracts the CPU capacity allocated to DRA `ResourceClaims` directly from the node's total Allocatable CPU pool.
 
-  ```yaml
-  # Example: Pod Level Resources
-  spec:
-    resources: # Pod Level Resources
-      requests:
-        cpu: "16" # 10 (exclusive cpu's for claim1) + 4 (exclusive cpu's for claim2) + 2 (shared cpus for sidecar1 and sidecar2)
-      limits:
-        cpu: "16"
-    containers:
-      - name: main-app
-        image: ...
-        resources:
-          # Omit CPU requests/limits, or set both to 10
-          claims:
-            - name: claim1
-      - name: worker
-        image: ...
-        resources:
-         # Omit CPU requests/limits, or set both to 4
-          claims:
-            - name: claim2
-      - name: sidecar1
-        image: ...
-        # Omit CPU resources, or ensure the combined requests/limits for sidecar1 and sidecar2 do not exceed 2.
-      - name: sidecar2
-        image: ...
-        # Omit CPU resources, or ensure the combined requests/limits for sidecar1 and sidecar2 do not exceed 2.
-    resourceClaims:
-      - name: claim1
-        resourceClaimName: cpu-claim-10 # Requests 10 CPUs
-      - name: claim2
-        resourceClaimName: cpu-claim-4  # Requests 4 CPUs
-  ```
+Consequently, you **DO NOT** need to duplicate or mirror resource requests in the container's standard `resources.requests.cpu` block. A container can request its DRA `ResourceClaim` directly, and scheduling accounting works out-of-the-box without risk of overcommitment.
 
-- **Option B: Container-Level Resources (No Pod Level Resources)**
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-app-with-dra-cpu
+spec:
+  containers:
+    - name: workload-container
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        claims:
+          - name: "pod-cpu-claim-ref"
+  resourceClaims:
+    - name: "pod-cpu-claim-ref"
+      resourceClaimName: claim-cpu-capacity-10 # Requests 10 CPUs
+```
 
-  - For each container that uses a DRA CPU claim, set `spec.containers[].resources.requests.cpu` and `spec.containers[].resources.limits.cpu` to be *exactly equal* to the number of CPUs requested in the `ResourceClaim` referenced by that container.
+> [!NOTE]
+> You should only include standard `resources.requests.cpu` alongside your claims if you are utilizing **Mixed Allocation Mode** (to leverage both dedicated and shared CPU pools) or if you need to define a custom QoS class/limits at the Pod level.
 
-  ```yaml
-  # Example: Container Level Mirroring
-  spec:
-    containers:
-      - name: my-container
-        image: ...
-        resources:
-          requests:
-            cpu: "10" # Must match the CPU count in "claim1"
-          limits:
-            cpu: "10" # Must match the CPU count in "claim1"
-          claims:
-            - name: claim1
-    resourceClaims:
-      - name: claim1
-        resourceClaimName: cpu-claim-10 # Requests 10 CPUs
-  ```
+______________________________________________________________________
+
+### With KEP-5517 Disabled (or on older Kubernetes control planes < 1.31)
+
+If you explicitly set `--disable-node-allocatable-mapping=true` or are running on control planes that do not support KEP-5517, standard resources and DRA claims are processed in isolated accounting lanes. To prevent scheduler-level double-booking and node overcommitment, you **MUST** configure your workloads using one of the following duplicate/mirror resource declaration workarounds:
+
+#### **Option A (Preferred): Pod Level Resources (`pod.spec.resources`)**
+
+This approach is preferred as it clearly defines the pod's total CPU budget and works well for pods with a mix of containers, some needing exclusive CPUs (requested via DRA) and others using shared CPUs.
+
+- Set `pod.spec.resources.requests.cpu` and `pod.spec.resources.limits.cpu` to the *sum* of all CPUs requested across all DRA claims used by containers in this pod, PLUS any additional CPUs for containers NOT using DRA claims.
+- Containers using DRA claims may omit `cpu` from their `resources.requests` and `resources.limits`. The Pod Level Resources will govern the QoS class and set cgroup limits at the pod level.
+
+```yaml
+# Example: Pod Level Resources Workaround
+spec:
+  resources: # Pod Level Resources
+    requests:
+      cpu: "16" # 10 (exclusive cpu's for claim1) + 4 (exclusive cpu's for claim2) + 2 (shared cpus for sidecar1 and sidecar2)
+    limits:
+      cpu: "16"
+  containers:
+    - name: main-app
+      image: ...
+      resources:
+        # Omit CPU requests/limits, or set both to 10
+        claims:
+          - name: claim1
+    - name: worker
+      image: ...
+      resources:
+       # Omit CPU requests/limits, or set both to 4
+        claims:
+          - name: claim2
+    - name: sidecar1
+      image: ...
+      # Omit CPU resources, or ensure the combined requests/limits for sidecar1 and sidecar2 do not exceed 2.
+    - name: sidecar2
+      image: ...
+      # Omit CPU resources, or ensure the combined requests/limits for sidecar1 and sidecar2 do not exceed 2.
+  resourceClaims:
+    - name: claim1
+      resourceClaimName: cpu-claim-10 # Requests 10 CPUs
+    - name: claim2
+      resourceClaimName: cpu-claim-4  # Requests 4 CPUs
+```
+
+#### **Option B: Container-Level Resources (No Pod Level Resources)**
+
+For each container that uses a DRA CPU claim, set `spec.containers[].resources.requests.cpu` and `spec.containers[].resources.limits.cpu` to be *exactly equal* to the number of CPUs requested in the `ResourceClaim` referenced by that container.
+
+```yaml
+# Example: Container Level Mirroring Workaround
+spec:
+  containers:
+    - name: my-container
+      image: ...
+      resources:
+        requests:
+          cpu: "10" # Must match the CPU count in "claim1"
+        limits:
+          cpu: "10" # Must match the CPU count in "claim1"
+        claims:
+          - name: claim1
+  resourceClaims:
+    - name: claim1
+      resourceClaimName: cpu-claim-10 # Requests 10 CPUs
+```
 
 **1-to-1 Claim to Container:** This driver enforces that a specific CPU `ResourceClaim` can only be used by *one* container within or across pods. See [Sharing resource claims](#sharing-resource-claims).
 

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -46,13 +46,14 @@ const (
 )
 
 var (
-	hostnameOverride string
-	kubeconfig       string
-	bindAddress      string
-	reservedCPUs     string
-	ready            atomic.Bool
-	cpuDeviceMode    string
-	groupBy          string
+	hostnameOverride              string
+	kubeconfig                    string
+	bindAddress                   string
+	reservedCPUs                  string
+	ready                         atomic.Bool
+	cpuDeviceMode                 string
+	groupBy                       string
+	disableNodeAllocatableMapping bool
 )
 
 type cpuDeviceModeValue struct {
@@ -65,6 +66,7 @@ func newCPUDeviceModeValue(val *string, def string) *cpuDeviceModeValue {
 }
 
 func (v *cpuDeviceModeValue) String() string {
+	
 	if v == nil || v.value == nil {
 		return ""
 	}
@@ -110,6 +112,7 @@ func init() {
 	flag.StringVar(&reservedCPUs, "reserved-cpus", "", "cpuset of CPUs to be excluded from ResourceSlice.")
 	flag.Var(newCPUDeviceModeValue(&cpuDeviceMode, driver.CPU_DEVICE_MODE_GROUPED), "cpu-device-mode", "Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device.")
 	flag.Var(newGroupByValue(&groupBy, driver.GROUP_BY_NUMA_NODE), "group-by", "When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket' or 'numanode'.")
+	flag.BoolVar(&disableNodeAllocatableMapping, "disable-node-allocatable-mapping", false, "Disable NodeAllocatable mapping in resource slice. This disables the kube-scheduler from natively subtracting the DRA claim resources from node allocatable.")
 }
 
 func main() {
@@ -213,11 +216,12 @@ func run(logger logr.Logger) error {
 	signal.Notify(signalCh, os.Interrupt, unix.SIGINT)
 
 	driverConfig := &driver.Config{
-		DriverName:       driverName,
-		NodeName:         nodeName,
-		ReservedCPUs:     reservedCPUSet,
-		CpuDeviceMode:    cpuDeviceMode,
-		CPUDeviceGroupBy: groupBy,
+		DriverName:                    driverName,
+		NodeName:                      nodeName,
+		ReservedCPUs:                  reservedCPUSet,
+		CpuDeviceMode:                 cpuDeviceMode,
+		CPUDeviceGroupBy:              groupBy,
+		DisableNodeAllocatableMapping: disableNodeAllocatableMapping,
 	}
 	dracpu, asyncErr, err := driver.Start(ctx, clientset, driverConfig)
 	if err != nil {

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -53,6 +53,7 @@ var (
 	ready                         atomic.Bool
 	cpuDeviceMode                 string
 	groupBy                       string
+	mixedAllocationMode           bool
 	disableNodeAllocatableMapping bool
 )
 
@@ -66,7 +67,6 @@ func newCPUDeviceModeValue(val *string, def string) *cpuDeviceModeValue {
 }
 
 func (v *cpuDeviceModeValue) String() string {
-	
 	if v == nil || v.value == nil {
 		return ""
 	}
@@ -112,6 +112,7 @@ func init() {
 	flag.StringVar(&reservedCPUs, "reserved-cpus", "", "cpuset of CPUs to be excluded from ResourceSlice.")
 	flag.Var(newCPUDeviceModeValue(&cpuDeviceMode, driver.CPU_DEVICE_MODE_GROUPED), "cpu-device-mode", "Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device.")
 	flag.Var(newGroupByValue(&groupBy, driver.GROUP_BY_NUMA_NODE), "group-by", "When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket' or 'numanode'.")
+	flag.BoolVar(&mixedAllocationMode, "mixed-allocation-mode", false, "Enable mixed shared and isolated CPU allocation mode.")
 	flag.BoolVar(&disableNodeAllocatableMapping, "disable-node-allocatable-mapping", false, "Disable NodeAllocatable mapping in resource slice. This disables the kube-scheduler from natively subtracting the DRA claim resources from node allocatable.")
 }
 
@@ -221,6 +222,7 @@ func run(logger logr.Logger) error {
 		ReservedCPUs:                  reservedCPUSet,
 		CpuDeviceMode:                 cpuDeviceMode,
 		CPUDeviceGroupBy:              groupBy,
+		MixedAllocationMode:           mixedAllocationMode,
 		DisableNodeAllocatableMapping: disableNodeAllocatableMapping,
 	}
 	dracpu, asyncErr, err := driver.Start(ctx, clientset, driverConfig)

--- a/hack/ci/kind-ci.yaml
+++ b/hack/ci/kind-ci.yaml
@@ -14,9 +14,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
-  DynamicResourceAllocation: true
-  DRAResourceClaimDeviceStatus: true
-  DRAConsumableCapacity: true
+  DRANodeAllocatableResources: true
 nodes:
 - role: control-plane
   image: kindest/node:v1.36.0

--- a/hack/examples/pod_guaranteed.yaml
+++ b/hack/examples/pod_guaranteed.yaml
@@ -1,0 +1,39 @@
+# This example illustrates a Pod consuming exclusive CPUs under Guaranteed-Only mode.
+# Even when Mixed Allocation Mode is enabled on the driver, containers that omit
+# standard CPU requests automatically default back to strictly exclusive guaranteed allocations.
+#
+# Required Driver Configuration:
+#   --mixed-allocation-mode: true (or false)
+#   --cpu-device-mode: "grouped" (this example uses grouped mode).
+#   --disable-node-allocatable-mapping: false (Default, recommended so that the scheduler natively
+#                                            accounts for DRA exclusive allocations and avoids double-counting).
+#
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-cpu-guaranteed-test
+spec:
+  devices:
+    requests:
+    - name: req-cpu-slice
+      exactly:
+        deviceClassName: dra.cpu
+        capacity:
+          requests:
+            dra.cpu/cpu: "4"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-cpu-guaranteed-test
+spec:
+  containers:
+    - name: guaranteed-app
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        # Standard requests.cpu is intentionally omitted to verify fallback
+        claims:
+          - name: "dedicated-cpu-claim-ref"
+  resourceClaims:
+    - name: "dedicated-cpu-claim-ref"
+      resourceClaimName: claim-cpu-guaranteed-test

--- a/hack/examples/pod_mixed_mode.yaml
+++ b/hack/examples/pod_mixed_mode.yaml
@@ -1,0 +1,39 @@
+# This example illustrates a hybrid workload running under Mixed Allocation Mode, consuming
+# both exclusive CPUs (via DRA) and standard shared CPUs (via Pod spec CPU requests).
+#
+# Required Driver Configuration:
+#   --mixed-allocation-mode: true
+#   --cpu-device-mode: "grouped" (this example uses grouped mode; could also be individual with count-based claims).
+#   --disable-node-allocatable-mapping: false (Default, recommended so that the scheduler natively
+#                                            accounts for DRA exclusive allocations and avoids double-counting).
+#
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-cpu-capacity-4
+spec:
+  devices:
+    requests:
+    - name: req-cpu-slice
+      exactly:
+        deviceClassName: dra.cpu
+        capacity:
+          requests:
+            dra.cpu/cpu: "4"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-cpu-mixed-mode
+spec:
+  containers:
+    - name: main-application
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        requests:
+          cpu: "2" # Requests 2 shared CPUs for standard/background threads
+        claims:
+          - name: "dedicated-cpu-claim-ref" # Requests 4 exclusive CPUs
+  resourceClaims:
+    - name: "dedicated-cpu-claim-ref"
+      resourceClaimName: claim-cpu-capacity-4

--- a/hack/examples/pod_with_pod_level_resources.yaml
+++ b/hack/examples/pod_with_pod_level_resources.yaml
@@ -1,0 +1,62 @@
+# This example illustrates a Pod using the Pod-Level Resources
+#
+#
+# Required Driver Configuration:
+#   --cpu-device-mode: "grouped" (CPUs are grouped, e.g. by NUMA node, and exposed as consumable capacity).
+#
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-cpu-capacity-10
+spec:
+  devices:
+    requests:
+    - name: req-cpu-slice
+      exactly:
+        deviceClassName: dra.cpu
+        capacity:
+          requests:
+            dra.cpu/cpu: "10"
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-cpu-capacity-4
+spec:
+  devices:
+    requests:
+    - name: req-cpu-slice-2
+      exactly:
+        deviceClassName: dra.cpu
+        capacity:
+          requests:
+            dra.cpu/cpu: "4"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-with-pod-level-resources
+spec:
+  resources:
+    requests:
+      cpu: "16" # 10 (exclusive CPUs for claim1) + 4 (exclusive CPUs for claim2) + 2 (shared CPUs for sidecars)
+    limits:
+      cpu: "16"
+  containers:
+    - name: main-app
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        claims:
+          - name: "container1-claim"
+    - name: worker
+      image: "registry.k8s.io/pause:3.9"
+      resources:
+        claims:
+          - name: "container2-claim"
+    - name: sidecar
+      image: "registry.k8s.io/pause:3.9"
+  resourceClaims:
+    - name: "container1-claim"
+      resourceClaimName: claim-cpu-capacity-10
+    - name: "container2-claim"
+      resourceClaimName: claim-cpu-capacity-4

--- a/hack/examples/pod_with_resource_claim_grouped_mode.yaml
+++ b/hack/examples/pod_with_resource_claim_grouped_mode.yaml
@@ -1,3 +1,11 @@
+# This example illustrates a Pod consuming exclusive CPUs under Grouped CPU Device Mode (default).
+#
+# Required Driver Configuration:
+#   --cpu-device-mode: "grouped" (CPUs are grouped, e.g. by NUMA node, and exposed as consumable capacity).
+#   --disable-node-allocatable-mapping: true (Required because container CPU requests are explicitly replicated in
+#                                            the standard 'resources.requests.cpu' block to perform manual scheduling
+#                                            accounting and prevent scheduler-level double-counting).
+#
 apiVersion: resource.k8s.io/v1
 kind: ResourceClaim
 metadata:

--- a/hack/examples/pod_with_resource_claim_individual_mode.yaml
+++ b/hack/examples/pod_with_resource_claim_individual_mode.yaml
@@ -1,3 +1,11 @@
+# This example illustrates a Pod consuming exclusive CPUs under Individual CPU Device Mode.
+#
+# Required Driver Configuration:
+#   --cpu-device-mode: "individual" (Each CPU is exposed as an individual device in the ResourceSlice).
+#   --disable-node-allocatable-mapping: true (Required because container CPU requests are explicitly replicated in
+#                                            the standard 'resources.requests.cpu' block to perform manual scheduling
+#                                            accounting and prevent scheduler-level double-counting).
+#
 apiVersion: resource.k8s.io/v1
 kind: ResourceClaim
 metadata:

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -14,9 +14,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
-  DynamicResourceAllocation: true
-  DRAResourceClaimDeviceStatus: true
-  DRAConsumableCapacity: true
+  DRANodeAllocatableResources: true
 nodes:
 - role: control-plane
   image: kindest/node:v1.36.0

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpumanager"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,10 +89,11 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resour
 			}
 
 			devices = append(devices, resourceapi.Device{
-				Name:                     deviceName,
-				Attributes:               deviceAttrs,
-				Capacity:                 deviceCapacity,
-				AllowMultipleAllocations: ptr.To(true),
+				Name:                            deviceName,
+				Attributes:                      deviceAttrs,
+				Capacity:                        deviceCapacity,
+				AllowMultipleAllocations:        ptr.To(true),
+				NodeAllocatableResourceMappings: cp.getNodeAllocatableResourceMappings(ptr.To(resourceapi.QualifiedName(cpuResourceQualifiedName))),
 			})
 		}
 	case GROUP_BY_NUMA_NODE:
@@ -125,10 +127,11 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resour
 			device.SetCompatibilityAttributes(deviceAttrs, int64(numaID))
 
 			devices = append(devices, resourceapi.Device{
-				Name:                     deviceName,
-				Attributes:               deviceAttrs,
-				Capacity:                 deviceCapacity,
-				AllowMultipleAllocations: ptr.To(true),
+				Name:                            deviceName,
+				Attributes:                      deviceAttrs,
+				Capacity:                        deviceCapacity,
+				AllowMultipleAllocations:        ptr.To(true),
+				NodeAllocatableResourceMappings: cp.getNodeAllocatableResourceMappings(ptr.To(resourceapi.QualifiedName(cpuResourceQualifiedName))),
 			})
 		}
 	}
@@ -206,9 +209,10 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 			devId++
 			cp.deviceNameToCPUID[deviceName] = cpu.CpuID
 			cpuDevice := resourceapi.Device{
-				Name:       deviceName,
-				Attributes: deviceAttrs,
-				Capacity:   make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity),
+				Name:                            deviceName,
+				Attributes:                      deviceAttrs,
+				Capacity:                        make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity),
+				NodeAllocatableResourceMappings: cp.getNodeAllocatableResourceMappings(nil),
 			}
 			allDevices = append(allDevices, cpuDevice)
 		}
@@ -490,5 +494,20 @@ func (cp *CPUDriver) HandleError(ctx context.Context, err error, msg string) {
 		)
 		klog.Flush()
 		os.Exit(1)
+	}
+}
+
+func (cp *CPUDriver) getNodeAllocatableResourceMappings(capacityKey *resourceapi.QualifiedName) map[corev1.ResourceName]resourceapi.NodeAllocatableResourceMapping {
+	if cp.disableNodeAllocatableMapping {
+		return nil
+	}
+	mapping := resourceapi.NodeAllocatableResourceMapping{
+		AllocationMultiplier: resource.NewQuantity(1, resource.DecimalSI),
+	}
+	if capacityKey != nil {
+		mapping.CapacityKey = capacityKey
+	}
+	return map[corev1.ResourceName]resourceapi.NodeAllocatableResourceMapping{
+		corev1.ResourceCPU: mapping,
 	}
 }

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,15 +171,18 @@ var (
 
 func TestPublishResources(t *testing.T) {
 	testCases := []struct {
-		name                       string
-		cpuInfos                   []cpuinfo.CPUInfo
-		cpuInfoErr                 error
-		publishError               error
-		reservedCPUs               cpuset.CPUSet
-		expectPublish              bool
-		expectedNumSlices          int
-		expectedDevices            int
-		expectedDevicesPerNUMANode map[int]int
+		name                          string
+		cpuInfos                      []cpuinfo.CPUInfo
+		cpuInfoErr                    error
+		publishError                  error
+		reservedCPUs                  cpuset.CPUSet
+		expectPublish                 bool
+		expectedNumSlices             int
+		expectedDevices               int
+		expectedDevicesPerNUMANode    map[int]int
+		cpuDeviceMode                 string
+		cpuDeviceGroupBy              string
+		disableNodeAllocatableMapping bool
 	}{
 		{
 			name:                       "single socket, HT on",
@@ -291,6 +295,48 @@ func TestPublishResources(t *testing.T) {
 			expectedDevices:            0,
 			expectedDevicesPerNUMANode: map[int]int{},
 		},
+		{
+			name:              "grouped by socket, HT on",
+			cpuInfos:          mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
+			reservedCPUs:      cpuset.New(),
+			expectPublish:     true,
+			expectedNumSlices: 1,
+			expectedDevices:   2, // 2 sockets
+			cpuDeviceMode:     CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy:  GROUP_BY_SOCKET,
+		},
+		{
+			name:              "grouped by NUMA, HT on",
+			cpuInfos:          mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
+			reservedCPUs:      cpuset.New(0), // Reserve one CPU on Socket 0 (NUMA 0)
+			expectPublish:     true,
+			expectedNumSlices: 1,
+			expectedDevices:   2, // 2 NUMA nodes
+			cpuDeviceMode:     CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy:  GROUP_BY_NUMA_NODE,
+		},
+		{
+			name:                          "grouped by NUMA, HT on, disable NodeAllocatable",
+			cpuInfos:                      mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
+			reservedCPUs:                  cpuset.New(0),
+			expectPublish:                 true,
+			expectedNumSlices:             1,
+			expectedDevices:               2,
+			cpuDeviceMode:                 CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy:              GROUP_BY_NUMA_NODE,
+			disableNodeAllocatableMapping: true,
+		},
+		{
+			name:                          "individual mode, disable NodeAllocatable",
+			cpuInfos:                      mockCPUInfos_SingleSocket_4CPUS_HT,
+			reservedCPUs:                  cpuset.New(),
+			expectPublish:                 true,
+			expectedNumSlices:             1,
+			expectedDevices:               len(mockCPUInfos_SingleSocket_4CPUS_HT),
+			expectedDevicesPerNUMANode:    map[int]int{0: 4},
+			cpuDeviceMode:                 CPU_DEVICE_MODE_INDIVIDUAL,
+			disableNodeAllocatableMapping: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -299,11 +345,16 @@ func TestPublishResources(t *testing.T) {
 			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: tc.cpuInfos, Err: tc.cpuInfoErr}
 			topo, _ := mockProvider.GetCPUTopology()
 			cp := &CPUDriver{
-				nodeName:          testNodeName,
-				draPlugin:         mockPlugin,
-				deviceNameToCPUID: make(map[string]int),
-				cpuTopology:       topo,
-				reservedCPUs:      tc.reservedCPUs,
+				nodeName:                      testNodeName,
+				draPlugin:                     mockPlugin,
+				deviceNameToCPUID:             make(map[string]int),
+				deviceNameToSocketID:          make(map[string]int),
+				deviceNameToNUMANodeID:        make(map[string]int),
+				cpuTopology:                   topo,
+				reservedCPUs:                  tc.reservedCPUs,
+				cpuDeviceMode:                 tc.cpuDeviceMode,
+				cpuDeviceGroupBy:              tc.cpuDeviceGroupBy,
+				disableNodeAllocatableMapping: tc.disableNodeAllocatableMapping,
 			}
 
 			cp.PublishResources(context.Background())
@@ -337,6 +388,28 @@ func TestPublishResources(t *testing.T) {
 				totalDevices += len(s.Devices)
 			}
 			require.Equal(t, tc.expectedDevices, totalDevices)
+
+			if tc.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
+				// Verify NodeAllocatableResourceMappings for Grouped Mode
+				expectedCapacityKey := "dra.cpu/cpu"
+				for _, slice := range pool.Slices {
+					for _, device := range slice.Devices {
+						if tc.disableNodeAllocatableMapping {
+							require.Nil(t, device.NodeAllocatableResourceMappings)
+						} else {
+							require.NotNil(t, device.NodeAllocatableResourceMappings)
+							mapping, ok := device.NodeAllocatableResourceMappings[corev1.ResourceCPU]
+							require.True(t, ok)
+							require.NotNil(t, mapping.CapacityKey)
+							require.Equal(t, expectedCapacityKey, string(*mapping.CapacityKey))
+							require.NotNil(t, mapping.AllocationMultiplier)
+							require.Equal(t, int64(1), mapping.AllocationMultiplier.Value())
+						}
+					}
+				}
+				return
+			}
+
 			require.Equal(t, tc.expectedDevices, len(cp.deviceNameToCPUID))
 
 			// Verify device attributes
@@ -371,6 +444,19 @@ func TestPublishResources(t *testing.T) {
 					require.Equal(t, CacheL3ID, *device.Attributes["dra.cpu/cacheL3ID"].IntValue)
 					require.Equal(t, coreType, *device.Attributes["dra.cpu/coreType"].StringValue)
 					require.Equal(t, socketID, *device.Attributes["dra.cpu/socketID"].IntValue)
+
+					// Verify NodeAllocatableResourceMappings
+					if tc.disableNodeAllocatableMapping {
+						require.Nil(t, device.NodeAllocatableResourceMappings)
+					} else {
+						require.NotNil(t, device.NodeAllocatableResourceMappings)
+						mapping, ok := device.NodeAllocatableResourceMappings[corev1.ResourceCPU]
+						require.True(t, ok, "missing mapping for resource CPU")
+						require.Nil(t, mapping.CapacityKey)
+						require.NotNil(t, mapping.AllocationMultiplier)
+						require.Equal(t, int64(1), mapping.AllocationMultiplier.Value())
+					}
+
 					devicesPerNumaInSlices[cpuInfo.NUMANodeID]++
 				}
 			}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -94,6 +94,7 @@ type CPUDriver struct {
 	cpuDeviceMode          string
 	cpuDeviceGroupBy       string
 	claimTracker           *store.ClaimTracker
+	disableNodeAllocatableMapping bool
 }
 
 // Config is the configuration for the CPUDriver.
@@ -102,7 +103,8 @@ type Config struct {
 	NodeName         string
 	ReservedCPUs     cpuset.CPUSet
 	CpuDeviceMode    string
-	CPUDeviceGroupBy string
+	CPUDeviceGroupBy              string
+	DisableNodeAllocatableMapping bool
 }
 
 // Start creates and starts a new CPUDriver.
@@ -118,7 +120,8 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		reservedCPUs:           config.ReservedCPUs,
 		cpuDeviceMode:          config.CpuDeviceMode,
 		cpuDeviceGroupBy:       config.CPUDeviceGroupBy,
-		claimTracker:           store.NewClaimTracker(),
+		claimTracker:                  store.NewClaimTracker(),
+		disableNodeAllocatableMapping: config.DisableNodeAllocatableMapping,
 	}
 	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()
 	topo, err := cpuInfoProvider.GetCPUTopology()

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -19,7 +19,7 @@ package driver
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
+	rand "math/rand/v2"
 	"os"
 	"path/filepath"
 	"time"
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
 )
 
@@ -78,32 +78,34 @@ type CPUInfoProvider interface {
 
 // CPUDriver is the structure that holds all the driver runtime information.
 type CPUDriver struct {
-	driverName             string
-	nodeName               string
-	kubeClient             kubernetes.Interface
-	draPlugin              KubeletPlugin
-	nriPlugin              stub.Stub
-	podConfigStore         *store.PodConfig
-	cpuAllocationStore     *store.CPUAllocation
-	cdiMgr                 cdiManager
-	cpuTopology            *cpuinfo.CPUTopology
-	deviceNameToCPUID      map[string]int
-	deviceNameToSocketID   map[string]int
-	deviceNameToNUMANodeID map[string]int
-	reservedCPUs           cpuset.CPUSet
-	cpuDeviceMode          string
-	cpuDeviceGroupBy       string
-	claimTracker           *store.ClaimTracker
+	driverName                    string
+	nodeName                      string
+	kubeClient                    kubernetes.Interface
+	draPlugin                     KubeletPlugin
+	nriPlugin                     stub.Stub
+	podConfigStore                *store.PodConfig
+	cpuAllocationStore            *store.CPUAllocation
+	cdiMgr                        cdiManager
+	cpuTopology                   *cpuinfo.CPUTopology
+	deviceNameToCPUID             map[string]int
+	deviceNameToSocketID          map[string]int
+	deviceNameToNUMANodeID        map[string]int
+	reservedCPUs                  cpuset.CPUSet
+	cpuDeviceMode                 string
+	cpuDeviceGroupBy              string
+	claimTracker                  *store.ClaimTracker
+	mixedAllocationMode           bool
 	disableNodeAllocatableMapping bool
 }
 
 // Config is the configuration for the CPUDriver.
 type Config struct {
-	DriverName       string
-	NodeName         string
-	ReservedCPUs     cpuset.CPUSet
-	CpuDeviceMode    string
+	DriverName                    string
+	NodeName                      string
+	ReservedCPUs                  cpuset.CPUSet
+	CpuDeviceMode                 string
 	CPUDeviceGroupBy              string
+	MixedAllocationMode           bool
 	DisableNodeAllocatableMapping bool
 }
 
@@ -111,16 +113,17 @@ type Config struct {
 func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) (*CPUDriver, <-chan error, error) {
 	asyncErr := make(chan error, 1)
 	plugin := &CPUDriver{
-		driverName:             config.DriverName,
-		nodeName:               config.NodeName,
-		kubeClient:             clientset,
-		deviceNameToCPUID:      make(map[string]int),
-		deviceNameToSocketID:   make(map[string]int),
-		deviceNameToNUMANodeID: make(map[string]int),
-		reservedCPUs:           config.ReservedCPUs,
-		cpuDeviceMode:          config.CpuDeviceMode,
-		cpuDeviceGroupBy:       config.CPUDeviceGroupBy,
+		driverName:                    config.DriverName,
+		nodeName:                      config.NodeName,
+		kubeClient:                    clientset,
+		deviceNameToCPUID:             make(map[string]int),
+		deviceNameToSocketID:          make(map[string]int),
+		deviceNameToNUMANodeID:        make(map[string]int),
+		reservedCPUs:                  config.ReservedCPUs,
+		cpuDeviceMode:                 config.CpuDeviceMode,
+		cpuDeviceGroupBy:              config.CPUDeviceGroupBy,
 		claimTracker:                  store.NewClaimTracker(),
+		mixedAllocationMode:           config.MixedAllocationMode,
 		disableNodeAllocatableMapping: config.DisableNodeAllocatableMapping,
 	}
 	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -29,6 +29,12 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
+const (
+	// MinCPUShares is the minimum CPU shares assigned by Kubelet to a container without CPU requests.
+	// See: https://github.com/kubernetes/kubernetes/blob/d0ab3fc75768ae8081bff58d7050be045eb7ec2e/pkg/kubelet/cm/helpers_linux.go#L44
+	MinCPUShares = 2
+)
+
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
 func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	logger := klog.FromContext(ctx).WithValues("opID", generateShortID(opIDLen))
@@ -57,31 +63,35 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 			}
 			containerUID := types.UID(container.GetId())
 			var state *store.ContainerState
-			var claimUIDs []types.UID
 			if len(claimAllocations) == 0 {
-				state = store.NewContainerState(container.GetName(), containerUID)
+				state = store.NewContainerState(container.GetName(), containerUID, store.AllocationTypeShared)
 			} else {
-				allGuaranteedCPUs := cpuset.New()
-				for uid, cpus := range claimAllocations {
-					caLogger := cLogger.WithValues("claimUID", uid)
-					err := cp.claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
-					if err != nil {
-						return nil, err
-					}
-
-					allGuaranteedCPUs = allGuaranteedCPUs.Union(cpus)
-					claimUIDs = append(claimUIDs, uid)
-					cpuAllocationStore.AddResourceClaimAllocation(caLogger, uid, cpus)
+				claims, allGuaranteedCPUs, err := cp.getGuaranteedCPUsFromClaims(cLogger, types.UID(pod.Uid), container.Name, claimAllocations)
+				if err != nil {
+					return nil, err
+				}
+				for _, claim := range claims {
+					caLogger := cLogger.WithValues("claimUID", claim.ClaimUID)
+					cpuAllocationStore.AddResourceClaimAllocation(caLogger, claim.ClaimUID, claim.CPUs)
 				}
 				cLogger.V(2).Info("found guaranteed CPUs", "cpus", allGuaranteedCPUs.String())
-				state = store.NewContainerState(container.GetName(), containerUID, claimUIDs...)
-
-				// Reconcile guaranteed container CPU mask.
-				guaranteedUpdate := &api.ContainerUpdate{
-					ContainerId: container.GetId(),
+				isMixed := cp.isMixedAllocation(cLogger, container)
+				allocType := store.AllocationTypeGuaranteed
+				if isMixed {
+					allocType = store.AllocationTypeMixed
 				}
-				guaranteedUpdate.SetLinuxCPUSetCPUs(allGuaranteedCPUs.String())
-				containerUpdates = append(containerUpdates, guaranteedUpdate)
+				state = store.NewContainerState(container.GetName(), containerUID, allocType, claims...)
+
+				if !isMixed {
+					// Reconcile strictly guaranteed container CPU mask.
+					// Mixed containers will be fully updated to guaranteed + shared CPUs during
+					// the post-synchronize reconciliation at the end of this function.
+					guaranteedUpdate := &api.ContainerUpdate{
+						ContainerId: container.GetId(),
+					}
+					guaranteedUpdate.SetLinuxCPUSetCPUs(allGuaranteedCPUs.String())
+					containerUpdates = append(containerUpdates, guaranteedUpdate)
+				}
 			}
 			podConfigStore.SetContainerState(types.UID(pod.GetUid()), state)
 		}
@@ -131,18 +141,28 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) []*api.ContainerUpdate {
 	updates := []*api.ContainerUpdate{}
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
-	sharedCPUContainers := cp.podConfigStore.GetContainersWithSharedCPUs()
-	logger.V(2).Info("updating CPU allocation for containers without guaranteed CPUs", "sharedCPUs", sharedCPUs.String())
+	sharedCPUContainers := cp.podConfigStore.GetContainersWithSharedCPUs(true)
+	logger.V(2).Info("updating CPU allocation for shared and mixed containers", "sharedCPUs", sharedCPUs.String())
 	for _, containerUID := range sharedCPUContainers {
 		if containerUID == excludeID {
-			// Skip the container being created as it is already covered in the container adjustment.
 			continue
+		}
+
+		cs, ok := cp.podConfigStore.GetContainerStateByUID(containerUID)
+		if !ok {
+			continue
+		}
+
+		assignedCPUs := sharedCPUs
+		if cs.Type() == store.AllocationTypeMixed {
+			assignedCPUs = cs.GetExclusiveCPUs().Union(sharedCPUs)
+			logger.Info("recalculating cpus for running mixed container", "container", cs.GetContainerName(), "exclusive", cs.GetExclusiveCPUs().String(), "shared", sharedCPUs.String(), "union", assignedCPUs.String())
 		}
 
 		containerUpdate := &api.ContainerUpdate{
 			ContainerId: string(containerUID),
 		}
-		containerUpdate.SetLinuxCPUSetCPUs(sharedCPUs.String())
+		containerUpdate.SetLinuxCPUSetCPUs(assignedCPUs.String())
 		updates = append(updates, containerUpdate)
 	}
 	return updates
@@ -167,28 +187,30 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 
 	if len(claimAllocations) == 0 {
 		// This is a shared container.
-		state := store.NewContainerState(ctr.GetName(), containerId)
+		state := store.NewContainerState(ctr.GetName(), containerId, store.AllocationTypeShared)
 		cp.podConfigStore.SetContainerState(podUID, state)
 
 		sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 		logger.V(2).Info("no guaranteed CPUs found, using shared CPUs", "sharedCPUs", sharedCPUs.String())
 		adjust.SetLinuxCPUSetCPUs(sharedCPUs.String())
 	} else {
-		guaranteedCPUs := cpuset.New()
-		claimUIDs := []types.UID{}
-		for uid, cpus := range claimAllocations {
-			cLogger := logger.WithValues("claimUID", uid)
-			err := cp.claimTracker.SetOwner(cLogger, uid, types.UID(pod.Uid), ctr.Name)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			guaranteedCPUs = guaranteedCPUs.Union(cpus)
-			claimUIDs = append(claimUIDs, uid)
+		claims, guaranteedCPUs, err := cp.getGuaranteedCPUsFromClaims(logger, types.UID(pod.Uid), ctr.Name, claimAllocations)
+		if err != nil {
+			return nil, nil, err
 		}
 		logger.V(2).Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
-		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
-		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
+
+		assignedCPUs := guaranteedCPUs
+		allocType := store.AllocationTypeGuaranteed
+		if cp.isMixedAllocation(logger, ctr) {
+			sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
+			assignedCPUs = guaranteedCPUs.Union(sharedCPUs)
+			logger.Info("assigning both guaranteed and shared CPUs to mixed container", "pod", klog.KObj(pod), "container", ctr.Name, "assignedCPUs", assignedCPUs.String())
+			allocType = store.AllocationTypeMixed
+		}
+
+		state := store.NewContainerState(ctr.GetName(), containerId, allocType, claims...)
+		adjust.SetLinuxCPUSetCPUs(assignedCPUs.String())
 		cp.podConfigStore.SetContainerState(podUID, state)
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
 		updates = cp.getSharedContainerUpdates(logger, containerId)
@@ -239,4 +261,51 @@ func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, c
 		logger.Info("RemoveContainer spurious updates needed (unexpected, please file a bug)", "updates", cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId())))
 	}
 	return nil
+}
+
+func (cp *CPUDriver) isMixedAllocation(logger logr.Logger, ctr *api.Container) bool {
+	if !cp.mixedAllocationMode {
+		return false
+	}
+	if ctr.Linux == nil || ctr.Linux.Resources == nil || ctr.Linux.Resources.Cpu == nil || ctr.Linux.Resources.Cpu.Shares == nil {
+		logger.Info("could not read cpu shares for container, skipping mixed allocation check")
+		return false
+	}
+	shares := ctr.Linux.Resources.Cpu.Shares.GetValue()
+
+	// Kubernetes/Kubelet maps container CPU requests to CGroup CPU shares.
+	//
+	// If a container does NOT specify any standard CPU request (e.g. it only uses DRA claims),
+	// Kubelet defaults to the absolute minimum CPU shares on Linux, which is 2.
+	//
+	// However, if the container requests ANY standard CPU resources (e.g., cpu: "100m"), Kubelet
+	// configures CGroup shares strictly greater than 2 (shares = milliCPUs * 1024 / 1000).
+	//
+	// Comparing shares > 2 tells us whether the container explicitly requested standard CPU resources
+	// alongside its DRA claims, identifying it as a mixed allocation container.
+	// See Kubelet helper: https://github.com/kubernetes/kubernetes/blob/d0ab3fc75768ae8081bff58d7050be045eb7ec2e/pkg/kubelet/cm/helpers_linux.go
+	if shares > MinCPUShares {
+		logger.Info("mixed allocation detected", "shares", shares)
+		return true
+	}
+	return false
+}
+
+func (cp *CPUDriver) getGuaranteedCPUsFromClaims(logger logr.Logger, podUID types.UID, containerName string, claimAllocations map[types.UID]cpuset.CPUSet) ([]store.ClaimInfo, cpuset.CPUSet, error) {
+	var claims []store.ClaimInfo
+	guaranteedCPUs := cpuset.New()
+	for uid, cpus := range claimAllocations {
+		cLogger := logger.WithValues("claimUID", uid)
+		err := cp.claimTracker.SetOwner(cLogger, uid, podUID, containerName)
+		if err != nil {
+			return nil, cpuset.New(), err
+		}
+
+		claims = append(claims, store.ClaimInfo{
+			ClaimUID: uid,
+			CPUs:     cpus,
+		})
+		guaranteedCPUs = guaranteedCPUs.Union(cpus)
+	}
+	return claims, guaranteedCPUs, nil
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -126,6 +126,7 @@ func TestCreateContainer(t *testing.T) {
 
 	testCases := []struct {
 		name                        string
+		mixedAllocationMode         bool
 		podConfigStore              *store.PodConfig
 		cpuAllocationStore          *store.CPUAllocation
 		claimTracker                *store.ClaimTracker
@@ -159,8 +160,8 @@ func TestCreateContainer(t *testing.T) {
 			name: "guaranteed container triggers container adjustment and update for other shared container",
 			podConfigStore: func() *store.PodConfig {
 				conf := store.NewPodConfig()
-				conf.SetContainerState("shared-pod-1", store.NewContainerState("shared-ctr-1", "shared-uid-1"))
-				conf.SetContainerState("shared-pod-2", store.NewContainerState("shared-ctr-2", "shared-uid-2"))
+				conf.SetContainerState("shared-pod-1", store.NewContainerState("shared-ctr-1", "shared-uid-1", store.AllocationTypeShared))
+				conf.SetContainerState("shared-pod-2", store.NewContainerState("shared-ctr-2", "shared-uid-2", store.AllocationTypeShared))
 				return conf
 			}(),
 			cpuAllocationStore: func() *store.CPUAllocation {
@@ -200,14 +201,111 @@ func TestCreateContainer(t *testing.T) {
 			},
 			expectedContainerUpdates: []*api.ContainerUpdate{},
 		},
+		{
+			name: "guaranteed container triggers update and shrink for running mixed allocation container",
+			podConfigStore: func() *store.PodConfig {
+				conf := store.NewPodConfig()
+				cs := store.NewContainerState("mixed-ctr-1", "mixed-uid-1", store.AllocationTypeMixed, store.ClaimInfo{ClaimUID: "claim-A", CPUs: cpuset.New(0)})
+				conf.SetContainerState("mixed-pod-1", cs)
+				return conf
+			}(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				store := store.NewCPUAllocation(topo, cpuset.New())
+				store.AddResourceClaimAllocation(testr.New(t), "claim-A", cpuset.New(0))
+				store.AddResourceClaimAllocation(testr.New(t), "claim-B", cpuset.New(1))
+				return store
+			}(),
+			claimTracker: store.NewClaimTracker(),
+			container:    newTestContainer("claim-B", "1"),
+			expectedContainerAdjustment: &api.ContainerAdjustment{
+				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "1"}}},
+			},
+			expectedContainerUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "mixed-uid-1",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0,2-7"}}},
+				},
+			},
+		},
+		{
+			name:                "guaranteed container with mixed mode enabled but shares at minimum triggers strictly guaranteed adjustment",
+			mixedAllocationMode: true,
+			podConfigStore: func() *store.PodConfig {
+				conf := store.NewPodConfig()
+				conf.SetContainerState("shared-pod-1", store.NewContainerState("shared-ctr-1", "shared-uid-1", store.AllocationTypeShared))
+				return conf
+			}(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				store := store.NewCPUAllocation(topo, cpuset.New())
+				store.AddResourceClaimAllocation(testr.New(t), types.UID(claimUID), cpuset.New(2, 3))
+				return store
+			}(),
+			claimTracker: store.NewClaimTracker(),
+			container: func() *api.Container {
+				ctr := newTestContainer(claimUID, "2-3")
+				ctr.Linux = &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: MinCPUShares},
+						},
+					},
+				}
+				return ctr
+			}(),
+			expectedContainerAdjustment: &api.ContainerAdjustment{
+				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-3"}}},
+			},
+			expectedContainerUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "shared-uid-1",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1,4-7"}}},
+				},
+			},
+		},
+		{
+			name:                "mixed container triggers container adjustment and updates other shared container",
+			mixedAllocationMode: true,
+			podConfigStore: func() *store.PodConfig {
+				conf := store.NewPodConfig()
+				conf.SetContainerState("shared-pod-1", store.NewContainerState("shared-ctr-1", "shared-uid-1", store.AllocationTypeShared))
+				return conf
+			}(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				store := store.NewCPUAllocation(topo, cpuset.New())
+				store.AddResourceClaimAllocation(testr.New(t), types.UID(claimUID), cpuset.New(2, 3))
+				return store
+			}(),
+			claimTracker: store.NewClaimTracker(),
+			container: func() *api.Container {
+				ctr := newTestContainer(claimUID, "2-3")
+				ctr.Linux = &api.LinuxContainer{
+					Resources: &api.LinuxResources{
+						Cpu: &api.LinuxCPU{
+							Shares: &api.OptionalUInt64{Value: 3072},
+						},
+					},
+				}
+				return ctr
+			}(),
+			expectedContainerAdjustment: &api.ContainerAdjustment{
+				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
+			},
+			expectedContainerUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "shared-uid-1",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1,4-7"}}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			driver := &CPUDriver{
-				podConfigStore:     tc.podConfigStore,
-				cpuAllocationStore: tc.cpuAllocationStore,
-				claimTracker:       tc.claimTracker,
+				podConfigStore:      tc.podConfigStore,
+				cpuAllocationStore:  tc.cpuAllocationStore,
+				claimTracker:        tc.claimTracker,
+				mixedAllocationMode: tc.mixedAllocationMode,
 			}
 			adjust, updates, err := driver.CreateContainer(context.Background(), pod, tc.container)
 			require.NoError(t, err)
@@ -246,8 +344,8 @@ func TestStopContainer(t *testing.T) {
 					claimTracker:       store.NewClaimTracker(),
 					cpuTopology:        topo,
 				}
-				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), types.UID("claim-uid-1")))
-				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
+				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), store.AllocationTypeGuaranteed, store.ClaimInfo{ClaimUID: "claim-uid-1", CPUs: cpuset.New()}))
+				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id), store.AllocationTypeShared))
 				return driver
 			}(),
 			expectedUpdatesFor: []string{ctr2.Id},
@@ -261,8 +359,8 @@ func TestStopContainer(t *testing.T) {
 					claimTracker:       store.NewClaimTracker(),
 					cpuTopology:        topo,
 				}
-				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id)))
-				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
+				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), store.AllocationTypeShared))
+				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id), store.AllocationTypeShared))
 				return driver
 			}(),
 			expectedUpdatesFor: []string{},
@@ -308,7 +406,7 @@ func TestNRISynchronize(t *testing.T) {
 					claimTracker:       store.NewClaimTracker(),
 					cpuTopology:        topo,
 				}
-				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState("stale-ctr", "stale-id", types.UID("stale-claim")))
+				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState("stale-ctr", "stale-id", store.AllocationTypeGuaranteed, store.ClaimInfo{ClaimUID: "stale-claim", CPUs: cpuset.New()}))
 				return driver
 			}(),
 			runtimePods:     []*api.PodSandbox{},
@@ -411,6 +509,70 @@ func TestNRISynchronize(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "mixed allocation container recovery",
+			driver: &CPUDriver{
+				podConfigStore:      store.NewPodConfig(),
+				cpuAllocationStore:  store.NewCPUAllocation(topo, cpuset.New()),
+				claimTracker:        store.NewClaimTracker(),
+				cpuTopology:         topo,
+				mixedAllocationMode: true,
+			},
+			runtimePods: []*api.PodSandbox{pod1},
+			runtimeCtrs: []*api.Container{
+				{
+					Id:           "p1-mixed",
+					PodSandboxId: pod1.Id,
+					Name:         "mixed-ctr",
+					Env:          []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")},
+					Linux: &api.LinuxContainer{
+						Resources: &api.LinuxResources{
+							Cpu: &api.LinuxCPU{
+								Shares: &api.OptionalUInt64{Value: 3072},
+							},
+						},
+					},
+				},
+			},
+			expectedUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "p1-mixed",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
+				},
+			},
+		},
+		{
+			name: "guaranteed container recovery with mixed mode enabled but shares at minimum defaults to guaranteed",
+			driver: &CPUDriver{
+				podConfigStore:      store.NewPodConfig(),
+				cpuAllocationStore:  store.NewCPUAllocation(topo, cpuset.New()),
+				claimTracker:        store.NewClaimTracker(),
+				cpuTopology:         topo,
+				mixedAllocationMode: true,
+			},
+			runtimePods: []*api.PodSandbox{pod1},
+			runtimeCtrs: []*api.Container{
+				{
+					Id:           "p1-guaranteed",
+					PodSandboxId: pod1.Id,
+					Name:         "guaranteed-ctr",
+					Env:          []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")},
+					Linux: &api.LinuxContainer{
+						Resources: &api.LinuxResources{
+							Cpu: &api.LinuxCPU{
+								Shares: &api.OptionalUInt64{Value: MinCPUShares},
+							},
+						},
+					},
+				},
+			},
+			expectedUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "p1-guaranteed",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1"}}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -430,7 +592,8 @@ func TestNRISynchronize(t *testing.T) {
 					if container.PodSandboxId != pod.Id {
 						continue
 					}
-					state := tc.driver.podConfigStore.GetContainerState(types.UID(pod.Uid), container.Name)
+					state, ok := tc.driver.podConfigStore.GetContainerStateByUID(types.UID(container.Id))
+					require.True(t, ok)
 					require.NotNil(t, state)
 				}
 			}

--- a/pkg/store/pod_config.go
+++ b/pkg/store/pod_config.go
@@ -20,7 +20,26 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/cpuset"
 )
+
+// AllocationType defines the high-level CPU allocation category for a container.
+type AllocationType string
+
+const (
+	// AllocationTypeShared indicates a container running entirely on the node's shared CPU pool.
+	AllocationTypeShared AllocationType = "shared"
+	// AllocationTypeGuaranteed indicates a container with dedicated exclusive CPU resource (requested through claims) allocated via DRA claims.
+	AllocationTypeGuaranteed AllocationType = "guaranteed"
+	// AllocationTypeMixed indicates a container running on both dedicated exclusive CPU resources (requested through claims) and the shared CPU pool.
+	AllocationTypeMixed AllocationType = "mixed"
+)
+
+// ClaimInfo holds information about a single resource claim's allocation.
+type ClaimInfo struct {
+	ClaimUID types.UID
+	CPUs     cpuset.CPUSet
+}
 
 // ContainerState holds the allocation type and all claim assignments for a container.
 type ContainerState struct {
@@ -28,16 +47,19 @@ type ContainerState struct {
 	containerName string
 	// containerUID is used by the container runtime to apply updates to a container.
 	containerUID types.UID
-	// resourceClaimUIDs is a list of resource claims associated with this container.
-	resourceClaimUIDs []types.UID
+	// claims holds information about resource claims allocated to this container.
+	claims []ClaimInfo
+	// allocationType indicates the high-level CPU allocation category for this container.
+	allocationType AllocationType
 }
 
 // NewContainerState creates a new ContainerState.
-func NewContainerState(containerName string, containerUID types.UID, claimUIDs ...types.UID) *ContainerState {
+func NewContainerState(containerName string, containerUID types.UID, allocType AllocationType, claims ...ClaimInfo) *ContainerState {
 	return &ContainerState{
-		containerName:     containerName,
-		containerUID:      containerUID,
-		resourceClaimUIDs: claimUIDs,
+		containerName:  containerName,
+		containerUID:   containerUID,
+		claims:         claims,
+		allocationType: allocType,
 	}
 }
 
@@ -48,14 +70,18 @@ type PodCPUAssignments map[string]*ContainerState
 type PodConfig struct {
 	mu                  sync.RWMutex
 	configs             map[types.UID]PodCPUAssignments
+	containersByUID     map[types.UID]*ContainerState
 	sharedCPUContainers sets.Set[types.UID]
+	mixedCPUContainers  sets.Set[types.UID]
 }
 
 // NewPodConfig creates a new PodConfig.
 func NewPodConfig() *PodConfig {
 	return &PodConfig{
 		configs:             make(map[types.UID]PodCPUAssignments),
+		containersByUID:     make(map[types.UID]*ContainerState),
 		sharedCPUContainers: sets.New[types.UID](),
+		mixedCPUContainers:  sets.New[types.UID](),
 	}
 }
 
@@ -71,25 +97,28 @@ func (s *PodConfig) SetContainerState(podUID types.UID, state *ContainerState) {
 	}
 
 	if oldState, exists := podAssignments[state.containerName]; exists {
+		delete(s.containersByUID, oldState.containerUID)
 		s.sharedCPUContainers.Delete(oldState.containerUID)
+		s.mixedCPUContainers.Delete(oldState.containerUID)
 	}
 
 	podAssignments[state.containerName] = state
+	s.containersByUID[state.containerUID] = state
 
-	if !state.HasExclusiveCPUAllocation() {
+	switch state.allocationType {
+	case AllocationTypeShared:
 		s.sharedCPUContainers.Insert(state.containerUID)
+	case AllocationTypeMixed:
+		s.mixedCPUContainers.Insert(state.containerUID)
 	}
 }
 
-// GetContainerState retrieves a container's state.
-func (s *PodConfig) GetContainerState(podUID types.UID, containerName string) *ContainerState {
+// GetContainerStateByUID retrieves a container's state by its runtime UID in O(1) time.
+func (s *PodConfig) GetContainerStateByUID(containerUID types.UID) (*ContainerState, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	if podAssignments, ok := s.configs[podUID]; ok {
-		return podAssignments[containerName]
-	}
-	return nil
+	cs, ok := s.containersByUID[containerUID]
+	return cs, ok
 }
 
 // RemoveContainerState removes a container's state from the store.
@@ -107,13 +136,11 @@ func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string)
 		return []types.UID{}
 	}
 
-	claimUIDs := cs.resourceClaimUIDs
-	if claimUIDs == nil {
-		claimUIDs = []types.UID{}
-	}
+	claimUIDs := cs.GetResourceClaimUIDs()
 
-	// Remove from sharedCPUContainers cache.
+	delete(s.containersByUID, cs.containerUID)
 	s.sharedCPUContainers.Delete(cs.containerUID)
+	s.mixedCPUContainers.Delete(cs.containerUID)
 
 	delete(podAssignments, containerName)
 	if len(podAssignments) == 0 {
@@ -124,10 +151,15 @@ func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string)
 }
 
 // GetContainersWithSharedCPUs returns a list of container UIDs that have shared CPU allocation.
-func (s *PodConfig) GetContainersWithSharedCPUs() []types.UID {
+// The caller can specify whether to include mixed-allocation containers.
+func (s *PodConfig) GetContainersWithSharedCPUs(includeMixed bool) []types.UID {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.sharedCPUContainers.UnsortedList()
+	list := s.sharedCPUContainers.UnsortedList()
+	if includeMixed {
+		list = append(list, s.mixedCPUContainers.UnsortedList()...)
+	}
+	return list
 }
 
 func (s *PodConfig) Len() int {
@@ -136,7 +168,30 @@ func (s *PodConfig) Len() int {
 	return len(s.configs)
 }
 
-// HasExclusiveCPUAllocation returns true if the container has associated resource claims.
-func (cs *ContainerState) HasExclusiveCPUAllocation() bool {
-	return len(cs.resourceClaimUIDs) > 0
+// Type returns the high-level CPU allocation category of the container.
+func (cs *ContainerState) Type() AllocationType {
+	return cs.allocationType
+}
+
+// GetResourceClaimUIDs returns the list of resource claim UIDs.
+func (cs *ContainerState) GetResourceClaimUIDs() []types.UID {
+	var uids []types.UID
+	for _, claim := range cs.claims {
+		uids = append(uids, claim.ClaimUID)
+	}
+	return uids
+}
+
+// GetContainerName returns the container name.
+func (cs *ContainerState) GetContainerName() string {
+	return cs.containerName
+}
+
+// GetExclusiveCPUs retrieves the stored exclusive CPU set.
+func (cs *ContainerState) GetExclusiveCPUs() cpuset.CPUSet {
+	exclusiveCPUs := cpuset.New()
+	for _, claim := range cs.claims {
+		exclusiveCPUs = exclusiveCPUs.Union(claim.CPUs)
+	}
+	return exclusiveCPUs
 }

--- a/pkg/store/pod_config_test.go
+++ b/pkg/store/pod_config_test.go
@@ -22,20 +22,23 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/cpuset"
 )
 
 func TestSetAndGetContainerState(t *testing.T) {
 	store := NewPodConfig()
 	podUID := types.UID("pod-uid-1")
 	ctrName := "ctr-name-1"
-	state := NewContainerState(ctrName, "ctr-uid-1", types.UID("claim-uid-1"))
+	state := NewContainerState(ctrName, "ctr-uid-1", AllocationTypeGuaranteed, ClaimInfo{ClaimUID: "claim-uid-1", CPUs: cpuset.New()})
 
 	// Get non-existent state
-	require.Nil(t, store.GetContainerState(podUID, ctrName))
+	_, ok := store.GetContainerStateByUID("ctr-uid-1")
+	require.False(t, ok)
 
 	// Set and get state
 	store.SetContainerState(podUID, state)
-	gotState := store.GetContainerState(podUID, ctrName)
+	gotState, ok := store.GetContainerStateByUID("ctr-uid-1")
+	require.True(t, ok)
 	require.Equal(t, state, gotState)
 }
 
@@ -44,23 +47,28 @@ func TestRemoveContainerState(t *testing.T) {
 	podUID := types.UID("pod-uid-1")
 	ctrName1 := "ctr-name-1"
 	ctrName2 := "ctr-name-2"
-	state1 := NewContainerState(ctrName1, "ctr-uid-1", types.UID("claim-uid-1"))
-	state2 := NewContainerState(ctrName2, "ctr-uid-2")
+	state1 := NewContainerState(ctrName1, "ctr-uid-1", AllocationTypeGuaranteed, ClaimInfo{ClaimUID: "claim-uid-1", CPUs: cpuset.New()})
+	state2 := NewContainerState(ctrName2, "ctr-uid-2", AllocationTypeShared)
 
 	// Setup: add a pod with two containers
 	store.SetContainerState(podUID, state1)
 	store.SetContainerState(podUID, state2)
-	require.NotNil(t, store.GetContainerState(podUID, ctrName1))
-	require.NotNil(t, store.GetContainerState(podUID, ctrName2))
+	_, ok1 := store.GetContainerStateByUID("ctr-uid-1")
+	require.True(t, ok1)
+	_, ok2 := store.GetContainerStateByUID("ctr-uid-2")
+	require.True(t, ok2)
 
 	// Remove one container
 	store.RemoveContainerState(podUID, ctrName1)
-	require.Nil(t, store.GetContainerState(podUID, ctrName1))
-	require.NotNil(t, store.GetContainerState(podUID, ctrName2), "other container should still exist")
+	_, ok1 = store.GetContainerStateByUID("ctr-uid-1")
+	require.False(t, ok1)
+	_, ok2 = store.GetContainerStateByUID("ctr-uid-2")
+	require.True(t, ok2, "other container should still exist")
 
 	// Remove the second container, which should remove the pod entry
 	store.RemoveContainerState(podUID, ctrName2)
-	require.Nil(t, store.GetContainerState(podUID, ctrName2))
+	_, ok2 = store.GetContainerStateByUID("ctr-uid-2")
+	require.False(t, ok2)
 	_, podExists := store.configs[podUID]
 	require.False(t, podExists, "pod entry should be gone after last container is removed")
 
@@ -69,9 +77,9 @@ func TestRemoveContainerState(t *testing.T) {
 }
 
 func TestGetSharedCPUContainerUIDs(t *testing.T) {
-	sharedState1 := NewContainerState("c1", "id1")
-	sharedState2 := NewContainerState("c2", "id2")
-	guaranteedState := NewContainerState("c3", "id3", types.UID("claim-uid-1"))
+	sharedState1 := NewContainerState("c1", "id1", AllocationTypeShared)
+	sharedState2 := NewContainerState("c2", "id2", AllocationTypeShared)
+	guaranteedState := NewContainerState("c3", "id3", AllocationTypeGuaranteed, ClaimInfo{ClaimUID: "claim-uid-1", CPUs: cpuset.New()})
 
 	testCases := []struct {
 		name     string
@@ -105,7 +113,7 @@ func TestGetSharedCPUContainerUIDs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			store := NewPodConfig()
 			tc.setup(store)
-			gotUIDs := store.GetContainersWithSharedCPUs()
+			gotUIDs := store.GetContainersWithSharedCPUs(false)
 			require.ElementsMatch(t, tc.wantUIDs, gotUIDs)
 		})
 	}
@@ -114,29 +122,29 @@ func TestGetSharedCPUContainerUIDs(t *testing.T) {
 func TestSharedCPUContainersCacheConsistency(t *testing.T) {
 	store := NewPodConfig()
 
-	store.SetContainerState("pod1", NewContainerState("c1", "id1"))
-	store.SetContainerState("pod1", NewContainerState("c2", "id2"))
-	store.SetContainerState("pod2", NewContainerState("c3", "id3"))
+	store.SetContainerState("pod1", NewContainerState("c1", "id1", AllocationTypeShared))
+	store.SetContainerState("pod1", NewContainerState("c2", "id2", AllocationTypeShared))
+	store.SetContainerState("pod2", NewContainerState("c3", "id3", AllocationTypeShared))
 
-	sharedUIDs := store.GetContainersWithSharedCPUs()
+	sharedUIDs := store.GetContainersWithSharedCPUs(false)
 	require.Len(t, sharedUIDs, 3)
 
-	store.SetContainerState("pod3", NewContainerState("c4", "id4", "claim-1"))
-	sharedUIDs = store.GetContainersWithSharedCPUs()
+	store.SetContainerState("pod3", NewContainerState("c4", "id4", AllocationTypeGuaranteed, ClaimInfo{ClaimUID: "claim-1", CPUs: cpuset.New()}))
+	sharedUIDs = store.GetContainersWithSharedCPUs(false)
 	require.Len(t, sharedUIDs, 3)
 
-	store.SetContainerState("pod1", NewContainerState("c1", "id1", "claim-2"))
-	sharedUIDs = store.GetContainersWithSharedCPUs()
+	store.SetContainerState("pod1", NewContainerState("c1", "id1", AllocationTypeGuaranteed, ClaimInfo{ClaimUID: "claim-2", CPUs: cpuset.New()}))
+	sharedUIDs = store.GetContainersWithSharedCPUs(false)
 	require.Len(t, sharedUIDs, 2)
 	require.NotContains(t, sharedUIDs, types.UID("id1"))
 
 	store.RemoveContainerState("pod1", "c2")
-	sharedUIDs = store.GetContainersWithSharedCPUs()
+	sharedUIDs = store.GetContainersWithSharedCPUs(false)
 	require.Len(t, sharedUIDs, 1)
 	require.ElementsMatch(t, []types.UID{"id3"}, sharedUIDs)
 
 	store.RemoveContainerState("pod2", "c3")
-	sharedUIDs = store.GetContainersWithSharedCPUs()
+	sharedUIDs = store.GetContainersWithSharedCPUs(false)
 	require.Len(t, sharedUIDs, 0)
 }
 
@@ -145,12 +153,12 @@ func TestSetContainerState_ContainerRestart(t *testing.T) {
 	podUID := types.UID("pod1")
 
 	// Initial container with shared CPUs.
-	store.SetContainerState(podUID, NewContainerState("ctr", "old-uid"))
-	require.ElementsMatch(t, []types.UID{"old-uid"}, store.GetContainersWithSharedCPUs())
+	store.SetContainerState(podUID, NewContainerState("ctr", "old-uid", AllocationTypeShared))
+	require.ElementsMatch(t, []types.UID{"old-uid"}, store.GetContainersWithSharedCPUs(false))
 
 	// Container restarts: same name, new UID.
-	store.SetContainerState(podUID, NewContainerState("ctr", "new-uid"))
-	sharedUIDs := store.GetContainersWithSharedCPUs()
+	store.SetContainerState(podUID, NewContainerState("ctr", "new-uid", AllocationTypeShared))
+	sharedUIDs := store.GetContainersWithSharedCPUs(false)
 	require.Len(t, sharedUIDs, 1)
 	require.NotContains(t, sharedUIDs, types.UID("old-uid"), "stale UID should be removed")
 	require.Contains(t, sharedUIDs, types.UID("new-uid"))
@@ -160,7 +168,7 @@ func getContainersWithSharedCPUsNaive(configs map[types.UID]map[string]*Containe
 	var result []types.UID
 	for _, containers := range configs {
 		for _, state := range containers {
-			if len(state.resourceClaimUIDs) == 0 {
+			if state.Type() == AllocationTypeShared {
 				result = append(result, state.containerUID)
 			}
 		}
@@ -196,9 +204,9 @@ func BenchmarkGetContainersWithSharedCPUs(b *testing.B) {
 
 				var state *ContainerState
 				if (ctrIndex*100)/(tc.numPods*tc.ctrsPerPod) < tc.sharedPercent {
-					state = NewContainerState(ctrName, ctrUID)
+					state = NewContainerState(ctrName, ctrUID, AllocationTypeShared)
 				} else {
-					state = NewContainerState(ctrName, ctrUID, types.UID(fmt.Sprintf("claim-%d", ctrIndex)))
+					state = NewContainerState(ctrName, ctrUID, AllocationTypeGuaranteed, ClaimInfo{ClaimUID: types.UID(fmt.Sprintf("claim-%d", ctrIndex)), CPUs: cpuset.New()})
 				}
 				configs[podUID][ctrName] = state
 				store.SetContainerState(podUID, state)
@@ -214,7 +222,7 @@ func BenchmarkGetContainersWithSharedCPUs(b *testing.B) {
 
 		b.Run(tc.name+"/optimized", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = store.GetContainersWithSharedCPUs()
+				_ = store.GetContainersWithSharedCPUs(false)
 			}
 		})
 	}


### PR DESCRIPTION
POC for https://github.com/kubernetes-sigs/dra-driver-cpu/issues/103

This PR introduces Mixed Allocation Mode to the CPU DRA driver, enabling workloads to request both exclusive and shared CPUs. 

Key Principles: 
* Any request that goes in the standard container spec is considered as a request for shared CPUs.
* Any claim request is considered as a request for guaranteed exclusive CPUs.
* Relies on [KEP-5517](https://github.com/kubernetes/enhancements/issues/5517) to allow for correct scheduler accounting.

Flags:
* Added `--mixed-allocation-mode` flag to enable or disable mixed allocation mode.
* Added `--disable-node-allocatable-mapping` flag to toggle native KEP-5517 scheduler accounting.

DRA Hook:
* Adds a native NodeAllocatable resource mapping to published ResourceSlices. This allows kube-scheduler to track and subtract DRA based CPU requests directly from node allocatable capacity.


NRI Hook:
* Mixed Allocation Mode Implementation:
  - Configured the NRI plugin to inspect container CPU shares at runtime.
  - Containers with shares > 2 are automatically identified as running in mixed mode. Kubelet sets container shares to exactly 2 when standard CPU requests are omitted, as defined in [helpers_linux.go](https://github.com/kubernetes/kubernetes/blob/d0ab3fc75768ae8081bff58d7050be045eb7ec2e/pkg/kubelet/cm/helpers_linux.go#L44).
  - Configures the CPU affinity mask of mixed containers to the union of their dedicated exclusive CPUs and the node's shared CPU pool.
  - Shrinks the shared CPU pool of other standard containers by subtracting exclusive CPUs.