### PR TITLE
feat: expose cpuset via env vars

### DIFF
--- a/pkg/driver/cdi.go
+++ b/pkg/driver/cdi.go
@@ -28,7 +28,9 @@ const (
 	cdiVendor       = "dra.k8s.io"
 	cdiClass        = "cpu"
 	cdiEnvVarPrefix = "DRA_CPUSET"
-	cdiSpecDir      = "/var/run/cdi"
+	// This mirrors the semantics of the assigned.cpuset introduced in k/k KEP #6122.
+	cdiEnvVarAssigned = "DRA_CPUSET_ASSIGNED"
+	cdiSpecDir        = "/var/run/cdi"
 )
 
 // CdiManager handles the lifecycle of CDI allocations for the driver.
@@ -66,7 +68,7 @@ func (c *CdiManager) getSpecName(deviceName string) string {
 }
 
 // AddDevice writes a dedicated CDI spec file for a single device allocation.
-func (c *CdiManager) AddDevice(logger logr.Logger, deviceName string, envVar string) error {
+func (c *CdiManager) AddDevice(logger logr.Logger, deviceName string, envVars []string) error {
 	specName := c.getSpecName(deviceName)
 
 	spec := &cdiSpec.Spec{
@@ -76,7 +78,7 @@ func (c *CdiManager) AddDevice(logger logr.Logger, deviceName string, envVar str
 			{
 				Name: deviceName,
 				ContainerEdits: cdiSpec.ContainerEdits{
-					Env: []string{envVar},
+					Env: envVars,
 				},
 			},
 		},
@@ -86,7 +88,7 @@ func (c *CdiManager) AddDevice(logger logr.Logger, deviceName string, envVar str
 		return fmt.Errorf("failed to write CDI spec %q: %w", specName, err)
 	}
 
-	logger.V(4).Info("Added CDI device", "deviceName", deviceName, "specName", specName, "env", envVar)
+	logger.V(4).Info("Added CDI device", "deviceName", deviceName, "specName", specName, "envVars", envVars)
 	return nil
 }
 

--- a/pkg/driver/cdi_test.go
+++ b/pkg/driver/cdi_test.go
@@ -81,7 +81,7 @@ func TestAddDevice(t *testing.T) {
 			expectedSpecName := mgr.getSpecName(tc.deviceName)
 			expectedFilePath := filepath.Join(tempCDIDir, expectedSpecName)
 
-			err = mgr.AddDevice(logger, tc.deviceName, tc.envVar)
+			err = mgr.AddDevice(logger, tc.deviceName, []string{tc.envVar})
 
 			if tc.expectedError != "" {
 				require.Error(t, err)
@@ -157,7 +157,7 @@ func TestRemoveDevice(t *testing.T) {
 			expectedFilePath := filepath.Join(tempCDIDir, expectedSpecName)
 
 			if !tc.simulateErr {
-				err = mgr.AddDevice(logger, tc.deviceName, tc.envVar)
+				err = mgr.AddDevice(logger, tc.deviceName, []string{tc.envVar})
 				require.NoError(t, err)
 			}
 
@@ -197,7 +197,7 @@ func TestAddDeviceOverwrite(t *testing.T) {
 		require.Len(t, files, expected)
 	}
 
-	err = mgr.AddDevice(logger, deviceName, "CPU=0,1")
+	err = mgr.AddDevice(logger, deviceName, []string{"CPU=0,1"})
 	require.NoError(t, err)
 	assertFileCount(1)
 
@@ -207,7 +207,7 @@ func TestAddDeviceOverwrite(t *testing.T) {
 	require.Equal(t, []string{"CPU=0,1"}, spec1.Devices[0].ContainerEdits.Env)
 
 	// Call AddDevice again with the same deviceName and same data
-	err = mgr.AddDevice(logger, deviceName, "CPU=0,1")
+	err = mgr.AddDevice(logger, deviceName, []string{"CPU=0,1"})
 	require.NoError(t, err)
 	// Verify that we do not create a new file
 	assertFileCount(1)

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -512,13 +512,14 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 
 func (cp *CPUDriver) prepareDevices(logger logr.Logger, claim *resourceapi.ResourceClaim, claimCPUSet cpuset.CPUSet) kubeletplugin.PrepareResult {
 	deviceName := getCDIDeviceName(claim.UID)
-	envVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, claimCPUSet.String())
-	if err := cp.cdiMgr.AddDevice(logger, deviceName, envVar); err != nil {
+	perClaimEnvVar := fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claim.UID, claimCPUSet.String())
+	aggregateEnvVar := fmt.Sprintf("%s=%s", cdiEnvVarAssigned, claimCPUSet.String())
+	if err := cp.cdiMgr.AddDevice(logger, deviceName, []string{perClaimEnvVar, aggregateEnvVar}); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
 	}
 
 	qualifiedName := cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName)
-	logger.V(6).Info("prepared CDI device", "cdiDeviceName", deviceName, "envVar", envVar, "qualifiedName", qualifiedName)
+	logger.V(6).Info("prepared CDI device", "cdiDeviceName", deviceName, "perClaimEnvVar", perClaimEnvVar, "aggregateEnvVar", aggregateEnvVar, "qualifiedName", qualifiedName)
 	preparedDevices := []kubeletplugin.Device{}
 	for _, allocResult := range claim.Status.Allocation.Devices.Results {
 		if allocResult.Driver != cp.driverName {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -60,22 +60,22 @@ func (m *mockKubeletPlugin) PublishResources(ctx context.Context, resources reso
 func (m *mockKubeletPlugin) Stop() {}
 
 type mockCdiMgr struct {
-	devices     map[string]string
+	devices     map[string][]string
 	addError    error
 	removeError error
 }
 
 func newMockCdiMgr() *mockCdiMgr {
 	return &mockCdiMgr{
-		devices: make(map[string]string),
+		devices: make(map[string][]string),
 	}
 }
 
-func (m *mockCdiMgr) AddDevice(_ logr.Logger, deviceName, envVar string) error {
+func (m *mockCdiMgr) AddDevice(_ logr.Logger, deviceName string, envVars []string) error {
 	if m.addError != nil {
 		return m.addError
 	}
-	m.devices[deviceName] = envVar
+	m.devices[deviceName] = envVars
 	return nil
 }
 
@@ -815,9 +815,9 @@ func TestPrepareResourceClaims(t *testing.T) {
 
 			require.Len(t, mockCdiMgr.devices, tc.expectedCdiDevicesCount)
 			if tc.expectedCdiDevice != "" {
-				envVar, ok := mockCdiMgr.devices[tc.expectedCdiDevice]
+				envVars, ok := mockCdiMgr.devices[tc.expectedCdiDevice]
 				require.True(t, ok, "expected CDI device not found")
-				require.Equal(t, tc.expectedCdiEnvVar, envVar)
+				require.Equal(t, tc.expectedCdiEnvVar, envVars[0])
 			}
 		})
 	}
@@ -1249,7 +1249,11 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 					}
 					require.ElementsMatch(t, expectedPreparedDevices, result.Devices)
 
-					envVar := mockCdiMgr.devices[cdiDeviceName]
+					envVars := mockCdiMgr.devices[cdiDeviceName]
+					var envVar string
+					if len(envVars) > 0 {
+						envVar = envVars[0]
+					}
 					parts := strings.SplitN(envVar, "=", 2)
 					// if expectedCPUSet is empty, parts[1] can be empty
 					if tc.expectedCPUSet.Size() > 0 {
@@ -1267,6 +1271,8 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 					require.True(t, actualCPUSet.Equals(tc.expectedCPUSet), "Expected CPUSet %s, but got %s for test case %s", tc.expectedCPUSet.String(), actualCPUSet.String(), tc.name)
 					if tc.expectedCPUSet.Size() > 0 {
 						require.Equal(t, 1, len(mockCdiMgr.devices), "Expected 1 CDI device to be created")
+						require.Len(t, envVars, 2, "Expected 2 env vars in CDI device spec")
+						require.Equal(t, fmt.Sprintf("%s=%s", cdiEnvVarAssigned, tc.expectedCPUSet.String()), envVars[1], "Expected DRA_CPUSET_ASSIGNED env var")
 					} else {
 						require.Equal(t, 0, len(mockCdiMgr.devices), "Expected 0 CDI devices to be created")
 					}
@@ -1364,8 +1370,8 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 				require.True(t, tc.expectedCPUSet.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedCPUSet)
 				require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
 
-				envVar := cdiMgr.devices[cdiDeviceName]
-				parts := strings.SplitN(envVar, "=", 2)
+				envVars := cdiMgr.devices[cdiDeviceName]
+				parts := strings.SplitN(envVars[0], "=", 2)
 				require.Len(t, parts, 2)
 				actualCPUSet, err := cpuset.Parse(parts[1])
 				require.NoError(t, err)
@@ -1480,8 +1486,8 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			require.True(t, gotCPUsAfterFirst.Equals(gotCPUs), "claim cpus must be unchanged after second prepare: got %s, want %s", gotCPUs, gotCPUsAfterFirst)
 			require.True(t, tc.expectedShared.Equals(cpuStore.GetSharedCPUs()), "shared cpus must be unchanged after second prepare: got %s, want %s", cpuStore.GetSharedCPUs(), tc.expectedShared)
 
-			envVar := cdiMgr.devices[cdiDeviceName]
-			parts := strings.SplitN(envVar, "=", 2)
+			envVars := cdiMgr.devices[cdiDeviceName]
+			parts := strings.SplitN(envVars[0], "=", 2)
 			require.Len(t, parts, 2)
 			actualCPUSet, err := cpuset.Parse(parts[1])
 			require.NoError(t, err)
@@ -1588,7 +1594,10 @@ func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID type
 	t.Helper()
 
 	mockCdiMgr := newMockCdiMgr()
-	mockCdiMgr.devices[getCDIDeviceName(claimUID)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, allocatedCPUs.String())
+	mockCdiMgr.devices[getCDIDeviceName(claimUID)] = []string{
+		fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, allocatedCPUs.String()),
+		fmt.Sprintf("%s=%s", cdiEnvVarAssigned, allocatedCPUs.String()),
+	}
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT}
 	topo, err := mockProvider.GetCPUTopology(logger)
 	require.NoError(t, err)
@@ -1948,7 +1957,7 @@ func TestOpaqueConfigAllocation(t *testing.T) {
 
 					cdiDeviceName := fmt.Sprintf("claim-%s", claim.UID)
 					expectedEnvVar := fmt.Sprintf("DRA_CPUSET_%s=%s", claim.UID, expectedSet.String())
-					assert.Equal(t, expectedEnvVar, mockCdi.devices[cdiDeviceName])
+					assert.Equal(t, expectedEnvVar, mockCdi.devices[cdiDeviceName][0])
 				}
 			}
 		})

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -69,7 +69,7 @@ type KubeletPlugin interface {
 }
 
 type cdiManager interface {
-	AddDevice(logger logr.Logger, deviceName string, envVar string) error
+	AddDevice(logger logr.Logger, deviceName string, envVars []string) error
 	RemoveDevice(logger logr.Logger, deviceName string) error
 }
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -112,6 +112,10 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 		key, value := parts[0], parts[1]
 		var claimUID types.UID
 		if strings.HasPrefix(key, cdiEnvVarPrefix+"_") {
+			// Skip the stable user-facing aggregate env var; only parse per-claim entries.
+			if key == cdiEnvVarAssigned {
+				continue
+			}
 			uidStr := strings.TrimPrefix(key, cdiEnvVarPrefix+"_")
 			claimUID = types.UID(uidStr)
 		} else {

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -73,6 +73,16 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 			expectedErrorContains: "failed to parse cpuset value",
 		},
 		{
+			name: "ignores DRA_CPUSET_ASSIGNED env var",
+			envs: []string{
+				fmt.Sprintf("%s_claim-uid-1=%s", cdiEnvVarPrefix, "0-1"),
+				fmt.Sprintf("%s=%s", cdiEnvVarAssigned, "0-1"),
+			},
+			expectedAllocations: map[types.UID]cpuset.CPUSet{
+				"claim-uid-1": cpuset.New(0, 1),
+			},
+		},
+		{
 			name:                "empty env",
 			envs:                []string{},
 			expectedAllocations: map[types.UID]cpuset.CPUSet{},


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/181

Regarding exposing the assigned set via a CDI file mount, I checked the possible use cases vs the trade offs from a security perspective and based on the discussion on the issue, at least for now,  I thought I won't to include it. But, if there is an interest in replacing the env var with a file based approach or even having both, then I'm happy to improve & cherry pick https://github.com/kubernetes-sigs/dra-driver-cpu/commit/85640eaf7c5863a285a4cc6c0b8ecbec98598293. 

Example run: 

```YAML
apiVersion: v1
kind: Pod
metadata:
  name: my-pod
spec:
  resourceClaims:
  - name: pod-cpu-claim-ref
    resourceClaimName: my-cpus
  containers:
  - name: app
    image: busybox
    command: ["sh", "-c", "env | grep DRA_CPUSET; sleep 3600"]
    resources:
      claims:
      - name: pod-cpu-claim-ref
```

```
$ kubectl logs my-pod
DRA_CPUSET_fdab0575-4c48-4566-a4aa-31d8d6552956=0,64
DRA_CPUSET_ASSIGNED=0,64
```