### PR TITLE
dra: ensure idempotency of PrepareResourceClaims

### DIFF
--- a/pkg/driver/cdi_test.go
+++ b/pkg/driver/cdi_test.go
@@ -180,3 +180,35 @@ func TestRemoveDevice(t *testing.T) {
 		})
 	}
 }
+
+func TestAddDeviceOverwrite(t *testing.T) {
+	logger := testr.New(t)
+	tempCDIDir := t.TempDir()
+
+	mgr, err := NewCdiManager(logger, testDriverName, tempCDIDir)
+	require.NoError(t, err)
+
+	deviceName := "claim-cpu-overwrite"
+	expectedSpecName := mgr.getSpecName(deviceName)
+
+	assertFileCount := func(expected int) {
+		files, err := os.ReadDir(tempCDIDir)
+		require.NoError(t, err)
+		require.Len(t, files, expected)
+	}
+
+	err = mgr.AddDevice(logger, deviceName, "CPU=0,1")
+	require.NoError(t, err)
+	assertFileCount(1)
+
+	// Verify the cache has the initial spec
+	spec1 := getSpecFromCache(mgr, expectedSpecName)
+	require.NotNil(t, spec1)
+	require.Equal(t, []string{"CPU=0,1"}, spec1.Devices[0].ContainerEdits.Env)
+
+	// Call AddDevice again with the same deviceName and same data
+	err = mgr.AddDevice(logger, deviceName, "CPU=0,1")
+	require.NoError(t, err)
+	// Verify that we do not create a new file
+	assertFileCount(1)
+}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -351,6 +351,16 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		}
 	}
 
+	if existingCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(claim.UID); ok {
+		logger.V(2).Info("claim already has allocated CPUs in store, reusing assignment", "cpus", existingCPUs.String())
+		// Even if the claim is already allocated in our in-memory store (which happens when a duplicate prepare
+		// call is invoked without an intermediate unprepare), we must call prepareDevices and return the result back to Kubelet.
+		// If the CDI file is already created on disk, the CDI manager will safely overwrite it with the same configuration.
+		// This ensures that the CDI specification file is written/recreated on disk (for example, if the driver
+		// pod restarted and synchronized its memory store from the runtime but did not recreate the CDI files on disk).
+		return cp.prepareDevices(logger, claim, existingCPUs)
+	}
+
 	var cpuAssignment cpuset.CPUSet
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	for _, alloc := range claim.Status.Allocation.Devices.Results {
@@ -400,32 +410,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 
 	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, cpuAssignment)
 
-	deviceName := getCDIDeviceName(claim.UID)
-	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, cpuAssignment.String())
-	if err := cp.cdiMgr.AddDevice(logger, deviceName, envVar); err != nil {
-		return kubeletplugin.PrepareResult{Err: err}
-	}
-
-	qualifiedName := cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName)
-	logger.V(6).Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
-	preparedDevices := []kubeletplugin.Device{}
-	for _, allocResult := range claim.Status.Allocation.Devices.Results {
-		if allocResult.Driver != cp.driverName {
-			continue
-		}
-		preparedDevice := kubeletplugin.Device{
-			PoolName:     allocResult.Pool,
-			DeviceName:   allocResult.Device,
-			CDIDeviceIDs: []string{qualifiedName},
-			Requests:     []string{allocResult.Request},
-		}
-		preparedDevices = append(preparedDevices, preparedDevice)
-	}
-
-	logger.V(4).Info("prepared devices for grouped resource claim", "preparedDevices", preparedDevices)
-	return kubeletplugin.PrepareResult{
-		Devices: preparedDevices,
-	}
+	return cp.prepareDevices(logger, claim, cpuAssignment)
 }
 
 func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
@@ -457,6 +442,17 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 	}
 
 	claimCPUSet := cpuset.New(claimCPUIDs...)
+	if existingCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(claim.UID); ok {
+		logger.V(2).Info("claim already has allocated CPUs in store, reusing assignment", "cpus", existingCPUs.String())
+		if !existingCPUs.Equals(claimCPUSet) {
+			// This should realistically never happen as the claim is immutable.
+			return kubeletplugin.PrepareResult{
+				Err: fmt.Errorf("claim %s/%s is already prepared with different CPUs %s (requested %s)", claim.Namespace, claim.Name, existingCPUs.String(), claimCPUSet.String()),
+			}
+		}
+		return cp.prepareDevices(logger, claim, existingCPUs)
+	}
+
 	// All the CPUs allocated to a claim should currently be in the shared pool.
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	if !claimCPUSet.IsSubsetOf(sharedCPUs) {
@@ -466,6 +462,10 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 	}
 
 	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, claimCPUSet)
+	return cp.prepareDevices(logger, claim, claimCPUSet)
+}
+
+func (cp *CPUDriver) prepareDevices(logger logr.Logger, claim *resourceapi.ResourceClaim, claimCPUSet cpuset.CPUSet) kubeletplugin.PrepareResult {
 	deviceName := getCDIDeviceName(claim.UID)
 	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, claimCPUSet.String())
 	if err := cp.cdiMgr.AddDevice(logger, deviceName, envVar); err != nil {
@@ -484,10 +484,13 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 			DeviceName:   allocResult.Device,
 			CDIDeviceIDs: []string{qualifiedName},
 		}
+		if allocResult.Request != "" {
+			preparedDevice.Requests = []string{allocResult.Request}
+		}
 		preparedDevices = append(preparedDevices, preparedDevice)
 	}
 
-	logger.V(4).Info("prepared devices for individual resource claim", "preparedDevices", preparedDevices)
+	logger.V(4).Info("prepared devices for resource claim", "preparedDevices", preparedDevices)
 	return kubeletplugin.PrepareResult{
 		Devices: preparedDevices,
 	}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1156,8 +1156,13 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// tests should not access private data. Using fake/mocks, passing them to the driver
+			// and asserting on the fake/mock state accessed directly from test code (not through
+			// the driver private data) is bending the rules and a practical choice.
+			cdiMgr := newMockCdiMgr()
 			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
 			topo, _ := mockProvider.GetCPUTopology(logger)
+			cpuStore := store.NewCPUAllocation(topo, cpuset.New())
 			driver := &CPUDriver{
 				driverName: testDriverName,
 				deviceNameToCPUID: map[string]int{
@@ -1166,8 +1171,8 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 					"cpudev2": 2,
 					"cpudev3": 3,
 				},
-				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
-				cdiMgr:             newMockCdiMgr(),
+				cpuAllocationStore: cpuStore,
+				cdiMgr:             cdiMgr,
 			}
 
 			makeClaim := func(devices []string) []*resourceapi.ResourceClaim {
@@ -1187,18 +1192,131 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 				}
 			}
 
-			_, err := driver.PrepareResourceClaims(context.Background(), makeClaim(tc.firstDevices))
+			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), makeClaim(tc.firstDevices))
 			require.NoError(t, err)
+			require.NoError(t, preparedClaims[claimUID].Err)
 
-			_, err = driver.PrepareResourceClaims(context.Background(), makeClaim(tc.secondDevices))
+			preparedClaims, err = driver.PrepareResourceClaims(context.Background(), makeClaim(tc.secondDevices))
 			require.NoError(t, err)
+			require.NoError(t, preparedClaims[claimUID].Err)
 
-			gotCPUs, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+			gotCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
 			require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
-			require.True(t, tc.expectedShared.Equals(driver.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s, want %s", driver.cpuAllocationStore.GetSharedCPUs(), tc.expectedShared)
+			require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
 
-			envVar := driver.cdiMgr.(*mockCdiMgr).devices[cdiDeviceName]
+			envVar := cdiMgr.devices[cdiDeviceName]
+			parts := strings.SplitN(envVar, "=", 2)
+			require.Len(t, parts, 2)
+			actualCPUSet, err := cpuset.Parse(parts[1])
+			require.NoError(t, err)
+			require.True(t, tc.expectedCPUSet.Equals(actualCPUSet), "cdi env cpus: got %s, want %s", actualCPUSet, tc.expectedCPUSet)
+		})
+	}
+}
+
+func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
+	logger := testr.New(t)
+	claimUID := types.UID("claim-1")
+	cdiDeviceName := getCDIDeviceName(claimUID)
+
+	// tests should not access private data. Using fake/mocks, passing them to the driver
+	// and asserting on the fake/mock state accessed directly from test code (not through
+	// the driver private data) is bending the rules and a practical choice.
+
+	makeSocketDriver := func(logger logr.Logger) (*CPUDriver, *store.CPUAllocation, *mockCdiMgr) {
+		cdiMgr := newMockCdiMgr()
+		mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT}
+		topo, _ := mockProvider.GetCPUTopology(logger)
+		cpuStore := store.NewCPUAllocation(topo, cpuset.New())
+		return &CPUDriver{
+			driverName:             testDriverName,
+			cpuDeviceMode:          CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy:       GROUP_BY_SOCKET,
+			cpuTopology:            topo,
+			deviceNameToSocketID:   map[string]int{"cpudevsocket0": 0, "cpudevsocket1": 1},
+			deviceNameToNUMANodeID: map[string]int{},
+			cpuAllocationStore:     cpuStore,
+			cdiMgr:                 cdiMgr,
+		}, cpuStore, cdiMgr
+	}
+	makeNUMADriver := func(logger logr.Logger) (*CPUDriver, *store.CPUAllocation, *mockCdiMgr) {
+		cdiMgr := newMockCdiMgr()
+		mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT}
+		topo, _ := mockProvider.GetCPUTopology(logger)
+		cpuStore := store.NewCPUAllocation(topo, cpuset.New())
+		return &CPUDriver{
+			driverName:             testDriverName,
+			cpuDeviceMode:          CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy:       GROUP_BY_NUMA_NODE,
+			cpuTopology:            topo,
+			deviceNameToSocketID:   map[string]int{},
+			deviceNameToNUMANodeID: map[string]int{"cpudevnuma0": 0, "cpudevnuma1": 1},
+			cpuAllocationStore:     cpuStore,
+			cdiMgr:                 cdiMgr,
+		}, cpuStore, cdiMgr
+	}
+
+	testCases := []struct {
+		name           string
+		makeDriver     func(logr.Logger) (*CPUDriver, *store.CPUAllocation, *mockCdiMgr)
+		firstClaim     *resourceapi.ResourceClaim
+		secondClaim    *resourceapi.ResourceClaim
+		expectedCPUSet cpuset.CPUSet
+		expectedShared cpuset.CPUSet
+	}{
+		{
+			name:           "same socket repeated",
+			makeDriver:     makeSocketDriver,
+			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
+			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+		},
+		{
+			name:           "different socket repeated",
+			makeDriver:     makeSocketDriver,
+			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
+			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket1": 2}),
+			expectedCPUSet: cpuset.New(2, 6),
+			expectedShared: cpuset.New(0, 1, 3, 4, 5, 7),
+		},
+		{
+			name:           "same NUMA node repeated",
+			makeDriver:     makeNUMADriver,
+			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
+			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+		},
+		{
+			name:           "different NUMA node repeated",
+			makeDriver:     makeNUMADriver,
+			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
+			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma1": 2}),
+			expectedCPUSet: cpuset.New(2, 6),
+			expectedShared: cpuset.New(0, 1, 3, 4, 5, 7),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			driver, cpuStore, cdiMgr := tc.makeDriver(logger)
+
+			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.firstClaim})
+			require.NoError(t, err)
+			require.NoError(t, preparedClaims[claimUID].Err)
+
+			preparedClaims, err = driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.secondClaim})
+			require.NoError(t, err)
+			require.NoError(t, preparedClaims[claimUID].Err)
+
+			gotCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
+			require.True(t, ok)
+			require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
+			require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
+
+			envVar := cdiMgr.devices[cdiDeviceName]
 			parts := strings.SplitN(envVar, "=", 2)
 			require.Len(t, parts, 2)
 			actualCPUSet, err := cpuset.Parse(parts[1])

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1137,6 +1137,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 		secondDevices  []string
 		expectedCPUSet cpuset.CPUSet
 		expectedShared cpuset.CPUSet
+		expectError    bool
 	}{
 		{
 			name:           "individual mode - same devices repeated",
@@ -1144,25 +1145,22 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 			secondDevices:  []string{"cpudev0", "cpudev1"},
 			expectedCPUSet: cpuset.New(0, 1),
 			expectedShared: cpuset.New(2, 3),
+			expectError:    false,
 		},
 		{
 			name:           "individual mode - different devices repeated",
 			firstDevices:   []string{"cpudev0", "cpudev1"},
 			secondDevices:  []string{"cpudev2", "cpudev3"},
-			expectedCPUSet: cpuset.New(2, 3),
-			expectedShared: cpuset.New(0, 1),
+			expectedCPUSet: cpuset.New(0, 1),
+			expectedShared: cpuset.New(2, 3),
+			expectError:    true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// tests should not access private data. Using fake/mocks, passing them to the driver
-			// and asserting on the fake/mock state accessed directly from test code (not through
-			// the driver private data) is bending the rules and a practical choice.
-			cdiMgr := newMockCdiMgr()
 			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
 			topo, _ := mockProvider.GetCPUTopology(logger)
-			cpuStore := store.NewCPUAllocation(topo, cpuset.New())
 			driver := &CPUDriver{
 				driverName: testDriverName,
 				deviceNameToCPUID: map[string]int{
@@ -1171,8 +1169,8 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 					"cpudev2": 2,
 					"cpudev3": 3,
 				},
-				cpuAllocationStore: cpuStore,
-				cdiMgr:             cdiMgr,
+				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+				cdiMgr:             newMockCdiMgr(),
 			}
 
 			makeClaim := func(devices []string) []*resourceapi.ResourceClaim {
@@ -1192,25 +1190,32 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 				}
 			}
 
-			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), makeClaim(tc.firstDevices))
+			_, err := driver.PrepareResourceClaims(context.Background(), makeClaim(tc.firstDevices))
 			require.NoError(t, err)
-			require.NoError(t, preparedClaims[claimUID].Err)
 
-			preparedClaims, err = driver.PrepareResourceClaims(context.Background(), makeClaim(tc.secondDevices))
+			prepareResults, err := driver.PrepareResourceClaims(context.Background(), makeClaim(tc.secondDevices))
 			require.NoError(t, err)
-			require.NoError(t, preparedClaims[claimUID].Err)
 
-			gotCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
+			claimResult, ok := prepareResults[claimUID]
 			require.True(t, ok)
-			require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
-			require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
 
-			envVar := cdiMgr.devices[cdiDeviceName]
-			parts := strings.SplitN(envVar, "=", 2)
-			require.Len(t, parts, 2)
-			actualCPUSet, err := cpuset.Parse(parts[1])
-			require.NoError(t, err)
-			require.True(t, tc.expectedCPUSet.Equals(actualCPUSet), "cdi env cpus: got %s, want %s", actualCPUSet, tc.expectedCPUSet)
+			if tc.expectError {
+				require.Error(t, claimResult.Err)
+			} else {
+				require.NoError(t, claimResult.Err)
+
+				gotCPUs, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+				require.True(t, ok)
+				require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
+				require.True(t, tc.expectedShared.Equals(driver.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s, want %s", driver.cpuAllocationStore.GetSharedCPUs(), tc.expectedShared)
+
+				envVar := driver.cdiMgr.(*mockCdiMgr).devices[cdiDeviceName]
+				parts := strings.SplitN(envVar, "=", 2)
+				require.Len(t, parts, 2)
+				actualCPUSet, err := cpuset.Parse(parts[1])
+				require.NoError(t, err)
+				require.True(t, tc.expectedCPUSet.Equals(actualCPUSet), "cdi env cpus: got %s, want %s", actualCPUSet, tc.expectedCPUSet)
+			}
 		})
 	}
 }
@@ -1278,8 +1283,8 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			makeDriver:     makeSocketDriver,
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket1": 2}),
-			expectedCPUSet: cpuset.New(2, 6),
-			expectedShared: cpuset.New(0, 1, 3, 4, 5, 7),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
 		},
 		{
 			name:           "same NUMA node repeated",
@@ -1294,8 +1299,8 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			makeDriver:     makeNUMADriver,
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma1": 2}),
-			expectedCPUSet: cpuset.New(2, 6),
-			expectedShared: cpuset.New(0, 1, 3, 4, 5, 7),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
 		},
 	}
 
@@ -1303,18 +1308,22 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			driver, cpuStore, cdiMgr := tc.makeDriver(logger)
 
-			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.firstClaim})
+			_, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.firstClaim})
 			require.NoError(t, err)
-			require.NoError(t, preparedClaims[claimUID].Err)
 
-			preparedClaims, err = driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.secondClaim})
+			gotCPUsAfterFirst, ok := cpuStore.GetResourceClaimAllocation(claimUID)
+			require.True(t, ok)
+			require.True(t, tc.expectedCPUSet.Equals(gotCPUsAfterFirst), "claim cpus after first prepare: got %s, want %s", gotCPUsAfterFirst, tc.expectedCPUSet)
+			require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus after first prepare: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
+
+			prepareResults, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.secondClaim})
 			require.NoError(t, err)
-			require.NoError(t, preparedClaims[claimUID].Err)
+			require.NoError(t, prepareResults[claimUID].Err)
 
 			gotCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
-			require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
-			require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
+			require.True(t, gotCPUsAfterFirst.Equals(gotCPUs), "claim cpus must be unchanged after second prepare: got %s, want %s", gotCPUs, gotCPUsAfterFirst)
+			require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus must be unchanged after second prepare: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
 
 			envVar := cdiMgr.devices[cdiDeviceName]
 			parts := strings.SplitN(envVar, "=", 2)
@@ -1402,6 +1411,7 @@ func testClaim(claimUID types.UID, driverName, poolName string, consumedCapacity
 			Driver:           driverName,
 			Pool:             poolName,
 			Device:           device,
+			Request:          string(claimUID),
 			ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(quantity, resource.DecimalSI)},
 		})
 	}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -575,10 +575,12 @@ func TestPrepareResourceClaimsSucceedsBeforePublishResources(t *testing.T) {
 			topo, err := mockProvider.GetCPUTopology(logger)
 			require.NoError(t, err)
 
+			cpuStore := store.NewCPUAllocation(topo, cpuset.New())
+
 			driver := &CPUDriver{
 				driverName:         testDriverName,
 				cpuTopology:        topo,
-				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+				cpuAllocationStore: cpuStore,
 				cdiMgr:             newMockCdiMgr(),
 				cpuDeviceMode:      tc.cpuDeviceMode,
 				cpuDeviceGroupBy:   tc.cpuDeviceGroupBy,
@@ -592,7 +594,7 @@ func TestPrepareResourceClaimsSucceedsBeforePublishResources(t *testing.T) {
 			require.NotEmpty(t, preparedClaims[claimUID].Devices)
 			require.Len(t, driver.cdiMgr.(*mockCdiMgr).devices, 1)
 
-			_, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+			_, ok := cpuStore.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
 		})
 	}
@@ -1161,6 +1163,8 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
 			topo, _ := mockProvider.GetCPUTopology(logger)
+			cpuStore := store.NewCPUAllocation(topo, cpuset.New())
+			cdiMgr := newMockCdiMgr()
 			driver := &CPUDriver{
 				driverName: testDriverName,
 				deviceNameToCPUID: map[string]int{
@@ -1169,8 +1173,8 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 					"cpudev2": 2,
 					"cpudev3": 3,
 				},
-				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
-				cdiMgr:             newMockCdiMgr(),
+				cpuAllocationStore: cpuStore,
+				cdiMgr:             cdiMgr,
 			}
 
 			makeClaim := func(devices []string) []*resourceapi.ResourceClaim {
@@ -1204,12 +1208,12 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 			} else {
 				require.NoError(t, claimResult.Err)
 
-				gotCPUs, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+				gotCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
 				require.True(t, ok)
 				require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
-				require.True(t, tc.expectedShared.Equals(driver.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s, want %s", driver.cpuAllocationStore.GetSharedCPUs(), tc.expectedShared)
+				require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
 
-				envVar := driver.cdiMgr.(*mockCdiMgr).devices[cdiDeviceName]
+				envVar := cdiMgr.devices[cdiDeviceName]
 				parts := strings.SplitN(envVar, "=", 2)
 				require.Len(t, parts, 2)
 				actualCPUSet, err := cpuset.Parse(parts[1])


### PR DESCRIPTION
Ensure DRA calls are idempotent. From #169 and the review of #170 (and independently fixed in #165) it emerged the driver is not correctly implementing this constraint.

Spawned from #170
Includes the fix https://github.com/kubernetes-sigs/dra-driver-cpu/pull/165/changes/ceeec6086749cfd303cfb9e4a39a54eb596c6e29