### PR TITLE
Fail closed on malformed DRA_CPUSET env

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The driver is deployed as a DaemonSet which contains two core components:
 
   - A CDI JSON spec file is created or updated for the allocated claim.
   - This spec instructs the runtime to inject an environment variable (e.g., `DRA_CPUSET_<claimUID>=<cpuset>`) into the container.
+  - The `DRA_CPUSET_*` environment variable prefix is reserved for the driver. Containers with malformed `DRA_CPUSET_*` values are rejected during creation.
   - The driver includes mechanisms for thread-safe and atomic updates to the CDI spec files.
 
 - **NRI Plugin**: This component integrates with the container runtime via the Node Resource Interface (NRI).

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -160,6 +160,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 	claimAllocations, err := parseDRAEnvToClaimAllocations(logger, ctr.Env)
 	if err != nil {
 		logger.Error(err, "error parsing DRA env for container")
+		return nil, nil, err
 	}
 
 	containerId := types.UID(ctr.GetId())

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -133,6 +133,7 @@ func TestCreateContainer(t *testing.T) {
 		container                   *api.Container
 		expectedContainerAdjustment *api.ContainerAdjustment
 		expectedContainerUpdates    []*api.ContainerUpdate
+		expectedErrorContains       string
 	}{
 		{
 			name:               "guaranteed container triggers container adjustment with cpus in resource claim",
@@ -186,7 +187,7 @@ func TestCreateContainer(t *testing.T) {
 			},
 		},
 		{
-			name:               "guaranteed container with malformed env falls back to shared",
+			name:               "guaranteed container with malformed env fails closed",
 			podConfigStore:     store.NewPodConfig(),
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 			claimTracker:       store.NewClaimTracker(),
@@ -196,10 +197,7 @@ func TestCreateContainer(t *testing.T) {
 				Name:         "my-ctr",
 				Env:          []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, "a-b")},
 			},
-			expectedContainerAdjustment: &api.ContainerAdjustment{
-				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
-			},
-			expectedContainerUpdates: []*api.ContainerUpdate{},
+			expectedErrorContains: "failed to parse cpuset value",
 		},
 	}
 
@@ -211,8 +209,15 @@ func TestCreateContainer(t *testing.T) {
 				claimTracker:       tc.claimTracker,
 			}
 			adjust, updates, err := driver.CreateContainer(context.Background(), pod, tc.container)
-			require.NoError(t, err)
+			if tc.expectedErrorContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErrorContains)
+				require.Nil(t, adjust)
+				require.Nil(t, updates)
+				return
+			}
 
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedContainerAdjustment, adjust)
 			require.ElementsMatch(t, tc.expectedContainerUpdates, updates)
 		})

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -142,6 +142,20 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 			gomega.Expect(fxt.Teardown(ctx)).To(gomega.Succeed())
 		})
 
+		ginkgo.It("should fail to create a container with malformed DRA_CPUSET env", ginkgo.Label("negative"), func(ctx context.Context) {
+			pod := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
+			pod.GenerateName = "tester-pod-malformed-dra-cpuset-"
+			pod.Spec.RestartPolicy = v1.RestartPolicyNever
+			pod.Spec.Containers[0].Env = []v1.EnvVar{
+				{Name: "DRA_CPUSET_malformed_claim", Value: "a-b"},
+			}
+			pod = e2epod.PinToNode(pod, targetNode.Name)
+
+			createdPod, err := fxt.K8SClientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			EventuallyFailedToCreate(ctx, fxt, createdPod)
+		})
+
 		ginkgo.Context("for exclusive CPU allocation", func() {
 			// TODO: check and ensure cpumanager configuration?
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -121,6 +121,18 @@ func BeFailedToCreate(fxt *fixture.Fixture) types.GomegaMatcher {
 	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} was not in failed phase")
 }
 
+func EventuallyFailedToCreate(ctx context.Context, fxt *fixture.Fixture, pod *v1.Pod) {
+	ginkgo.GinkgoHelper()
+
+	gomega.Eventually(func() *v1.Pod {
+		pod, err := fxt.K8SClientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil
+		}
+		return pod
+	}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(BeFailedToCreate(fxt))
+}
+
 func findWaitingContainerStatus(statuses []v1.ContainerStatus) *v1.ContainerStatus {
 	for idx := range statuses {
 		cntSt := &statuses[idx]

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -183,13 +183,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 			fixture.By("creating a second pod consuming the ResourceClaim on %q, ensuring it gets ContainerCreate Error", fxt.Namespace.Name)
 			createdPod2, err := fxt.K8SClientset.CoreV1().Pods(testPod.Namespace).Create(ctx, &testPod, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Eventually(func() *v1.Pod {
-				pod, err := fxt.K8SClientset.CoreV1().Pods(createdPod2.Namespace).Get(ctx, createdPod2.Name, metav1.GetOptions{})
-				if err != nil {
-					return nil
-				}
-				return pod
-			}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(BeFailedToCreate(fxt))
+			EventuallyFailedToCreate(ctx, fxt, createdPod2)
 		})
 
 		ginkgo.It("should fail to run a pod with multiple containers which share a claim", ginkgo.Label("negative"), func(ctx context.Context) {
@@ -246,13 +240,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 			fixture.By("creating a pod with multiple containers consuming the ResourceClaim on %q, ensuring it gets ContainerCreateError", fxt.Namespace.Name)
 			createdPod, err := fxt.K8SClientset.CoreV1().Pods(testPod.Namespace).Create(ctx, &testPod, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Eventually(func() *v1.Pod {
-				pod, err := fxt.K8SClientset.CoreV1().Pods(createdPod.Namespace).Get(ctx, createdPod.Name, metav1.GetOptions{})
-				if err != nil {
-					return nil
-				}
-				return pod
-			}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(BeFailedToCreate(fxt))
+			EventuallyFailedToCreate(ctx, fxt, createdPod)
 		})
 	})
 })


### PR DESCRIPTION
Fixes #185
- Make the NRI `CreateContainer` hook return an error when parsing a driver-owned `DRA_CPUSET_*` env fails.
- Add unit coverage to ensure malformed `DRA_CPUSET_*` no longer falls back to the shared CPU pool.
- Add e2e coverage for the kubelet-facing `CreateContainerError` behavior.
﻿
## Why
`DRA_CPUSET_*` is generated by the driver through CDI. If this env is malformed, treating the container as shared can silently break the workload's CPU allocation guarantees. Failing container creation is easier to debug and safer than running with broken promises.