### PR TITLE
Initialize device lookup maps before publishing

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -52,105 +52,70 @@ const (
 	cpuDeviceNUMAGroupedPrefix   = "cpudevnuma"
 )
 
-// createGroupedCPUDeviceSlices creates Device objects based on the CPU topology, grouped by a specific criteria.
-func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resourceapi.Device {
-	logger.V(4).Info("creating grouped CPU devices")
-	var devices []resourceapi.Device
+type groupedCPUDeviceInfo struct {
+	name       string
+	cpus       cpuset.CPUSet
+	socketID   int
+	numaNodeID int
+}
 
+type cpuDeviceInfo struct {
+	name string
+	cpu  cpuinfo.CPUInfo
+}
+
+func (cp *CPUDriver) groupedCPUDeviceInfos() []groupedCPUDeviceInfo {
+	var devices []groupedCPUDeviceInfo
 	topo := cp.cpuTopology
 
 	switch cp.cpuDeviceGroupBy {
 	case GROUP_BY_SOCKET:
 		socketIDs := topo.CPUDetails.Sockets().List()
 		for _, socketID := range socketIDs {
-			deviceName := fmt.Sprintf("%s%03d", cpuDeviceSocketGroupedPrefix, socketID)
-			socketCPUSet := topo.CPUDetails.CPUsInSockets(socketID)
-			allocatableCPUs := socketCPUSet.Difference(cp.reservedCPUs)
-			availableCPUsInSocket := int64(allocatableCPUs.Size())
-
+			allocatableCPUs := topo.CPUDetails.CPUsInSockets(socketID).Difference(cp.reservedCPUs)
 			if allocatableCPUs.Size() == 0 {
 				continue
 			}
-
-			deviceCapacity := map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
-				cpuResourceQualifiedName: {Value: *resource.NewQuantity(availableCPUsInSocket, resource.DecimalSI)},
-			}
-
-			cp.deviceNameToSocketID[deviceName] = socketID
-
-			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttributeSocketID:   {IntValue: ptr.To(int64(socketID))},
-				AttributeNumCPUs:    {IntValue: ptr.To(availableCPUsInSocket)},
-				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
-			}
-			cp.setPCIeRootsAttribute(deviceAttrs, allocatableCPUs.UnsortedList()...)
-
-			devices = append(devices, resourceapi.Device{
-				Name:                     deviceName,
-				Attributes:               deviceAttrs,
-				Capacity:                 deviceCapacity,
-				AllowMultipleAllocations: ptr.To(true),
+			devices = append(devices, groupedCPUDeviceInfo{
+				name:     fmt.Sprintf("%s%03d", cpuDeviceSocketGroupedPrefix, socketID),
+				cpus:     allocatableCPUs,
+				socketID: socketID,
 			})
 		}
 	case GROUP_BY_NUMA_NODE:
 		numaNodeIDs := topo.CPUDetails.NUMANodes().List()
 		for _, numaID := range numaNodeIDs {
-			deviceName := fmt.Sprintf("%s%03d", cpuDeviceNUMAGroupedPrefix, numaID)
-			numaNodeCPUSet := topo.CPUDetails.CPUsInNUMANodes(numaID)
-			allocatableCPUs := numaNodeCPUSet.Difference(cp.reservedCPUs)
-			availableCPUsInNUMANode := int64(allocatableCPUs.Size())
-
+			allocatableCPUs := topo.CPUDetails.CPUsInNUMANodes(numaID).Difference(cp.reservedCPUs)
 			if allocatableCPUs.Size() == 0 {
 				continue
 			}
 
 			// All CPUs in a NUMA node belong to the same socket.
 			anyCPU := allocatableCPUs.UnsortedList()[0]
-			socketID := int64(topo.CPUDetails[anyCPU].SocketID)
-
-			deviceCapacity := map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
-				cpuResourceQualifiedName: {Value: *resource.NewQuantity(availableCPUsInNUMANode, resource.DecimalSI)},
-			}
-
-			cp.deviceNameToNUMANodeID[deviceName] = numaID
-
-			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttributeNUMANodeID: {IntValue: ptr.To(int64(numaID))},
-				AttributeSocketID:   {IntValue: ptr.To(socketID)},
-				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
-				AttributeNumCPUs:    {IntValue: ptr.To(availableCPUsInNUMANode)},
-			}
-			cp.setPCIeRootsAttribute(deviceAttrs, allocatableCPUs.UnsortedList()...)
-			device.SetCompatibilityAttributes(deviceAttrs, int64(numaID))
-
-			devices = append(devices, resourceapi.Device{
-				Name:                     deviceName,
-				Attributes:               deviceAttrs,
-				Capacity:                 deviceCapacity,
-				AllowMultipleAllocations: ptr.To(true),
+			devices = append(devices, groupedCPUDeviceInfo{
+				name:       fmt.Sprintf("%s%03d", cpuDeviceNUMAGroupedPrefix, numaID),
+				cpus:       allocatableCPUs,
+				socketID:   topo.CPUDetails[anyCPU].SocketID,
+				numaNodeID: numaID,
 			})
 		}
 	}
-
-	if len(devices) == 0 {
-		return nil
-	}
-	return [][]resourceapi.Device{devices}
+	return devices
 }
 
-// CreateCPUDeviceSlices creates Device objects based on the CPU topology.
-// It groups CPUs by physical core to assign consecutive device IDs to hyperthreads.
-// This allows the DRA scheduler, which requests resources in contiguous blocks,
-// to co-locate workloads on hyperthreads of the same core.
-func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
+// cpuDeviceInfos returns the stable individual CPU device enumeration used by
+// both ResourceSlice publication and PrepareResourceClaims device lookup.
+// Keep the ordering in one place so device names resolve to the same CPUs even
+// when Prepare runs before the first ResourceSlice publication after restart.
+func (cp *CPUDriver) cpuDeviceInfos() []cpuDeviceInfo {
 	reservedCPUs := make(map[int]bool)
 	for _, cpuID := range cp.reservedCPUs.List() {
 		reservedCPUs[cpuID] = true
 	}
 
-	var availableCPUs []cpuinfo.CPUInfo
 	topo := cp.cpuTopology
 	allCPUs := make([]cpuinfo.CPUInfo, 0, len(topo.CPUDetails))
+	availableCPUs := []cpuinfo.CPUInfo{}
 	for _, cpu := range topo.CPUDetails {
 		allCPUs = append(allCPUs, cpu)
 		if !reservedCPUs[cpu.CpuID] {
@@ -162,7 +127,7 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 	})
 
 	processedCpus := make(map[int]bool)
-	var coreGroups [][]cpuinfo.CPUInfo
+	coreGroups := [][]cpuinfo.CPUInfo{}
 	cpuInfoMap := make(map[int]cpuinfo.CPUInfo)
 	for _, info := range allCPUs {
 		cpuInfoMap[info.CpuID] = info
@@ -186,32 +151,122 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 		return coreGroups[i][0].CpuID < coreGroups[j][0].CpuID
 	})
 
-	devId := 0
-	var allDevices []resourceapi.Device
+	devices := []cpuDeviceInfo{}
+	devID := 0
 	for _, group := range coreGroups {
 		for _, cpu := range group {
-			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttributeNUMANodeID: {IntValue: ptr.To(int64(cpu.NUMANodeID))},
-				AttributeSocketID:   {IntValue: ptr.To(int64(cpu.SocketID))},
-				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
-				AttributeCacheL3ID:  {IntValue: ptr.To(int64(cpu.UncoreCacheID))},
-				AttributeCoreType:   {StringValue: ptr.To(cpu.CoreType.String())},
-				AttributeCoreID:     {IntValue: ptr.To(int64(cpu.CoreID))},
-				AttributeCPUID:      {IntValue: ptr.To(int64(cpu.CpuID))},
-			}
-			device.SetCompatibilityAttributes(deviceAttrs, int64(cpu.NUMANodeID))
-			cp.setPCIeRootsAttribute(deviceAttrs, cpu.CpuID)
-
-			deviceName := fmt.Sprintf("%s%03d", cpuDevicePrefix, devId)
-			devId++
-			cp.deviceNameToCPUID[deviceName] = cpu.CpuID
-			cpuDevice := resourceapi.Device{
-				Name:       deviceName,
-				Attributes: deviceAttrs,
-				Capacity:   make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity),
-			}
-			allDevices = append(allDevices, cpuDevice)
+			devices = append(devices, cpuDeviceInfo{
+				name: fmt.Sprintf("%s%03d", cpuDevicePrefix, devID),
+				cpu:  cpu,
+			})
+			devID++
 		}
+	}
+	return devices
+}
+
+// initializeDeviceLookupMaps builds the indexes used by PrepareResourceClaims
+// before kubelet can call into the plugin. ResourceSlice publication must not
+// be required to populate these maps.
+func (cp *CPUDriver) initializeDeviceLookupMaps() {
+	cp.deviceNameToCPUID = make(map[string]int)
+	cp.deviceNameToSocketID = make(map[string]int)
+	cp.deviceNameToNUMANodeID = make(map[string]int)
+
+	if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
+		for _, device := range cp.groupedCPUDeviceInfos() {
+			switch cp.cpuDeviceGroupBy {
+			case GROUP_BY_SOCKET:
+				cp.deviceNameToSocketID[device.name] = device.socketID
+			case GROUP_BY_NUMA_NODE:
+				cp.deviceNameToNUMANodeID[device.name] = device.numaNodeID
+			}
+		}
+		return
+	}
+
+	for _, device := range cp.cpuDeviceInfos() {
+		cp.deviceNameToCPUID[device.name] = device.cpu.CpuID
+	}
+}
+
+// createGroupedCPUDeviceSlices creates Device objects based on the CPU topology, grouped by a specific criteria.
+func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resourceapi.Device {
+	logger.V(4).Info("creating grouped CPU devices")
+	var devices []resourceapi.Device
+
+	for _, deviceInfo := range cp.groupedCPUDeviceInfos() {
+		availableCPUs := int64(deviceInfo.cpus.Size())
+		deviceCapacity := map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+			cpuResourceQualifiedName: {Value: *resource.NewQuantity(availableCPUs, resource.DecimalSI)},
+		}
+
+		switch cp.cpuDeviceGroupBy {
+		case GROUP_BY_SOCKET:
+			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttributeSocketID:   {IntValue: ptr.To(int64(deviceInfo.socketID))},
+				AttributeNumCPUs:    {IntValue: ptr.To(availableCPUs)},
+				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
+			}
+			cp.setPCIeRootsAttribute(deviceAttrs, deviceInfo.cpus.UnsortedList()...)
+
+			devices = append(devices, resourceapi.Device{
+				Name:                     deviceInfo.name,
+				Attributes:               deviceAttrs,
+				Capacity:                 deviceCapacity,
+				AllowMultipleAllocations: ptr.To(true),
+			})
+		case GROUP_BY_NUMA_NODE:
+			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				AttributeNUMANodeID: {IntValue: ptr.To(int64(deviceInfo.numaNodeID))},
+				AttributeSocketID:   {IntValue: ptr.To(int64(deviceInfo.socketID))},
+				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
+				AttributeNumCPUs:    {IntValue: ptr.To(availableCPUs)},
+			}
+			device.SetCompatibilityAttributes(deviceAttrs, int64(deviceInfo.numaNodeID))
+			cp.setPCIeRootsAttribute(deviceAttrs, deviceInfo.cpus.UnsortedList()...)
+
+			devices = append(devices, resourceapi.Device{
+				Name:                     deviceInfo.name,
+				Attributes:               deviceAttrs,
+				Capacity:                 deviceCapacity,
+				AllowMultipleAllocations: ptr.To(true),
+			})
+		}
+	}
+
+	if len(devices) == 0 {
+		return nil
+	}
+	return [][]resourceapi.Device{devices}
+}
+
+// CreateCPUDeviceSlices creates Device objects based on the CPU topology.
+// It groups CPUs by physical core to assign consecutive device IDs to hyperthreads.
+// This allows the DRA scheduler, which requests resources in contiguous blocks,
+// to co-locate workloads on hyperthreads of the same core.
+func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
+	var allDevices []resourceapi.Device
+	for _, deviceInfo := range cp.cpuDeviceInfos() {
+		cpu := deviceInfo.cpu
+		deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+			AttributeNUMANodeID: {IntValue: ptr.To(int64(cpu.NUMANodeID))},
+			AttributeSocketID:   {IntValue: ptr.To(int64(cpu.SocketID))},
+			AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
+			AttributeCacheL3ID:  {IntValue: ptr.To(int64(cpu.UncoreCacheID))},
+			AttributeCoreType:   {StringValue: ptr.To(cpu.CoreType.String())},
+			AttributeCoreID:     {IntValue: ptr.To(int64(cpu.CoreID))},
+			AttributeCPUID:      {IntValue: ptr.To(int64(cpu.CpuID))},
+		}
+		device.SetCompatibilityAttributes(deviceAttrs, int64(cpu.NUMANodeID))
+		cp.setPCIeRootsAttribute(deviceAttrs, cpu.CpuID)
+
+		cpuDevice := resourceapi.Device{
+			Name:       deviceInfo.name,
+			Attributes: deviceAttrs,
+			Capacity:   make(map[resourceapi.QualifiedName]resourceapi.DeviceCapacity),
+		}
+		allDevices = append(allDevices, cpuDevice)
 	}
 
 	if len(allDevices) == 0 {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -351,7 +351,7 @@ func TestPublishResources(t *testing.T) {
 				totalDevices += len(s.Devices)
 			}
 			require.Equal(t, tc.expectedDevices, totalDevices)
-			require.Equal(t, tc.expectedDevices, len(cp.deviceNameToCPUID))
+			require.Empty(t, cp.deviceNameToCPUID)
 
 			// Verify device attributes
 			cpuInfosMap := make(map[int]cpuinfo.CPUInfo)
@@ -362,19 +362,12 @@ func TestPublishResources(t *testing.T) {
 			seenCPUIDs := make(map[int]bool)
 			for _, slice := range pool.Slices {
 				for _, device := range slice.Devices {
-					cpuID, ok := cp.deviceNameToCPUID[device.Name]
-					require.True(t, ok)
+					cpuID := int(*device.Attributes[AttributeCPUID].IntValue)
 					require.False(t, seenCPUIDs[cpuID], "duplicate cpuID found in slices: %d", cpuID)
 					seenCPUIDs[cpuID] = true
 
-					var cpuInfo *cpuinfo.CPUInfo
-					for i := range tc.cpuInfos {
-						if tc.cpuInfos[i].CpuID == cpuID {
-							cpuInfo = &tc.cpuInfos[i]
-							break
-						}
-					}
-					require.NotNil(t, cpuInfo, "could not find matching cpuInfo for device %s", device.Name)
+					cpuInfo, ok := cpuInfosMap[cpuID]
+					require.True(t, ok, "could not find matching cpuInfo for device %s", device.Name)
 
 					numaNode := int64(cpuInfo.NUMANodeID)
 					CacheL3ID := int64(cpuInfo.UncoreCacheID)
@@ -395,8 +388,11 @@ func TestPublishResources(t *testing.T) {
 
 			// Test if hyperthreads are given successive device names
 			cpuIDToDeviceName := make(map[int]string)
-			for devName, cpuID := range cp.deviceNameToCPUID {
-				cpuIDToDeviceName[cpuID] = devName
+			for _, slice := range pool.Slices {
+				for _, device := range slice.Devices {
+					cpuID := int(*device.Attributes[AttributeCPUID].IntValue)
+					cpuIDToDeviceName[cpuID] = device.Name
+				}
 			}
 			for _, info := range tc.cpuInfos {
 				if info.SiblingCPUID == -1 || info.CpuID > info.SiblingCPUID {
@@ -420,6 +416,123 @@ func TestPublishResources(t *testing.T) {
 
 				require.Equal(t, devNum1+1, devNum2, "hyperthread device names are not successive for core %d (cpus %d, %d)", info.CoreID, info.CpuID, info.SiblingCPUID)
 			}
+		})
+	}
+}
+
+func TestInitializeDeviceLookupMaps(t *testing.T) {
+	logger := testr.New(t)
+
+	testCases := []struct {
+		name                       string
+		cpuDeviceMode              string
+		cpuDeviceGroupBy           string
+		cpuInfos                   []cpuinfo.CPUInfo
+		reservedCPUs               cpuset.CPUSet
+		expectedDeviceNameToCPUID  map[string]int
+		expectedDeviceNameToSocket map[string]int
+		expectedDeviceNameToNUMA   map[string]int
+	}{
+		{
+			name:          "individual mode",
+			cpuDeviceMode: CPU_DEVICE_MODE_INDIVIDUAL,
+			cpuInfos:      mockCPUInfos_SingleSocket_4CPUS_HT,
+			reservedCPUs:  cpuset.New(1),
+			expectedDeviceNameToCPUID: map[string]int{
+				"cpudev000": 0,
+				"cpudev001": 2,
+				"cpudev002": 3,
+			},
+		},
+		{
+			name:                       "grouped by socket",
+			cpuDeviceMode:              CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy:           GROUP_BY_SOCKET,
+			cpuInfos:                   mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
+			reservedCPUs:               cpuset.New(0, 1, 4, 5),
+			expectedDeviceNameToSocket: map[string]int{"cpudevsocket001": 1},
+		},
+		{
+			name:                     "grouped by numa node",
+			cpuDeviceMode:            CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy:         GROUP_BY_NUMA_NODE,
+			cpuInfos:                 mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
+			reservedCPUs:             cpuset.New(2, 3, 6, 7),
+			expectedDeviceNameToNUMA: map[string]int{"cpudevnuma000": 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: tc.cpuInfos}
+			topo, err := mockProvider.GetCPUTopology(logger)
+			require.NoError(t, err)
+
+			cp := &CPUDriver{
+				cpuTopology:      topo,
+				reservedCPUs:     tc.reservedCPUs,
+				cpuDeviceMode:    tc.cpuDeviceMode,
+				cpuDeviceGroupBy: tc.cpuDeviceGroupBy,
+			}
+			cp.initializeDeviceLookupMaps()
+
+			if tc.expectedDeviceNameToCPUID == nil {
+				tc.expectedDeviceNameToCPUID = map[string]int{}
+			}
+			if tc.expectedDeviceNameToSocket == nil {
+				tc.expectedDeviceNameToSocket = map[string]int{}
+			}
+			if tc.expectedDeviceNameToNUMA == nil {
+				tc.expectedDeviceNameToNUMA = map[string]int{}
+			}
+			require.Equal(t, tc.expectedDeviceNameToCPUID, cp.deviceNameToCPUID)
+			require.Equal(t, tc.expectedDeviceNameToSocket, cp.deviceNameToSocketID)
+			require.Equal(t, tc.expectedDeviceNameToNUMA, cp.deviceNameToNUMANodeID)
+		})
+	}
+}
+
+func TestPublishResourcesDoesNotInitializeGroupedLookupMaps(t *testing.T) {
+	logger := testr.New(t)
+
+	testCases := []struct {
+		name             string
+		cpuDeviceGroupBy string
+	}{
+		{
+			name:             "socket grouped",
+			cpuDeviceGroupBy: GROUP_BY_SOCKET,
+		},
+		{
+			name:             "numa grouped",
+			cpuDeviceGroupBy: GROUP_BY_NUMA_NODE,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockPlugin := &mockKubeletPlugin{}
+			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT}
+			topo, err := mockProvider.GetCPUTopology(logger)
+			require.NoError(t, err)
+
+			cp := &CPUDriver{
+				nodeName:               testNodeName,
+				draPlugin:              mockPlugin,
+				deviceNameToSocketID:   make(map[string]int),
+				deviceNameToNUMANodeID: make(map[string]int),
+				cpuTopology:            topo,
+				cpuDeviceMode:          CPU_DEVICE_MODE_GROUPED,
+				cpuDeviceGroupBy:       tc.cpuDeviceGroupBy,
+				reservedCPUs:           cpuset.New(),
+				pcieRootMapper:         store.NewPCIeRootMapper(),
+			}
+
+			cp.PublishResources(context.Background())
+
+			require.NotNil(t, mockPlugin.publishedResources)
+			require.Empty(t, cp.deviceNameToSocketID)
+			require.Empty(t, cp.deviceNameToNUMANodeID)
 		})
 	}
 }

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -537,6 +537,67 @@ func TestPublishResourcesDoesNotInitializeGroupedLookupMaps(t *testing.T) {
 	}
 }
 
+func TestPrepareResourceClaimsSucceedsBeforePublishResources(t *testing.T) {
+	logger := testr.New(t)
+	claimUID := types.UID("claim-prepare-before-publish")
+
+	testCases := []struct {
+		name             string
+		cpuDeviceMode    string
+		cpuDeviceGroupBy string
+		claim            *resourceapi.ResourceClaim
+	}{
+		{
+			name:          "individual mode",
+			cpuDeviceMode: CPU_DEVICE_MODE_INDIVIDUAL,
+			claim: testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+				{Driver: testDriverName, Pool: testNodeName, Device: "cpudev000"},
+				{Driver: testDriverName, Pool: testNodeName, Device: "cpudev001"},
+			}),
+		},
+		{
+			name:             "socket grouped",
+			cpuDeviceMode:    CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy: GROUP_BY_SOCKET,
+			claim:            testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 2}),
+		},
+		{
+			name:             "numa grouped",
+			cpuDeviceMode:    CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy: GROUP_BY_NUMA_NODE,
+			claim:            testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma000": 2}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT}
+			topo, err := mockProvider.GetCPUTopology(logger)
+			require.NoError(t, err)
+
+			driver := &CPUDriver{
+				driverName:         testDriverName,
+				cpuTopology:        topo,
+				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+				cdiMgr:             newMockCdiMgr(),
+				cpuDeviceMode:      tc.cpuDeviceMode,
+				cpuDeviceGroupBy:   tc.cpuDeviceGroupBy,
+				reservedCPUs:       cpuset.New(),
+			}
+			driver.initializeDeviceLookupMaps()
+
+			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.claim})
+			require.NoError(t, err)
+			require.NoError(t, preparedClaims[claimUID].Err)
+			require.NotEmpty(t, preparedClaims[claimUID].Devices)
+			require.Len(t, driver.cdiMgr.(*mockCdiMgr).devices, 1)
+
+			_, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+			require.True(t, ok)
+		})
+	}
+}
+
 func TestPrepareResourceClaims(t *testing.T) {
 	logger := testr.New(t)
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -165,6 +165,7 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 
 	plugin.cpuAllocationStore = store.NewCPUAllocation(plugin.cpuTopology, config.ReservedCPUs)
 	plugin.podConfigStore = store.NewPodConfig()
+	plugin.initializeDeviceLookupMaps()
 
 	driverPluginPath := filepath.Join(kubeletPluginPath, config.DriverName)
 	if err := os.MkdirAll(driverPluginPath, 0750); err != nil {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -172,6 +172,12 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		return nil, asyncErr, fmt.Errorf("failed to create plugin path %s: %w", driverPluginPath, err)
 	}
 
+	cdiMgr, err := NewCdiManager(logger, config.DriverName, cdiSpecDir)
+	if err != nil {
+		return nil, asyncErr, fmt.Errorf("failed to create CDI manager: %w", err)
+	}
+	plugin.cdiMgr = cdiMgr
+
 	kubeletOpts := []kubeletplugin.Option{
 		kubeletplugin.DriverName(config.DriverName),
 		kubeletplugin.NodeName(config.NodeName),
@@ -192,12 +198,6 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	if err != nil {
 		return nil, asyncErr, err
 	}
-
-	cdiMgr, err := NewCdiManager(logger, config.DriverName, cdiSpecDir)
-	if err != nil {
-		return nil, asyncErr, fmt.Errorf("failed to create CDI manager: %w", err)
-	}
-	plugin.cdiMgr = cdiMgr
 
 	// register the NRI plugin
 	nriOpts := []stub.Option{


### PR DESCRIPTION
/kind bug
﻿
#### What this PR does / why we need it
﻿
Fixes `PrepareResourceClaims` so it no longer depends on `PublishResources` side effects to resolve allocated device names.
﻿
Previously, the driver populated `deviceNameToCPUID`, `deviceNameToSocketID`, and `deviceNameToNUMANodeID` while generating ResourceSlice devices. Because `PublishResources` runs asynchronously, kubelet could call `PrepareResourceClaims` after a driver restart before those maps were rebuilt, causing valid allocations to fail prepare.
﻿
This PR changes the driver to build those lookup maps during startup, before the kubelet plugin can serve prepare calls.
﻿
The ResourceSlice publication path now uses the same stable device enumeration helpers, but no longer mutates the lookup maps.
﻿
#### Which issue(s) this PR fixes
Fixes #168
﻿