### PR TITLE
refactor and split driver.Start()

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -162,7 +162,7 @@ func run(logger logr.Logger) error {
 	}()
 	signal.Notify(signalCh, os.Interrupt, unix.SIGINT)
 
-	driverConfig := &driver.Config{
+	driverConfig := driver.Config{
 		DriverName:       driverName,
 		NodeName:         nodeName,
 		ReservedCPUs:     reservedCPUSet,
@@ -170,7 +170,14 @@ func run(logger logr.Logger) error {
 		CPUDeviceGroupBy: driverFlags.GroupBy,
 		ExposePCIeRoots:  driverFlags.ExposePCIeRoots,
 	}
-	dracpu, asyncErr, err := driver.Start(ctx, clientset, driverConfig)
+	driverProviders := driver.Providers{
+		K8SClient: clientset,
+	}
+	dracpu, err := driver.New(logger, driverProviders, &driverConfig)
+	if err != nil {
+		return fmt.Errorf("driver failed to initialize: %w", err)
+	}
+	asyncErr, err := dracpu.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("driver failed to start: %w", err)
 	}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -172,31 +172,6 @@ func (cp *CPUDriver) cpuDeviceInfos() []cpuDeviceInfo {
 	return devices
 }
 
-// initializeDeviceLookupMaps builds the indexes used by PrepareResourceClaims
-// before kubelet can call into the plugin. ResourceSlice publication must not
-// be required to populate these maps.
-func (cp *CPUDriver) initializeDeviceLookupMaps() {
-	cp.deviceNameToCPUID = make(map[string]int)
-	cp.deviceNameToSocketID = make(map[string]int)
-	cp.deviceNameToNUMANodeID = make(map[string]int)
-
-	if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
-		for _, device := range cp.groupedDeviceInfos {
-			switch cp.cpuDeviceGroupBy {
-			case GROUP_BY_SOCKET:
-				cp.deviceNameToSocketID[device.name] = device.socketID
-			case GROUP_BY_NUMA_NODE:
-				cp.deviceNameToNUMANodeID[device.name] = device.numaNodeID
-			}
-		}
-		return
-	}
-
-	for _, device := range cp.individualDeviceInfos {
-		cp.deviceNameToCPUID[device.name] = device.cpu.CpuID
-	}
-}
-
 // createGroupedCPUDeviceSlices creates Device objects based on the CPU topology, grouped by a specific criteria.
 func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resourceapi.Device {
 	logger.V(4).Info("creating grouped CPU devices")

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -181,7 +181,7 @@ func (cp *CPUDriver) initializeDeviceLookupMaps() {
 	cp.deviceNameToNUMANodeID = make(map[string]int)
 
 	if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
-		for _, device := range cp.groupedCPUDeviceInfos() {
+		for _, device := range cp.groupedDeviceInfos {
 			switch cp.cpuDeviceGroupBy {
 			case GROUP_BY_SOCKET:
 				cp.deviceNameToSocketID[device.name] = device.socketID
@@ -192,7 +192,7 @@ func (cp *CPUDriver) initializeDeviceLookupMaps() {
 		return
 	}
 
-	for _, device := range cp.cpuDeviceInfos() {
+	for _, device := range cp.individualDeviceInfos {
 		cp.deviceNameToCPUID[device.name] = device.cpu.CpuID
 	}
 }
@@ -202,7 +202,7 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resour
 	logger.V(4).Info("creating grouped CPU devices")
 	var devices []resourceapi.Device
 
-	for _, deviceInfo := range cp.groupedCPUDeviceInfos() {
+	for _, deviceInfo := range cp.groupedDeviceInfos {
 		availableCPUs := int64(deviceInfo.cpus.Size())
 		deviceCapacity := map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
 			cpuResourceQualifiedName: {Value: *resource.NewQuantity(availableCPUs, resource.DecimalSI)},
@@ -266,7 +266,7 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resour
 // to co-locate workloads on hyperthreads of the same core.
 func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 	var allDevices []resourceapi.Device
-	for _, deviceInfo := range cp.cpuDeviceInfos() {
+	for _, deviceInfo := range cp.individualDeviceInfos {
 		cpu := deviceInfo.cpu
 		deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
 			AttributeNUMANodeID: {IntValue: new(int64(cpu.NUMANodeID))},

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -303,20 +303,13 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 	logger.V(4).Info("begin: publishing resources")
 	defer logger.V(4).Info("end: publishing resources")
 
-	var deviceChunks [][]resourceapi.Device
-	if cp.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
-		deviceChunks = cp.createGroupedCPUDeviceSlices(logger)
-	} else {
-		deviceChunks = cp.createCPUDeviceSlices()
-	}
-
-	if deviceChunks == nil {
+	if cp.deviceSlices == nil {
 		logger.Info("no devices to publish or error occurred")
 		return
 	}
 
-	slices := make([]resourceslice.Slice, 0, len(deviceChunks))
-	for _, chunk := range deviceChunks {
+	slices := make([]resourceslice.Slice, 0, len(cp.deviceSlices))
+	for _, chunk := range cp.deviceSlices {
 		slices = append(slices, resourceslice.Slice{Devices: chunk})
 	}
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -448,9 +448,7 @@ func TestPublishResources(t *testing.T) {
 	}
 }
 
-func TestPublishResourcesDoesNotInitializeGroupedLookupMaps(t *testing.T) {
-	logger := testr.New(t)
-
+func TestPublishResourcesGroupedModeInitializesLookupMaps(t *testing.T) {
 	testCases := []struct {
 		name             string
 		cpuDeviceGroupBy string
@@ -468,27 +466,30 @@ func TestPublishResourcesDoesNotInitializeGroupedLookupMaps(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockPlugin := &mockKubeletPlugin{}
-			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT}
-			topo, err := mockProvider.GetCPUTopology(logger)
-			require.NoError(t, err)
-
-			cp := &CPUDriver{
-				nodeName:               testNodeName,
-				draPlugin:              mockPlugin,
-				deviceNameToSocketID:   make(map[string]int),
-				deviceNameToNUMANodeID: make(map[string]int),
-				cpuTopology:            topo,
-				cpuDeviceMode:          CPU_DEVICE_MODE_GROUPED,
-				cpuDeviceGroupBy:       tc.cpuDeviceGroupBy,
-				reservedCPUs:           cpuset.New(),
-				pcieRootMapper:         store.NewPCIeRootMapper(),
+			prov := Providers{
+				CPUInfo: &cpuinfo.MockCPUInfoProvider{
+					CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
+				},
 			}
+			conf := Config{
+				DriverName:       testDriverName,
+				NodeName:         testNodeName,
+				CPUDeviceMode:    CPU_DEVICE_MODE_GROUPED,
+				CPUDeviceGroupBy: tc.cpuDeviceGroupBy,
+			}
+			cp, err := New(testr.New(t), prov, &conf)
+			require.NoError(t, err)
+			cp.draPlugin = mockPlugin
 
 			cp.PublishResources(context.Background())
 
 			require.NotNil(t, mockPlugin.publishedResources)
-			require.Empty(t, cp.deviceNameToSocketID)
-			require.Empty(t, cp.deviceNameToNUMANodeID)
+			switch tc.cpuDeviceGroupBy {
+			case GROUP_BY_SOCKET:
+				require.NotEmpty(t, cp.deviceNameToSocketID)
+			case GROUP_BY_NUMA_NODE:
+				require.NotEmpty(t, cp.deviceNameToNUMANodeID)
+			}
 		})
 	}
 }

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -19,8 +19,10 @@ package driver
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
@@ -43,6 +45,22 @@ const (
 	testNodeName   = "test-node"
 	testDriverName = "dra-driver-cpu.k8s.io"
 )
+
+// testSysFS enables full isolation and full mocking from the host filesystem.
+// It is not strictly speaking needed by the current tests, but it is added for better hygiene.
+func testSysFS(infos []cpuinfo.CPUInfo) fstest.MapFS {
+	cpuIDs := make([]int, 0, len(infos))
+	for _, info := range infos {
+		cpuIDs = append(cpuIDs, info.CpuID)
+	}
+	onlineRange := cpuset.New(cpuIDs...).String()
+	// this is coupled with what New() reads - online online CPUs for now
+	return fstest.MapFS{
+		filepath.Join("devices", "system", "cpu", "online"): &fstest.MapFile{
+			Data: []byte(onlineRange),
+		},
+	}
+}
 
 type mockKubeletPlugin struct {
 	publishedResources *resourceslice.DriverResources
@@ -171,7 +189,6 @@ var (
 )
 
 func TestPublishResources(t *testing.T) {
-	logger := testr.New(t)
 	testCases := []struct {
 		name                       string
 		config                     Config
@@ -310,17 +327,26 @@ func TestPublishResources(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockPlugin := &mockKubeletPlugin{publishError: tc.publishError}
-			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: tc.cpuInfos, Err: tc.cpuInfoErr}
-			topo, _ := mockProvider.GetCPUTopology(logger)
-			cp := &CPUDriver{
-				nodeName:                testNodeName,
-				draPlugin:               mockPlugin,
-				deviceNameToCPUID:       make(map[string]int),
-				cpuTopology:             topo,
-				reservedCPUs:            tc.reservedCPUs,
-				pcieRootMapper:          store.NewPCIeRootMapper(),
-				devicesPerResourceSlice: tc.config.DevicesPerResourceSlice(),
+			prov := Providers{
+				CPUInfo: &cpuinfo.MockCPUInfoProvider{
+					CPUInfos: tc.cpuInfos,
+					Err:      tc.cpuInfoErr,
+				},
+				SysFS: testSysFS(tc.cpuInfos),
 			}
+			conf := Config{
+				DriverName:      testDriverName,
+				NodeName:        testNodeName,
+				ReservedCPUs:    tc.reservedCPUs,
+				ExposePCIeRoots: tc.config.ExposePCIeRoots,
+			}
+			cp, err := New(testr.New(t), prov, &conf)
+			if tc.cpuInfoErr != nil {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			cp.draPlugin = mockPlugin
 
 			cp.PublishResources(context.Background())
 
@@ -353,7 +379,7 @@ func TestPublishResources(t *testing.T) {
 				totalDevices += len(s.Devices)
 			}
 			require.Equal(t, tc.expectedDevices, totalDevices)
-			require.Empty(t, cp.deviceNameToCPUID)
+			require.Len(t, cp.deviceNameToCPUID, tc.expectedDevices)
 
 			// Verify device attributes
 			cpuInfosMap := make(map[int]cpuinfo.CPUInfo)
@@ -422,78 +448,6 @@ func TestPublishResources(t *testing.T) {
 	}
 }
 
-func TestInitializeDeviceLookupMaps(t *testing.T) {
-	logger := testr.New(t)
-
-	testCases := []struct {
-		name                       string
-		cpuDeviceMode              string
-		cpuDeviceGroupBy           string
-		cpuInfos                   []cpuinfo.CPUInfo
-		reservedCPUs               cpuset.CPUSet
-		expectedDeviceNameToCPUID  map[string]int
-		expectedDeviceNameToSocket map[string]int
-		expectedDeviceNameToNUMA   map[string]int
-	}{
-		{
-			name:          "individual mode",
-			cpuDeviceMode: CPU_DEVICE_MODE_INDIVIDUAL,
-			cpuInfos:      mockCPUInfos_SingleSocket_4CPUS_HT,
-			reservedCPUs:  cpuset.New(1),
-			expectedDeviceNameToCPUID: map[string]int{
-				"cpudev000": 0,
-				"cpudev001": 2,
-				"cpudev002": 3,
-			},
-		},
-		{
-			name:                       "grouped by socket",
-			cpuDeviceMode:              CPU_DEVICE_MODE_GROUPED,
-			cpuDeviceGroupBy:           GROUP_BY_SOCKET,
-			cpuInfos:                   mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
-			reservedCPUs:               cpuset.New(0, 1, 4, 5),
-			expectedDeviceNameToSocket: map[string]int{"cpudevsocket001": 1},
-		},
-		{
-			name:                     "grouped by numa node",
-			cpuDeviceMode:            CPU_DEVICE_MODE_GROUPED,
-			cpuDeviceGroupBy:         GROUP_BY_NUMA_NODE,
-			cpuInfos:                 mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
-			reservedCPUs:             cpuset.New(2, 3, 6, 7),
-			expectedDeviceNameToNUMA: map[string]int{"cpudevnuma000": 0},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: tc.cpuInfos}
-			topo, err := mockProvider.GetCPUTopology(logger)
-			require.NoError(t, err)
-
-			cp := &CPUDriver{
-				cpuTopology:      topo,
-				reservedCPUs:     tc.reservedCPUs,
-				cpuDeviceMode:    tc.cpuDeviceMode,
-				cpuDeviceGroupBy: tc.cpuDeviceGroupBy,
-			}
-			cp.initializeDeviceLookupMaps()
-
-			if tc.expectedDeviceNameToCPUID == nil {
-				tc.expectedDeviceNameToCPUID = map[string]int{}
-			}
-			if tc.expectedDeviceNameToSocket == nil {
-				tc.expectedDeviceNameToSocket = map[string]int{}
-			}
-			if tc.expectedDeviceNameToNUMA == nil {
-				tc.expectedDeviceNameToNUMA = map[string]int{}
-			}
-			require.Equal(t, tc.expectedDeviceNameToCPUID, cp.deviceNameToCPUID)
-			require.Equal(t, tc.expectedDeviceNameToSocket, cp.deviceNameToSocketID)
-			require.Equal(t, tc.expectedDeviceNameToNUMA, cp.deviceNameToNUMANodeID)
-		})
-	}
-}
-
 func TestPublishResourcesDoesNotInitializeGroupedLookupMaps(t *testing.T) {
 	logger := testr.New(t)
 
@@ -540,7 +494,6 @@ func TestPublishResourcesDoesNotInitializeGroupedLookupMaps(t *testing.T) {
 }
 
 func TestPrepareResourceClaimsSucceedsBeforePublishResources(t *testing.T) {
-	logger := testr.New(t)
 	claimUID := types.UID("claim-prepare-before-publish")
 
 	testCases := []struct {
@@ -573,48 +526,52 @@ func TestPrepareResourceClaimsSucceedsBeforePublishResources(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT}
-			topo, err := mockProvider.GetCPUTopology(logger)
+			prov := Providers{
+				CPUInfo: &cpuinfo.MockCPUInfoProvider{
+					CPUInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
+				},
+				SysFS: testSysFS(mockCPUInfos_DualSocket_4CPUsPerSocket_HT),
+			}
+			conf := Config{
+				DriverName:       testDriverName,
+				NodeName:         testNodeName,
+				CPUDeviceMode:    tc.cpuDeviceMode,
+				CPUDeviceGroupBy: tc.cpuDeviceGroupBy,
+			}
+			driver, err := New(testr.New(t), prov, &conf)
 			require.NoError(t, err)
 
-			cpuStore := store.NewCPUAllocation(topo, cpuset.New())
-
-			driver := &CPUDriver{
-				driverName:         testDriverName,
-				cpuTopology:        topo,
-				cpuAllocationStore: cpuStore,
-				cdiMgr:             newMockCdiMgr(),
-				cpuDeviceMode:      tc.cpuDeviceMode,
-				cpuDeviceGroupBy:   tc.cpuDeviceGroupBy,
-				reservedCPUs:       cpuset.New(),
-			}
-			driver.initializeDeviceLookupMaps()
+			mockCdiMgr := newMockCdiMgr()
+			driver.cdiMgr = mockCdiMgr
 
 			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.claim})
 			require.NoError(t, err)
 			require.NoError(t, preparedClaims[claimUID].Err)
 			require.NotEmpty(t, preparedClaims[claimUID].Devices)
-			require.Len(t, driver.cdiMgr.(*mockCdiMgr).devices, 1)
+			require.Len(t, mockCdiMgr.devices, 1)
 
-			_, ok := cpuStore.GetResourceClaimAllocation(claimUID)
+			_, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
 		})
 	}
 }
 
 func TestPrepareResourceClaims(t *testing.T) {
-	logger := testr.New(t)
-	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
-	topo, _ := mockProvider.GetCPUTopology(logger)
-	baseCPUDriver := func() *CPUDriver {
-		return &CPUDriver{
-			driverName: testDriverName,
-			deviceNameToCPUID: map[string]int{
-				"cpudev0": 0,
-				"cpudev1": 1,
+	baseCPUDriver := func(t *testing.T) *CPUDriver {
+		t.Helper()
+		prov := Providers{
+			CPUInfo: &cpuinfo.MockCPUInfoProvider{
+				CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT,
 			},
-			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+			SysFS: testSysFS(mockCPUInfos_DualSocket_4CPUsPerSocket_HT),
 		}
+		conf := Config{
+			DriverName: testDriverName,
+			NodeName:   testNodeName,
+		}
+		cp, err := New(testr.New(t), prov, &conf)
+		require.NoError(t, err)
+		return cp
 	}
 
 	claimUID := types.UID("claim-1")
@@ -623,7 +580,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 
 	testCases := []struct {
 		name                    string
-		driver                  *CPUDriver
+		setupDriver             func(t *testing.T) *CPUDriver
 		claims                  []*resourceapi.ResourceClaim
 		mockCdiAddError         error
 		expectedResultsCount    int
@@ -634,8 +591,8 @@ func TestPrepareResourceClaims(t *testing.T) {
 		expectedPreparedDevices []kubeletplugin.Device
 	}{
 		{
-			name:   "success",
-			driver: baseCPUDriver(),
+			name:        "success",
+			setupDriver: baseCPUDriver,
 			claims: []*resourceapi.ResourceClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{UID: claimUID, Name: "my-claim"},
@@ -643,8 +600,8 @@ func TestPrepareResourceClaims(t *testing.T) {
 						Allocation: &resourceapi.AllocationResult{
 							Devices: resourceapi.DeviceAllocationResult{
 								Results: []resourceapi.DeviceRequestAllocationResult{
-									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev0"},
-									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev1"},
+									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev000"},
+									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev002"},
 								},
 							},
 						},
@@ -656,19 +613,19 @@ func TestPrepareResourceClaims(t *testing.T) {
 			expectedCdiDevice:       cdiDeviceName,
 			expectedCdiEnvVar:       fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, "0-1"),
 			expectedPreparedDevices: []kubeletplugin.Device{
-				{PoolName: testNodeName, DeviceName: "cpudev0", CDIDeviceIDs: []string{cdiQualifiedName}},
-				{PoolName: testNodeName, DeviceName: "cpudev1", CDIDeviceIDs: []string{cdiQualifiedName}},
+				{PoolName: testNodeName, DeviceName: "cpudev000", CDIDeviceIDs: []string{cdiQualifiedName}},
+				{PoolName: testNodeName, DeviceName: "cpudev002", CDIDeviceIDs: []string{cdiQualifiedName}},
 			},
 		},
 		{
 			name:                 "no claims",
-			driver:               baseCPUDriver(),
+			setupDriver:          baseCPUDriver,
 			claims:               []*resourceapi.ResourceClaim{},
 			expectedResultsCount: 0,
 		},
 		{
-			name:   "claim with no allocation",
-			driver: baseCPUDriver(),
+			name:        "claim with no allocation",
+			setupDriver: baseCPUDriver,
 			claims: []*resourceapi.ResourceClaim{
 				{ObjectMeta: metav1.ObjectMeta{UID: "claim-no-alloc"}},
 			},
@@ -676,8 +633,8 @@ func TestPrepareResourceClaims(t *testing.T) {
 			expectedError:        true,
 		},
 		{
-			name:   "claim with device from other driver",
-			driver: baseCPUDriver(),
+			name:        "claim with device from other driver",
+			setupDriver: baseCPUDriver,
 			claims: []*resourceapi.ResourceClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{UID: "claim-other-driver"},
@@ -697,8 +654,8 @@ func TestPrepareResourceClaims(t *testing.T) {
 			expectedPreparedDevices: nil,
 		},
 		{
-			name:   "error - device not found",
-			driver: baseCPUDriver(),
+			name:        "error - device not found",
+			setupDriver: baseCPUDriver,
 			claims: []*resourceapi.ResourceClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{UID: "claim-dev-not-found"},
@@ -718,7 +675,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 		},
 		{
 			name:            "error - cdi add fails",
-			driver:          baseCPUDriver(),
+			setupDriver:     baseCPUDriver,
 			mockCdiAddError: fmt.Errorf("cdi add error"),
 			claims: []*resourceapi.ResourceClaim{
 				{
@@ -727,7 +684,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 						Allocation: &resourceapi.AllocationResult{
 							Devices: resourceapi.DeviceAllocationResult{
 								Results: []resourceapi.DeviceRequestAllocationResult{
-									{Driver: testDriverName, Device: "cpudev0"},
+									{Driver: testDriverName, Device: "cpudev000"},
 								},
 							},
 						},
@@ -738,8 +695,8 @@ func TestPrepareResourceClaims(t *testing.T) {
 			expectedError:        true,
 		},
 		{
-			name:   "multi-driver claim - only our devices in preparedDevices",
-			driver: baseCPUDriver(),
+			name:        "multi-driver claim - only our devices in preparedDevices",
+			setupDriver: baseCPUDriver,
 			claims: []*resourceapi.ResourceClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{UID: claimUID, Name: "my-claim"},
@@ -747,7 +704,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 						Allocation: &resourceapi.AllocationResult{
 							Devices: resourceapi.DeviceAllocationResult{
 								Results: []resourceapi.DeviceRequestAllocationResult{
-									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev0"},
+									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev000"},
 									{Driver: "other-driver", Pool: testNodeName, Device: "other-device"},
 								},
 							},
@@ -759,19 +716,18 @@ func TestPrepareResourceClaims(t *testing.T) {
 			expectedCdiDevicesCount: 1,
 			expectedCdiDevice:       cdiDeviceName,
 			expectedCdiEnvVar:       fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, "0"),
-			// only our driver's device should appear in preparedDevices
 			expectedPreparedDevices: []kubeletplugin.Device{
-				{PoolName: testNodeName, DeviceName: "cpudev0", CDIDeviceIDs: []string{cdiQualifiedName}},
+				{PoolName: testNodeName, DeviceName: "cpudev000", CDIDeviceIDs: []string{cdiQualifiedName}},
 			},
 		},
 		{
 			name: "error - overlapping device assignment",
-			driver: func() *CPUDriver {
-				d := baseCPUDriver()
-				// Pre-allocate cpudev0 to an existing claim
-				d.cpuAllocationStore.AddResourceClaimAllocation(logger, "claim0", cpuset.New(0))
+			setupDriver: func(t *testing.T) *CPUDriver {
+				t.Helper()
+				d := baseCPUDriver(t)
+				d.cpuAllocationStore.AddResourceClaimAllocation(testr.New(t), "claim0", cpuset.New(0))
 				return d
-			}(),
+			},
 			claims: []*resourceapi.ResourceClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{UID: "claim1", Name: "claim1", Namespace: "default"},
@@ -779,7 +735,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 						Allocation: &resourceapi.AllocationResult{
 							Devices: resourceapi.DeviceAllocationResult{
 								Results: []resourceapi.DeviceRequestAllocationResult{
-									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev0"},
+									{Driver: testDriverName, Pool: testNodeName, Device: "cpudev000"},
 								},
 							},
 						},
@@ -793,11 +749,14 @@ func TestPrepareResourceClaims(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			driver := tc.setupDriver(t)
 			mockCdiMgr := newMockCdiMgr()
 			mockCdiMgr.addError = tc.mockCdiAddError
-			tc.driver.cdiMgr = mockCdiMgr
+			// cdiMgr is created in Start(), which does filesystem I/O.
+			// Inject a mock here because we test New()-only paths.
+			driver.cdiMgr = mockCdiMgr
 
-			preparedClaims, err := tc.driver.PrepareResourceClaims(context.Background(), tc.claims)
+			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), tc.claims)
 			require.NoError(t, err)
 			require.Len(t, preparedClaims, tc.expectedResultsCount)
 
@@ -943,35 +902,25 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 }
 
 func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
-	logger := testr.New(t)
-
-	baseCPUDriver := func(groupBy string, cpuInfos []cpuinfo.CPUInfo, initialAllocations map[types.UID]cpuset.CPUSet, reservedCPUs cpuset.CPUSet) *CPUDriver {
-		driver := &CPUDriver{}
-		driver.driverName = testDriverName
-		driver.cpuDeviceMode = CPU_DEVICE_MODE_GROUPED
-		driver.cpuDeviceGroupBy = groupBy
-		driver.deviceNameToSocketID = make(map[string]int)
-		driver.deviceNameToNUMANodeID = make(map[string]int)
-		mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: cpuInfos}
-		driver.cpuTopology, _ = mockProvider.GetCPUTopology(logger)
-		driver.onlineCPUs = driver.cpuTopology.CPUDetails.CPUs()
-		driver.cpuAllocationStore = store.NewCPUAllocation(driver.cpuTopology, reservedCPUs)
-		for claimUID, cpus := range initialAllocations {
-			driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, cpus)
+	baseCPUDriver := func(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPUInfo, initialAllocations map[types.UID]cpuset.CPUSet, reservedCPUs cpuset.CPUSet) *CPUDriver {
+		t.Helper()
+		prov := Providers{
+			CPUInfo: &cpuinfo.MockCPUInfoProvider{
+				CPUInfos: cpuInfos,
+			},
+			SysFS: testSysFS(cpuInfos),
 		}
-
-		topo, err := mockProvider.GetCPUTopology(logger)
-		require.NoError(t, err) // We don't expect errors in test setup
-
-		switch driver.cpuDeviceGroupBy {
-		case GROUP_BY_SOCKET:
-			for i := 0; i < topo.NumSockets; i++ {
-				driver.deviceNameToSocketID[fmt.Sprintf("%s%d", cpuDeviceSocketGroupedPrefix, i)] = i
-			}
-		case GROUP_BY_NUMA_NODE:
-			for i := 0; i < topo.NumNUMANodes; i++ {
-				driver.deviceNameToNUMANodeID[fmt.Sprintf("%snuma%d", cpuDevicePrefix, i)] = i
-			}
+		conf := Config{
+			DriverName:       testDriverName,
+			NodeName:         testNodeName,
+			CPUDeviceMode:    CPU_DEVICE_MODE_GROUPED,
+			CPUDeviceGroupBy: groupBy,
+			ReservedCPUs:     reservedCPUs,
+		}
+		driver, err := New(testr.New(t), prov, &conf)
+		require.NoError(t, err)
+		for claimUID, cpus := range initialAllocations {
+			driver.cpuAllocationStore.AddResourceClaimAllocation(testr.New(t), claimUID, cpus)
 		}
 		return driver
 	}
@@ -996,7 +945,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			name:     "SocketGrouped_TopoSingleSocketHT_Alloc2CPU",
 			cpuInfos: mockCPUInfos_SingleSocket_4CPUS_HT,
 			groupBy:  GROUP_BY_SOCKET,
-			claims:   []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2})},
+			claims:   []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 2})},
 			// 2 hyperthreads from the same core is allocated
 			expectedCPUSet: cpuset.New(0, 2),
 		},
@@ -1004,7 +953,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			name:     "NUMAGrouped_TopoSingleSocketHT_Alloc2CPU",
 			cpuInfos: mockCPUInfos_SingleSocket_4CPUS_HT,
 			groupBy:  GROUP_BY_NUMA_NODE,
-			claims:   []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2})},
+			claims:   []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma000": 2})},
 			// 2 hyperthreads from the same core is allocated
 			expectedCPUSet: cpuset.New(0, 2),
 		},
@@ -1012,7 +961,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			name:     "SocketGrouped_DualSocketHT_Alloc4CPU",
 			cpuInfos: mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:  GROUP_BY_SOCKET,
-			claims:   []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 4})},
+			claims:   []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 4})},
 			// hyperthreads from the same core is allocated
 			expectedCPUSet: cpuset.New(0, 4, 1, 5),
 		},
@@ -1020,7 +969,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			name:           "NUMAGrouped_DualSocketHT_Alloc4CPUFromNUMANode1",
 			cpuInfos:       mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:        GROUP_BY_NUMA_NODE,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma1": 4})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma001": 4})},
 			expectedCPUSet: cpuset.New(2, 6, 3, 7),
 		},
 		{
@@ -1028,7 +977,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			cpuInfos:     mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:      GROUP_BY_SOCKET,
 			reservedCPUs: cpuset.New(0, 4),
-			claims:       []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2})},
+			claims:       []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 2})},
 			// prefer hyperthreads on same core over lower numbered CPUs
 			expectedCPUSet: cpuset.New(1, 5),
 		},
@@ -1037,7 +986,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			cpuInfos:     mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:      GROUP_BY_NUMA_NODE,
 			reservedCPUs: cpuset.New(2, 6),
-			claims:       []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma1": 2})},
+			claims:       []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma001": 2})},
 			// prefer hyperthreads on same core over lower numbered CPUs
 			expectedCPUSet: cpuset.New(3, 7),
 			expectedError:  false,
@@ -1046,28 +995,28 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			name:          "SocketGrouped_DualSocketHT_DeviceNotFound_Socket",
 			cpuInfos:      mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:       GROUP_BY_SOCKET,
-			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket99": 2})},
+			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket099": 2})},
 			expectedError: true,
 		},
 		{
 			name:          "NUMAGrouped_DualSocketHT_DeviceNotFound_NUMA",
 			cpuInfos:      mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:       GROUP_BY_NUMA_NODE,
-			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma99": 2})},
+			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma099": 2})},
 			expectedError: true,
 		},
 		{
 			name:           "SocketGrouped_DualSocketHT_MultiSocketRequest",
 			cpuInfos:       mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:        GROUP_BY_SOCKET,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2, "cpudevsocket1": 2})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 2, "cpudevsocket001": 2})},
 			expectedCPUSet: cpuset.New(0, 2, 4, 6),
 		},
 		{
 			name:           "NUMAGrouped_DualSocketHT_MultiNumaRequest",
 			cpuInfos:       mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:        GROUP_BY_NUMA_NODE,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2, "cpudevnuma1": 2})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma000": 2, "cpudevnuma001": 2})},
 			expectedCPUSet: cpuset.New(0, 2, 4, 6),
 		},
 		{
@@ -1079,14 +1028,14 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 					{
 						Driver:           testDriverName,
 						Pool:             testNodeName,
-						Device:           "cpudevsocket0",
+						Device:           "cpudevsocket000",
 						Request:          "req-0",
 						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
 					},
 					{
 						Driver:           testDriverName,
 						Pool:             testNodeName,
-						Device:           "cpudevsocket0",
+						Device:           "cpudevsocket000",
 						Request:          "req-1",
 						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
 					},
@@ -1104,14 +1053,14 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 					{
 						Driver:           testDriverName,
 						Pool:             testNodeName,
-						Device:           "cpudevnuma0",
+						Device:           "cpudevnuma000",
 						Request:          "req-0",
 						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
 					},
 					{
 						Driver:           testDriverName,
 						Pool:             testNodeName,
-						Device:           "cpudevnuma0",
+						Device:           "cpudevnuma000",
 						Request:          "req-1",
 						ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{cpuResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
 					},
@@ -1125,35 +1074,35 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			cpuInfos:           mockCPUInfos_SingleSocket_4CPUS_HT,
 			groupBy:            GROUP_BY_SOCKET,
 			initialAllocations: map[types.UID]cpuset.CPUSet{"other-claim": cpuset.New(0, 2)},
-			claims:             []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2})},
+			claims:             []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 2})},
 			expectedCPUSet:     cpuset.New(1, 3),
 		},
 		{
 			name:           "SocketGrouped_SingleSocketHT_AllocAllCPU",
 			cpuInfos:       mockCPUInfos_SingleSocket_4CPUS_HT,
 			groupBy:        GROUP_BY_SOCKET,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 4})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 4})},
 			expectedCPUSet: cpuset.New(0, 1, 2, 3),
 		},
 		{
 			name:           "NUMAGrouped_DualSocketHT_AllocAllCPU_NUMA0",
 			cpuInfos:       mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:        GROUP_BY_NUMA_NODE,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 4})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma000": 4})},
 			expectedCPUSet: cpuset.New(0, 1, 4, 5),
 		},
 		{
 			name:          "SocketGrouped_DualSocketHT_MoreThanAvailable",
 			cpuInfos:      mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:       GROUP_BY_SOCKET,
-			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 5})},
+			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 5})},
 			expectedError: true,
 		},
 		{
 			name:            "SocketGrouped_DualSocketHT_CDIError",
 			cpuInfos:        mockCPUInfos_DualSocket_4CPUsPerSocket_HT,
 			groupBy:         GROUP_BY_SOCKET,
-			claims:          []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2})},
+			claims:          []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 2})},
 			mockCdiAddError: fmt.Errorf("cdi error"),
 			expectedError:   true,
 		},
@@ -1161,28 +1110,28 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 			name:           "SocketGrouped_TopoSingleSocketHT_Off_Alloc2CPU",
 			cpuInfos:       mockCPUInfos_SingleSocket_4CPUs_HT_Off,
 			groupBy:        GROUP_BY_SOCKET,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 2})},
 			expectedCPUSet: cpuset.New(0, 1),
 		},
 		{
 			name:           "NUMAGrouped_TopoSingleSocketHT_Off_Alloc2CPU",
 			cpuInfos:       mockCPUInfos_SingleSocket_4CPUs_HT_Off,
 			groupBy:        GROUP_BY_NUMA_NODE,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma000": 2})},
 			expectedCPUSet: cpuset.New(0, 1),
 		},
 		{
 			name:           "SocketGrouped_TopoSingleSocketHT_Off_AllocAllCPU",
 			cpuInfos:       mockCPUInfos_SingleSocket_4CPUs_HT_Off,
 			groupBy:        GROUP_BY_SOCKET,
-			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 4})},
+			claims:         []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 4})},
 			expectedCPUSet: cpuset.New(0, 1, 2, 3),
 		},
 		{
 			name:          "SocketGrouped_TopoSingleSocketHT_Off_MoreThanAvailable",
 			cpuInfos:      mockCPUInfos_SingleSocket_4CPUs_HT_Off,
 			groupBy:       GROUP_BY_SOCKET,
-			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 5})},
+			claims:        []*resourceapi.ResourceClaim{testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 5})},
 			expectedError: true,
 		},
 		{
@@ -1218,9 +1167,11 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			driver := baseCPUDriver(tc.groupBy, tc.cpuInfos, tc.initialAllocations, tc.reservedCPUs)
+			driver := baseCPUDriver(t, tc.groupBy, tc.cpuInfos, tc.initialAllocations, tc.reservedCPUs)
 			mockCdiMgr := newMockCdiMgr()
 			mockCdiMgr.addError = tc.mockCdiAddError
+			// cdiMgr is created in Start(), which does filesystem I/O.
+			// Inject a mock here because we test New()-only paths.
 			driver.cdiMgr = mockCdiMgr
 
 			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), tc.claims)
@@ -1280,7 +1231,6 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 }
 
 func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
-	logger := testr.New(t)
 	claimUID := types.UID("claim-1")
 	cdiDeviceName := getCDIDeviceName(claimUID)
 
@@ -1294,16 +1244,16 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 	}{
 		{
 			name:           "individual mode - same devices repeated",
-			firstDevices:   []string{"cpudev0", "cpudev1"},
-			secondDevices:  []string{"cpudev0", "cpudev1"},
+			firstDevices:   []string{"cpudev000", "cpudev002"},
+			secondDevices:  []string{"cpudev000", "cpudev002"},
 			expectedCPUSet: cpuset.New(0, 1),
 			expectedShared: cpuset.New(2, 3),
 			expectError:    false,
 		},
 		{
 			name:           "individual mode - different devices repeated",
-			firstDevices:   []string{"cpudev0", "cpudev1"},
-			secondDevices:  []string{"cpudev2", "cpudev3"},
+			firstDevices:   []string{"cpudev000", "cpudev002"},
+			secondDevices:  []string{"cpudev001", "cpudev003"},
 			expectedCPUSet: cpuset.New(0, 1),
 			expectedShared: cpuset.New(2, 3),
 			expectError:    true,
@@ -1312,21 +1262,20 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
-			topo, _ := mockProvider.GetCPUTopology(logger)
-			cpuStore := store.NewCPUAllocation(topo, cpuset.New())
-			cdiMgr := newMockCdiMgr()
-			driver := &CPUDriver{
-				driverName: testDriverName,
-				deviceNameToCPUID: map[string]int{
-					"cpudev0": 0,
-					"cpudev1": 1,
-					"cpudev2": 2,
-					"cpudev3": 3,
+			mockCdiMgr := newMockCdiMgr()
+			prov := Providers{
+				CPUInfo: &cpuinfo.MockCPUInfoProvider{
+					CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT,
 				},
-				cpuAllocationStore: cpuStore,
-				cdiMgr:             cdiMgr,
+				SysFS: testSysFS(mockCPUInfos_DualSocket_4CPUsPerSocket_HT),
 			}
+			conf := Config{
+				DriverName: testDriverName,
+				NodeName:   testNodeName,
+			}
+			driver, err := New(testr.New(t), prov, &conf)
+			require.NoError(t, err)
+			driver.cdiMgr = mockCdiMgr
 
 			makeClaim := func(devices []string) []*resourceapi.ResourceClaim {
 				results := make([]resourceapi.DeviceRequestAllocationResult, len(devices))
@@ -1345,7 +1294,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 				}
 			}
 
-			_, err := driver.PrepareResourceClaims(context.Background(), makeClaim(tc.firstDevices))
+			_, err = driver.PrepareResourceClaims(context.Background(), makeClaim(tc.firstDevices))
 			require.NoError(t, err)
 
 			prepareResults, err := driver.PrepareResourceClaims(context.Background(), makeClaim(tc.secondDevices))
@@ -1359,12 +1308,12 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 			} else {
 				require.NoError(t, claimResult.Err)
 
-				gotCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
+				gotCPUs, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
 				require.True(t, ok)
 				require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
-				require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
+				require.True(t, tc.expectedShared.Equals(driver.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s, want %s", driver.cpuAllocationStore.GetSharedCPUs(), tc.expectedShared)
 
-				envVar := cdiMgr.devices[cdiDeviceName]
+				envVar := mockCdiMgr.devices[cdiDeviceName]
 				parts := strings.SplitN(envVar, "=", 2)
 				require.Len(t, parts, 2)
 				actualCPUSet, err := cpuset.Parse(parts[1])
@@ -1491,7 +1440,6 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 }
 
 func TestUnprepareResourceClaims(t *testing.T) {
-	logger := testr.New(t)
 	claimUID := types.UID("test-claim-uid")
 
 	testCases := []struct {
@@ -1522,14 +1470,23 @@ func TestUnprepareResourceClaims(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			prov := Providers{
+				CPUInfo: &cpuinfo.MockCPUInfoProvider{
+					CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT,
+				},
+				SysFS: testSysFS(mockCPUInfos_SingleSocket_4CPUS_HT),
+			}
+			conf := Config{
+				DriverName: testDriverName,
+				NodeName:   testNodeName,
+			}
+			cp, err := New(testr.New(t), prov, &conf)
+			require.NoError(t, err)
 			mockCdiMgr := newMockCdiMgr()
 			mockCdiMgr.removeError = tc.cdiRemoveError
-			mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
-			topo, _ := mockProvider.GetCPUTopology(logger)
-			cp := &CPUDriver{
-				cdiMgr:             mockCdiMgr,
-				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
-			}
+			// cdiMgr is created in Start(), which does filesystem I/O.
+			// Inject a mock here because we test New()-only paths.
+			cp.cdiMgr = mockCdiMgr
 
 			unpreparedClaims, err := cp.UnprepareResourceClaims(context.Background(), tc.claims)
 			require.NoError(t, err)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -94,6 +94,7 @@ type CPUDriver struct {
 	deviceNameToCPUID       map[string]int
 	deviceNameToSocketID    map[string]int
 	deviceNameToNUMANodeID  map[string]int
+	deviceSlices            [][]resourceapi.Device
 	reservedCPUs            cpuset.CPUSet
 	onlineCPUs              cpuset.CPUSet
 	cpuDeviceMode           string
@@ -189,6 +190,12 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 	plugin.cpuAllocationStore = store.NewCPUAllocation(plugin.cpuTopology, config.ReservedCPUs)
 	plugin.podConfigStore = store.NewPodConfig()
 	plugin.initializeDeviceLookupMaps()
+
+	if plugin.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
+		plugin.deviceSlices = plugin.createGroupedCPUDeviceSlices(logger)
+	} else {
+		plugin.deviceSlices = plugin.createCPUDeviceSlices()
+	}
 
 	return plugin, nil
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -194,14 +194,20 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 
 	if plugin.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
 		plugin.groupedDeviceInfos = plugin.groupedCPUDeviceInfos()
-	} else {
-		plugin.individualDeviceInfos = plugin.cpuDeviceInfos()
-	}
-	plugin.initializeDeviceLookupMaps()
-
-	if plugin.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
+		for _, dev := range plugin.groupedDeviceInfos {
+			switch plugin.cpuDeviceGroupBy {
+			case GROUP_BY_SOCKET:
+				plugin.deviceNameToSocketID[dev.name] = dev.socketID
+			case GROUP_BY_NUMA_NODE:
+				plugin.deviceNameToNUMANodeID[dev.name] = dev.numaNodeID
+			}
+		}
 		plugin.deviceSlices = plugin.createGroupedCPUDeviceSlices(logger)
 	} else {
+		plugin.individualDeviceInfos = plugin.cpuDeviceInfos()
+		for _, dev := range plugin.individualDeviceInfos {
+			plugin.deviceNameToCPUID[dev.name] = dev.cpu.CpuID
+		}
 		plugin.deviceSlices = plugin.createCPUDeviceSlices()
 	}
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -94,6 +94,8 @@ type CPUDriver struct {
 	deviceNameToCPUID       map[string]int
 	deviceNameToSocketID    map[string]int
 	deviceNameToNUMANodeID  map[string]int
+	individualDeviceInfos   []cpuDeviceInfo
+	groupedDeviceInfos      []groupedCPUDeviceInfo
 	deviceSlices            [][]resourceapi.Device
 	reservedCPUs            cpuset.CPUSet
 	onlineCPUs              cpuset.CPUSet
@@ -189,6 +191,12 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 
 	plugin.cpuAllocationStore = store.NewCPUAllocation(plugin.cpuTopology, config.ReservedCPUs)
 	plugin.podConfigStore = store.NewPodConfig()
+
+	if plugin.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {
+		plugin.groupedDeviceInfos = plugin.groupedCPUDeviceInfos()
+	} else {
+		plugin.individualDeviceInfos = plugin.cpuDeviceInfos()
+	}
 	plugin.initializeDeviceLookupMaps()
 
 	if plugin.cpuDeviceMode == CPU_DEVICE_MODE_GROUPED {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -103,6 +103,27 @@ type CPUDriver struct {
 	devicesPerResourceSlice int
 }
 
+// Providers group the interfaces the CPUDriver depends on
+type Providers struct {
+	CPUInfo   CPUInfoProvider
+	SysFS     device.SysFS
+	K8SClient kubernetes.Interface
+}
+
+func (pr Providers) EnsureCPUInfo() CPUInfoProvider {
+	if pr.CPUInfo == nil {
+		return cpuinfo.NewSystemCPUInfo()
+	}
+	return pr.CPUInfo
+}
+
+func (pr Providers) EnsureSysFS() device.SysFS {
+	if pr.SysFS == nil {
+		return os.DirFS(device.SysfsRoot).(device.SysFS)
+	}
+	return pr.SysFS
+}
+
 // Config is the configuration for the CPUDriver.
 type Config struct {
 	DriverName       string
@@ -122,16 +143,15 @@ func (cfg Config) DevicesPerResourceSlice() int {
 	return resourceapi.ResourceSliceMaxDevices
 }
 
-// Start creates and starts a new CPUDriver.
-func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) (*CPUDriver, <-chan error, error) {
-	var logger logr.Logger
-	ctx, logger = ctxlog.WithValues(ctx, "driver", config.DriverName)
+// New creates and initializes a CPUDriver, preparing all internal state.
+// No external listeners or goroutines are started; call Start to begin serving.
+func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, error) {
+	logger = logger.WithValues("driver", config.DriverName)
 
-	asyncErr := make(chan error, 1)
 	plugin := &CPUDriver{
 		driverName:              config.DriverName,
 		nodeName:                config.NodeName,
-		kubeClient:              clientset,
+		kubeClient:              providers.K8SClient,
 		deviceNameToCPUID:       make(map[string]int),
 		deviceNameToSocketID:    make(map[string]int),
 		deviceNameToNUMANodeID:  make(map[string]int),
@@ -142,28 +162,27 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		pcieRootMapper:          store.NewPCIeRootMapper(),
 		devicesPerResourceSlice: config.DevicesPerResourceSlice(),
 	}
-	sysfs := os.DirFS(device.SysfsRoot).(device.SysFS)
+	sysfs := providers.EnsureSysFS()
 
 	onlineCPUs, err := cpuinfo.OnlineCPUs(logger, sysfs)
 	if err != nil {
-		return nil, asyncErr, fmt.Errorf("failed to get online CPUs: %w", err)
+		return nil, fmt.Errorf("failed to get online CPUs: %w", err)
 	}
 	logger.V(2).Info("detected online CPUs", "cpus", onlineCPUs.String())
 	plugin.onlineCPUs = onlineCPUs
 
-	cpuInfoProvider := cpuinfo.NewSystemCPUInfo()
-	topo, err := cpuInfoProvider.GetCPUTopology(logger)
+	topo, err := providers.EnsureCPUInfo().GetCPUTopology(logger)
 	if err != nil {
-		return nil, asyncErr, fmt.Errorf("failed to get CPU topology: %w", err)
+		return nil, fmt.Errorf("failed to get CPU topology: %w", err)
 	}
 	if topo == nil {
-		return nil, asyncErr, fmt.Errorf("failed to get CPU topology: topology is nil")
+		return nil, fmt.Errorf("failed to get CPU topology: topology is nil")
 	}
 	plugin.cpuTopology = topo
 
 	if config.ExposePCIeRoots {
 		if err := plugin.pcieRootMapper.Probe(logger, sysfs, onlineCPUs); err != nil {
-			return nil, asyncErr, fmt.Errorf("failed to list PCIe domains: %w", err)
+			return nil, fmt.Errorf("failed to list PCIe domains: %w", err)
 		}
 	}
 
@@ -171,27 +190,37 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 	plugin.podConfigStore = store.NewPodConfig()
 	plugin.initializeDeviceLookupMaps()
 
-	driverPluginPath := filepath.Join(kubeletPluginPath, config.DriverName)
+	return plugin, nil
+}
+
+// Start registers the plugin with kubelet, starts the NRI plugin, and begins
+// async resource publication. Setup must have been called first.
+func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
+	_, logger := ctxlog.WithValues(ctx, "driver", cp.driverName)
+
+	asyncErr := make(chan error, 1)
+
+	driverPluginPath := filepath.Join(kubeletPluginPath, cp.driverName)
 	if err := os.MkdirAll(driverPluginPath, 0750); err != nil {
-		return nil, asyncErr, fmt.Errorf("failed to create plugin path %s: %w", driverPluginPath, err)
+		return asyncErr, fmt.Errorf("failed to create plugin path %s: %w", driverPluginPath, err)
 	}
 
-	cdiMgr, err := NewCdiManager(logger, config.DriverName, cdiSpecDir)
+	cdiMgr, err := NewCdiManager(logger, cp.driverName, cdiSpecDir)
 	if err != nil {
-		return nil, asyncErr, fmt.Errorf("failed to create CDI manager: %w", err)
+		return asyncErr, fmt.Errorf("failed to create CDI manager: %w", err)
 	}
-	plugin.cdiMgr = cdiMgr
+	cp.cdiMgr = cdiMgr
 
 	kubeletOpts := []kubeletplugin.Option{
-		kubeletplugin.DriverName(config.DriverName),
-		kubeletplugin.NodeName(config.NodeName),
-		kubeletplugin.KubeClient(clientset),
+		kubeletplugin.DriverName(cp.driverName),
+		kubeletplugin.NodeName(cp.nodeName),
+		kubeletplugin.KubeClient(cp.kubeClient),
 	}
-	d, err := kubeletplugin.Start(ctx, plugin, kubeletOpts...)
+	d, err := kubeletplugin.Start(ctx, cp, kubeletOpts...)
 	if err != nil {
-		return nil, asyncErr, fmt.Errorf("start kubelet plugin: %w", err)
+		return asyncErr, fmt.Errorf("start kubelet plugin: %w", err)
 	}
-	plugin.draPlugin = d
+	cp.draPlugin = d
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
 		status := d.RegistrationStatus()
 		if status == nil {
@@ -200,12 +229,12 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 		return status.PluginRegistered, nil
 	})
 	if err != nil {
-		return nil, asyncErr, err
+		return asyncErr, err
 	}
 
 	// register the NRI plugin
 	nriOpts := []stub.Option{
-		stub.WithPluginName(config.DriverName),
+		stub.WithPluginName(cp.driverName),
 		stub.WithPluginIdx("00"),
 		// https://github.com/containerd/nri/pull/173
 		// Otherwise it silently exits the program
@@ -213,23 +242,23 @@ func Start(ctx context.Context, clientset kubernetes.Interface, config *Config) 
 			logger.Info("NRI plugin closed")
 		}),
 	}
-	stub, err := stub.New(plugin, nriOpts...)
+	stub, err := stub.New(cp, nriOpts...)
 	if err != nil {
-		return nil, asyncErr, fmt.Errorf("failed to create plugin stub: %w", err)
+		return asyncErr, fmt.Errorf("failed to create plugin stub: %w", err)
 	}
-	plugin.nriPlugin = stub
+	cp.nriPlugin = stub
 
 	go func() {
-		if err := runNRIPluginWithRetry(ctx, plugin.nriPlugin, maxAttempts); err != nil && ctx.Err() == nil {
+		if err := runNRIPluginWithRetry(ctx, cp.nriPlugin, maxAttempts); err != nil && ctx.Err() == nil {
 			logger.Error(err, "NRI plugin failed to be restarted", "maxAttempts", maxAttempts)
 			asyncErr <- err
 		}
 	}()
 
 	// publish available resources
-	go plugin.PublishResources(ctx)
+	go cp.PublishResources(ctx)
 
-	return plugin, asyncErr, nil
+	return asyncErr, nil
 }
 
 // Stop stops the CPUDriver.


### PR DESCRIPTION
The overarching goal is to avoid entirely the class of issues like https://github.com/kubernetes-sigs/dra-driver-cpu/issues/168

The core idea: move all the data initialization in the newly-introduced `driver.New()`, moving there all the initialization previously scatthered in the flows (e.g. publish resources).
With this series applied, the idea is when New() ends, the driver data initialization is complete, and the
object is ready to be wired using Start(); after that, the driver is finally ready to serve.

This split unlocks some further cleanups and code moving, e.g. computing device data once vs every time needed - device data is functionally tied to the driver lifecycle anyway, we don't support hot(un)plug so actually recomputing opens the door to subtle bugs.

**Notes for the reviewers**

- due to the simple and code-movement-driven nature of this PR, LLM assistance was used. All the changes are human-driven and thoroughfully reviewed by humans prior to submission.
- I have followup PR in the pipeline to split the device enumeration responsability from the CPUDriver object. I'd like to push back against the gravitational pull of `CPUDriver` and prevent it to become a god object - the trend is already slowly starting.

Followup of #171 and #175
Fixes: #174 