### PR TITLE
contextual logging: streamline plumbing

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -203,7 +203,7 @@ func run(logger logr.Logger) error {
 		DriverName:       driverName,
 		NodeName:         nodeName,
 		ReservedCPUs:     reservedCPUSet,
-		CpuDeviceMode:    cpuDeviceMode,
+		CPUDeviceMode:    cpuDeviceMode,
 		CPUDeviceGroupBy: groupBy,
 	}
 	dracpu, asyncErr, err := driver.Start(ctx, clientset, driverConfig)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -101,7 +101,7 @@ type Config struct {
 	DriverName       string
 	NodeName         string
 	ReservedCPUs     cpuset.CPUSet
-	CpuDeviceMode    string
+	CPUDeviceMode    string
 	CPUDeviceGroupBy string
 }
 
@@ -116,7 +116,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		deviceNameToSocketID:   make(map[string]int),
 		deviceNameToNUMANodeID: make(map[string]int),
 		reservedCPUs:           config.ReservedCPUs,
-		cpuDeviceMode:          config.CpuDeviceMode,
+		cpuDeviceMode:          config.CPUDeviceMode,
 		cpuDeviceGroupBy:       config.CPUDeviceGroupBy,
 		claimTracker:           store.NewClaimTracker(),
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -107,6 +107,9 @@ type Config struct {
 
 // Start creates and starts a new CPUDriver.
 func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) (*CPUDriver, <-chan error, error) {
+	var logger logr.Logger
+	ctx, logger = ctxlog.WithValues(ctx, "driver", config.DriverName)
+
 	asyncErr := make(chan error, 1)
 	plugin := &CPUDriver{
 		driverName:             config.DriverName,
@@ -120,7 +123,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		cpuDeviceGroupBy:       config.CPUDeviceGroupBy,
 		claimTracker:           store.NewClaimTracker(),
 	}
-	logger := ctxlog.FromContext(ctx)
+
 	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()
 	topo, err := cpuInfoProvider.GetCPUTopology(logger)
 	if err != nil {
@@ -158,8 +161,6 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	if err != nil {
 		return nil, asyncErr, err
 	}
-
-	ctx, logger = ctxlog.WithValues(ctx, "driver", config.DriverName)
 
 	cdiMgr, err := NewCdiManager(logger, config.DriverName)
 	if err != nil {


### PR DESCRIPTION
Ensure consistent plumbing in the driver setup.
Sneaks in a trivial consistency internal rename.
Spun off from #156 