### PR TITLE
use helm in CI flows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,13 @@ kind-load-image: build-image  ## load the current container image into kind
 	kind load docker-image ${IMAGE} ${IMAGE_LATEST} --name ${CLUSTER_NAME}
 
 kind-uninstall-cpu-dra: ## remove cpu dra from kind cluster
-	kubectl delete -f dist/install.yaml || true
+	helm uninstall dra-driver-cpu --namespace kube-system || true
 
-kind-install-cpu-dra: kind-uninstall-cpu-dra build-image kind-load-image ## install on cluster
-	kubectl apply -f dist/install.yaml
+kind-install-cpu-dra: kind-uninstall-cpu-dra build-image kind-load-image ## install on cluster mimicking production settings
+	helm install dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
+		--set image.repository=${REGISTRY}/${STAGING_REPO_NAME}/${IMAGE_NAME} \
+		--set image.tag=${TAG} \
+		--set image.pullPolicy=IfNotPresent
 
 delete-kind-cluster: ## delete kind cluster
 	kind delete cluster --name ${CLUSTER_NAME}

--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ $(OUT_DIR):  ## creates the output directory (used internally)
 
 # get image name from directory we're building
 CLUSTER_NAME=dra-driver-cpu
-STAGING_REPO_NAME=dra-driver-cpu
 IMAGE_NAME=dra-driver-cpu
 # docker image registry, default to upstream
 REGISTRY ?= us-central1-docker.pkg.dev/k8s-staging-images
 # this is an intentionally non-existent registry to be used only by local CI using the local image loading
 REGISTRY_CI := dev.kind.local/ci
-STAGING_IMAGE_NAME := ${REGISTRY}/${STAGING_REPO_NAME}/${IMAGE_NAME}
+IMAGE_REPO := ${REGISTRY}/${IMAGE_NAME}/${IMAGE_NAME}
+IMAGE_REPO_CI := ${REGISTRY_CI}/${IMAGE_NAME}
 # tag based on date-sha
 GIT_VERSION := $(shell date +v%Y%m%d)-$(shell git rev-parse --short HEAD)
 ifneq ($(shell git status --porcelain),)
@@ -87,10 +87,10 @@ ifneq ($(shell git status --porcelain),)
 endif
 TAG ?= $(GIT_VERSION)
 # the full image tag
-IMAGE_LATEST?=$(STAGING_IMAGE_NAME):latest
-IMAGE := ${STAGING_IMAGE_NAME}:${TAG}
-IMAGE_CI := ${REGISTRY_CI}/${IMAGE_NAME}:${TAG}
-IMAGE_TEST := ${REGISTRY_CI}/${IMAGE_NAME}-test:${TAG}
+IMAGE_LATEST?=$(IMAGE_REPO):latest
+IMAGE := ${IMAGE_REPO}:${TAG}
+IMAGE_CI := ${IMAGE_REPO_CI}:${TAG}
+IMAGE_TEST := ${IMAGE_REPO_CI}-test:${TAG}
 # target platform(s)
 PLATFORMS?=linux/amd64,linux/arm64
 LOCAL_PLATFORM?=linux/$(ARCH)
@@ -111,7 +111,7 @@ HELM_COMMON_ARGS := \
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled
 image: ## docker build load
-	docker build . -t ${STAGING_IMAGE_NAME} --load
+	docker build . -t ${IMAGE_REPO} --load
 
 build-image: ## build image
 	docker buildx build . \
@@ -151,7 +151,7 @@ kind-uninstall-cpu-dra: ## remove cpu dra from kind cluster
 
 kind-install-cpu-dra: kind-uninstall-cpu-dra build-image kind-load-image ## install on cluster mimicking production settings
 	helm install dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
-		--set image.repository=${REGISTRY}/${STAGING_REPO_NAME}/${IMAGE_NAME} \
+		--set image.repository=${IMAGE_REPO} \
 		--set image.tag=${TAG} \
 		--set image.pullPolicy=IfNotPresent
 
@@ -181,7 +181,7 @@ manifests: dist ensure-helm ## create the install manifest
 ifeq ($(OVERRIDE_IMAGE),true)
 	helm template dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
 		--set podLabels.build=${GIT_VERSION} \
-		--set image.repository=${STAGING_IMAGE_NAME} \
+		--set image.repository=${IMAGE_REPO} \
 		--set image.tag=${TAG} \
 		--set image.pullPolicy=IfNotPresent \
 		> dist/install.yaml
@@ -198,7 +198,7 @@ endif
 	kubectl label node ${CLUSTER_NAME}-worker node-role.kubernetes.io/worker=''
 	kind load docker-image --name ${CLUSTER_NAME} ${IMAGE_CI} ${IMAGE_TEST}
 	helm install dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
-		--set image.repository=${REGISTRY_CI}/${IMAGE_NAME} \
+		--set image.repository=${IMAGE_REPO_CI} \
 		--set image.tag=${TAG} \
 		--set image.pullPolicy=IfNotPresent \
 		--set args.cpuDeviceMode=${DRACPU_E2E_CPU_DEVICE_MODE} \
@@ -263,7 +263,7 @@ helm-schema: ## regenerate values.schema.json from values.yaml @schema annotatio
 helm-schema-check: helm-schema ## verify values.schema.json is up to date; fails if regeneration produces a diff
 	@git diff --exit-code ${HELM_CHART}/values.schema.json || \
 		(echo "ERROR: values.schema.json is out of date. Run 'make helm-schema' to update it." && exit 1)
-CHART_REGISTRY?=$(REGISTRY)/$(STAGING_REPO_NAME)/charts
+CHART_REGISTRY?=$(REGISTRY)/$(IMAGE_NAME)/charts
 HELM_VERSION_SHA?=a2369ca71c0ef633bf6e4fccd66d634eb379b371 # v3.20.1
 
 .PHONY: ensure-helm

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ install-golangci-lint: $(OUT_DIR) ## make sure the golangci-lint tool is availab
 	@hack/fetch-golangci-lint.sh $(OUT_DIR) $(GOLANGCI_LINT_VERSION)
 
 helm-lint: ## lint helm chart with strict mode
-	helm lint --strict deployment/helm/dra-driver-cpu
+	helm lint --strict ${HELM_CHART}
 
 .PHONY: helm-docs
 helm-docs: ## regenerate helm chart README from values.yaml annotations and README.md.gotmpl
@@ -254,14 +254,14 @@ helm-docs-check: helm-docs ## verify helm chart README is up to date; fails if r
 .PHONY: helm-schema
 helm-schema: ## regenerate values.schema.json from values.yaml @schema annotations
 	go run github.com/losisin/helm-values-schema-json/v2@v$(HELM_SCHEMA_VERSION) \
-		-f deployment/helm/dra-driver-cpu/values.yaml \
-		-o deployment/helm/dra-driver-cpu/values.schema.json \
+		-f ${HELM_CHART}/values.yaml \
+		-o ${HELM_CHART}/values.schema.json \
 		--use-helm-docs \
 		--indent 2
 
 .PHONY: helm-schema-check
 helm-schema-check: helm-schema ## verify values.schema.json is up to date; fails if regeneration produces a diff
-	@git diff --exit-code deployment/helm/dra-driver-cpu/values.schema.json || \
+	@git diff --exit-code ${HELM_CHART}/values.schema.json || \
 		(echo "ERROR: values.schema.json is out of date. Run 'make helm-schema' to update it." && exit 1)
 CHART_REGISTRY?=$(REGISTRY)/$(STAGING_REPO_NAME)/charts
 HELM_VERSION_SHA?=a2369ca71c0ef633bf6e4fccd66d634eb379b371 # v3.20.1
@@ -275,7 +275,7 @@ ensure-helm:
 
 .PHONY: helm-package
 helm-package: ensure-helm ## package helm chart for release
-	helm package deployment/helm/dra-driver-cpu \
+	helm package ${HELM_CHART} \
 		--version "$(CHART_VERSION)" \
 		--app-version "$(TAG)" \
 		--destination $(OUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ endif
 		--set image.repository=${IMAGE_REPO_CI} \
 		--set image.tag=${TAG} \
 		--set image.pullPolicy=IfNotPresent \
+		--set args.logLevel=6 \
 		--set args.cpuDeviceMode=${DRACPU_E2E_CPU_DEVICE_MODE} \
 		--set-string args.reservedCPUs=${DRACPU_E2E_RESERVED_CPUS}
 	hack/ci/wait-resourcelices.sh

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ endef
 dist:
 	@mkdir -p dist
 
-manifests: dist install-yq ## create the install manifest
+manifests-legacy: dist install-yq ## create the install manifest (legacy, pre-helm)
 	@cd dist && cp -a ../manifests/base/*.part.yaml .
 ifeq ($(OVERRIDE_IMAGE),true)
 	@$(YQ) -i '.spec.template.spec.containers[0].image = "${IMAGE}"' dist/daemonset-dracpu.part.yaml
@@ -196,6 +196,25 @@ endif
 		dist/deviceclass-dracpu.part.yaml \
 		> dist/install.yaml
 	@rm dist/*.part.yaml
+
+manifests: dist ensure-helm ## create the install manifest
+ifeq ($(OVERRIDE_IMAGE),true)
+	helm template dra-driver-cpu deployment/helm/dra-driver-cpu \
+		--namespace kube-system \
+		--set fullnameOverride=dracpu \
+		--set podLabels.app=dracpu \
+		--set podLabels.build=${GIT_VERSION} \
+		--set image.repository=${STAGING_IMAGE_NAME} \
+		--set image.tag=${TAG} \
+		--set image.pullPolicy=IfNotPresent \
+		> dist/install.yaml
+else
+	helm template dra-driver-cpu deployment/helm/dra-driver-cpu \
+		--namespace kube-system \
+		--set fullnameOverride=dracpu \
+		--set podLabels.app=dracpu \
+		> dist/install.yaml
+endif
 
 ci-manifests: install-yq ## create the CI install manifests
 ifneq ($(DRACPU_E2E_VERBOSE),)

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,11 @@ DRACPU_E2E_RESERVED_CPUS ?= 0
 # For example, set GOLANGCI_LINT_EXTRA_ARGS=--fix to auto-fix issues.
 GOLANGCI_LINT_EXTRA_ARGS ?=
 
-# shortcut
-CI_MANIFEST_FILE := hack/ci/install-ci-$(DRACPU_E2E_CPU_DEVICE_MODE)-mode.yaml
-# we need this because manifest processing always needs a nonempty value
+HELM_CHART := deployment/helm/dra-driver-cpu
+HELM_COMMON_ARGS := \
+	--namespace kube-system \
+	--set fullnameOverride=dracpu \
+	--set podLabels.app=dracpu
 
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled
@@ -153,31 +155,6 @@ kind-install-cpu-dra: kind-uninstall-cpu-dra build-image kind-load-image ## inst
 delete-kind-cluster: ## delete kind cluster
 	kind delete cluster --name ${CLUSTER_NAME}
 
-define kind_setup
-	kind create cluster --name ${CLUSTER_NAME} --image=kindest/node:$(KIND_K8S_VERSION) --config hack/ci/kind-ci.yaml
-	kubectl label node ${CLUSTER_NAME}-worker node-role.kubernetes.io/worker=''
-	kind load docker-image --name ${CLUSTER_NAME} ${IMAGE_CI} ${IMAGE_TEST}
-	kubectl create -f $(1)
-	hack/ci/wait-resourcelices.sh
-endef
-
-define generate_ci_manifest
-	@cd hack/ci && cp -a ../../manifests/base/*.part.yaml .
-	@# need to make kind load docker-image working as expected: see https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
-	@$(YQ) -i '.spec.template.spec.containers[0].imagePullPolicy = "IfNotPresent"' hack/ci/daemonset-dracpu.part.yaml
-	@$(YQ) -i '.spec.template.spec.containers[0].image = "${IMAGE_CI}"' hack/ci/daemonset-dracpu.part.yaml
-	$(if $(2),@$(YQ) -i '$(2)' hack/ci/daemonset-dracpu.part.yaml,)
-	@$(YQ) -i '.spec.template.metadata.labels["build"] = "${GIT_VERSION}"' hack/ci/daemonset-dracpu.part.yaml
-	@$(YQ) '.' \
-		hack/ci/clusterrole-dracpu.part.yaml \
-		hack/ci/serviceaccount-dracpu.part.yaml \
-		hack/ci/clusterrolebinding-dracpu.part.yaml \
-		hack/ci/daemonset-dracpu.part.yaml \
-		hack/ci/deviceclass-dracpu.part.yaml \
-		> $(1)
-	@rm hack/ci/*.part.yaml
-endef
-
 dist:
 	@mkdir -p dist
 
@@ -199,34 +176,31 @@ endif
 
 manifests: dist ensure-helm ## create the install manifest
 ifeq ($(OVERRIDE_IMAGE),true)
-	helm template dra-driver-cpu deployment/helm/dra-driver-cpu \
-		--namespace kube-system \
-		--set fullnameOverride=dracpu \
-		--set podLabels.app=dracpu \
+	helm template dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
 		--set podLabels.build=${GIT_VERSION} \
 		--set image.repository=${STAGING_IMAGE_NAME} \
 		--set image.tag=${TAG} \
 		--set image.pullPolicy=IfNotPresent \
 		> dist/install.yaml
 else
-	helm template dra-driver-cpu deployment/helm/dra-driver-cpu \
-		--namespace kube-system \
-		--set fullnameOverride=dracpu \
-		--set podLabels.app=dracpu \
+	helm template dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
 		> dist/install.yaml
 endif
 
-ci-manifests: install-yq ## create the CI install manifests
-ifneq ($(DRACPU_E2E_VERBOSE),)
-	@echo "setting up manifests for mode=$(DRACPU_E2E_CPU_DEVICE_MODE)"
-endif
-	$(call generate_ci_manifest,$(CI_MANIFEST_FILE),.spec.template.spec.containers[0].args |= (del(.[] | select(. == "--cpu-device-mode=*")) | . + ["--cpu-device-mode=$(DRACPU_E2E_CPU_DEVICE_MODE)", "--reserved-cpus=$(DRACPU_E2E_RESERVED_CPUS)"]))
-
-ci-kind-setup: ensure-kind-node-image ci-manifests build-image build-test-image ## setup a CI cluster from scratch using reserved CPUs
+ci-kind-setup: ensure-kind-node-image ensure-helm build-image build-test-image ## setup a CI cluster from scratch using reserved CPUs
 ifneq ($(DRACPU_E2E_VERBOSE),)
 	@echo "creating a kind cluster for mode=$(DRACPU_E2E_CPU_DEVICE_MODE)"
 endif
-	$(call kind_setup,$(CI_MANIFEST_FILE))
+	kind create cluster --name ${CLUSTER_NAME} --image=kindest/node:$(KIND_K8S_VERSION) --config hack/ci/kind-ci.yaml
+	kubectl label node ${CLUSTER_NAME}-worker node-role.kubernetes.io/worker=''
+	kind load docker-image --name ${CLUSTER_NAME} ${IMAGE_CI} ${IMAGE_TEST}
+	helm install dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
+		--set image.repository=${REGISTRY_CI}/${IMAGE_NAME} \
+		--set image.tag=${TAG} \
+		--set image.pullPolicy=IfNotPresent \
+		--set args.cpuDeviceMode=${DRACPU_E2E_CPU_DEVICE_MODE} \
+		--set-string args.reservedCPUs=${DRACPU_E2E_RESERVED_CPUS}
+	hack/ci/wait-resourcelices.sh
 
 build-test-image: ## build tests image
 	docker buildx build . \


### PR DESCRIPTION
We prefer helm to handle the manifests, **but we will still keep the legacy manifests flow for 0.2.0**.
To streamline the flows, exercise the helm flow more and to gain more confidence in the helm flow, we should
use helm in our prow CI environments.