### PR TITLE
CI cleanups

### DIFF
--- a/hack/ci/kind-ci.yaml
+++ b/hack/ci/kind-ci.yaml
@@ -13,10 +13,6 @@
 # limitations under the License.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  DynamicResourceAllocation: true
-  DRAResourceClaimDeviceStatus: true
-  DRAConsumableCapacity: true
 nodes:
 - role: control-plane
   image: kindest/node:v1.36.0

--- a/hack/ci/kind-ci.yaml
+++ b/hack/ci/kind-ci.yaml
@@ -43,3 +43,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         v: "5"
+- role: worker
+  image: kindest/node:v1.36.0
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "5"

--- a/hack/ci/wait-resourcelices.sh
+++ b/hack/ci/wait-resourcelices.sh
@@ -11,4 +11,8 @@ for try in $(seq 1 120); do
 	sleep 1s
 done
 
+echo "TIMEOUT: no resourceslice found after ${try} tries"
+kubectl get pods -A -l "app=dracpu" -o wide
+kubectl logs -n kube-system -l app=dracpu
+kubectl describe daemonset -n kube-system -l app=dracpu || true
 exit 1

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -13,10 +13,6 @@
 # limitations under the License.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  DynamicResourceAllocation: true
-  DRAResourceClaimDeviceStatus: true
-  DRAConsumableCapacity: true
 nodes:
 - role: control-plane
   image: kindest/node:v1.36.0


### PR DESCRIPTION
CI QoL improvements and cleanups: align and simplify the kind configuration we ship, and make sure to dump dracpu logs should the resourceslice fail to be come available when doing setup.
Spun from the review of #156