### PR TITLE
Fix UnprepareResourceClaims CDI removal ordering

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -520,9 +520,13 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 }
 
 func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplugin.NamespacedObject) error {
+	// Remove the CDI spec first. If that fails, keep the allocation recorded so
+	// the driver does not make those CPUs available while stale CDI state remains.
+	if err := cp.cdiMgr.RemoveDevice(logger, getCDIDeviceName(claim.UID)); err != nil {
+		return err
+	}
 	cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
-	// Remove the device from the CDI spec file using the manager.
-	return cp.cdiMgr.RemoveDevice(logger, getCDIDeviceName(claim.UID))
+	return nil
 }
 
 // HandleError is called by the kubelet plugin framework when an error occurs in the background,

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1264,6 +1264,61 @@ func TestUnprepareResourceClaims(t *testing.T) {
 	}
 }
 
+func TestUnprepareResourceClaimsKeepsAllocationWhenCDIRemoveFails(t *testing.T) {
+	logger := testr.New(t)
+	claimUID := types.UID("claim-cdi-remove-fails")
+	cdiDeviceName := getCDIDeviceName(claimUID)
+	allocatedCPUs := cpuset.New(0, 2)
+
+	cp, mockCdiMgr := newDriverWithAllocatedClaim(t, logger, claimUID, allocatedCPUs)
+	mockCdiMgr.removeError = fmt.Errorf("cdi remove error")
+
+	unpreparedClaims, err := cp.UnprepareResourceClaims(context.Background(), []kubeletplugin.NamespacedObject{{UID: claimUID}})
+	require.NoError(t, err)
+	require.Error(t, unpreparedClaims[claimUID])
+
+	gotCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+	require.True(t, ok)
+	require.True(t, allocatedCPUs.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, allocatedCPUs)
+	require.True(t, cpuset.New(1, 3).Equals(cp.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s", cp.cpuAllocationStore.GetSharedCPUs())
+	require.Contains(t, mockCdiMgr.devices, cdiDeviceName)
+}
+
+func TestUnprepareResourceClaimsRemovesAllocationAfterCDIRemoveSucceeds(t *testing.T) {
+	logger := testr.New(t)
+	claimUID := types.UID("claim-cdi-remove-succeeds")
+	cdiDeviceName := getCDIDeviceName(claimUID)
+	allocatedCPUs := cpuset.New(0, 2)
+
+	cp, mockCdiMgr := newDriverWithAllocatedClaim(t, logger, claimUID, allocatedCPUs)
+
+	unpreparedClaims, err := cp.UnprepareResourceClaims(context.Background(), []kubeletplugin.NamespacedObject{{UID: claimUID}})
+	require.NoError(t, err)
+	require.NoError(t, unpreparedClaims[claimUID])
+
+	_, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+	require.False(t, ok)
+	require.True(t, cpuset.New(0, 1, 2, 3).Equals(cp.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s", cp.cpuAllocationStore.GetSharedCPUs())
+	require.NotContains(t, mockCdiMgr.devices, cdiDeviceName)
+}
+
+func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID types.UID, allocatedCPUs cpuset.CPUSet) (*CPUDriver, *mockCdiMgr) {
+	t.Helper()
+
+	mockCdiMgr := newMockCdiMgr()
+	mockCdiMgr.devices[getCDIDeviceName(claimUID)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, allocatedCPUs.String())
+	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
+	topo, err := mockProvider.GetCPUTopology(logger)
+	require.NoError(t, err)
+	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
+	cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, allocatedCPUs)
+
+	return &CPUDriver{
+		cdiMgr:             mockCdiMgr,
+		cpuAllocationStore: cpuAllocationStore,
+	}, mockCdiMgr
+}
+
 func testClaimWithResults(claimUID types.UID, results []resourceapi.DeviceRequestAllocationResult) *resourceapi.ResourceClaim {
 	return &resourceapi.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{UID: claimUID, Name: string(claimUID)},


### PR DESCRIPTION
This PR updates `UnprepareResourceClaims` to remove the CDI device before releasing the CPU allocation from the driver store.
Previously, `unprepareResourceClaim` removed the claim allocation first and then removed the CDI device. If CDI removal failed due to a real filesystem/permission/IO error, the CPUs were returned to the shared pool while the stale CDI spec could still remain on disk.
﻿
Fixes #178