### PR TITLE
Fail closed during NRI synchronize

### DIFF
--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -39,6 +39,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 
 	cpuAllocationStore := store.NewCPUAllocation(cp.cpuTopology, cp.reservedCPUs)
 	podConfigStore := store.NewPodConfig()
+	claimTracker := store.NewClaimTracker()
 	var containerUpdates []*api.ContainerUpdate
 
 	for _, pod := range pods {
@@ -53,7 +54,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 			claimAllocations, err := parseDRAEnvToClaimAllocations(cLogger, container.Env)
 			if err != nil {
 				cLogger.Error(err, "error parsing DRA env for container")
-				continue
+				return nil, err
 			}
 			containerUID := types.UID(container.GetId())
 			var state *store.ContainerState
@@ -64,7 +65,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 				allGuaranteedCPUs := cpuset.New()
 				for uid, cpus := range claimAllocations {
 					caLogger := cLogger.WithValues("claimUID", uid)
-					err := cp.claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
+					err := claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
 					if err != nil {
 						return nil, err
 					}
@@ -89,6 +90,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 
 	cp.podConfigStore = podConfigStore
 	cp.cpuAllocationStore = cpuAllocationStore
+	cp.claimTracker = claimTracker
 
 	// Reconcile container CPU masks to handle cases where the NRI plugin might have crashed
 	// or restarted and missed updating the cgroup settings.

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -305,7 +305,9 @@ func TestNRISynchronize(t *testing.T) {
 		runtimePods     []*api.PodSandbox
 		runtimeCtrs     []*api.Container
 		expectedUpdates []*api.ContainerUpdate
-		expectedError   bool
+		expectedError   string
+		expectStoreLen  int
+		expectClaims    int
 	}{
 		{
 			name: "empty runtime state clears the store",
@@ -322,6 +324,8 @@ func TestNRISynchronize(t *testing.T) {
 			runtimePods:     []*api.PodSandbox{},
 			runtimeCtrs:     []*api.Container{},
 			expectedUpdates: []*api.ContainerUpdate{},
+			expectStoreLen:  0,
+			expectClaims:    0,
 		},
 		{
 			name: "mixed containers across multiple pods",
@@ -351,6 +355,8 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-7"}}},
 				},
 			},
+			expectStoreLen: 2,
+			expectClaims:   1,
 		},
 		{
 			name: "only shared containers",
@@ -375,6 +381,8 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
 				},
 			},
+			expectStoreLen: 2,
+			expectClaims:   0,
 		},
 		{
 			name: "only guaranteed containers",
@@ -399,6 +407,8 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-3"}}},
 				},
 			},
+			expectStoreLen: 2,
+			expectClaims:   2,
 		},
 		{
 			name: "container with multiple claims",
@@ -418,6 +428,29 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-3"}}},
 				},
 			},
+			expectStoreLen: 1,
+			expectClaims:   2,
+		},
+		{
+			name: "malformed DRA env fails without committing partial synchronized state",
+			driver: func() *CPUDriver {
+				driver := &CPUDriver{
+					podConfigStore:     store.NewPodConfig(),
+					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+					claimTracker:       store.NewClaimTracker(),
+					cpuTopology:        topo,
+				}
+				driver.podConfigStore.SetContainerState(types.UID("existing-pod"), store.NewContainerState("existing-ctr", "existing-id"))
+				return driver
+			}(),
+			runtimePods: []*api.PodSandbox{pod1},
+			runtimeCtrs: []*api.Container{
+				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
+				{Id: "p1-malformed", PodSandboxId: pod1.Id, Name: "malformed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "a-b")}},
+			},
+			expectedError:  "failed to parse cpuset value",
+			expectStoreLen: 1,
+			expectClaims:   0,
 		},
 	}
 
@@ -425,14 +458,17 @@ func TestNRISynchronize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			updates, err := tc.driver.Synchronize(context.Background(), tc.runtimePods, tc.runtimeCtrs)
 
-			if tc.expectedError {
+			if tc.expectedError != "" {
 				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				require.Equal(t, tc.expectStoreLen, tc.driver.podConfigStore.Len())
+				require.Equal(t, tc.expectClaims, tc.driver.claimTracker.Len())
 				return
 			}
 			require.NoError(t, err)
 
 			// Verify that the store has been populated correctly
-			require.Equal(t, len(tc.runtimePods), tc.driver.podConfigStore.Len())
+			require.Equal(t, tc.expectStoreLen, tc.driver.podConfigStore.Len())
 			for _, pod := range tc.runtimePods {
 				for _, container := range tc.runtimeCtrs {
 					if container.PodSandboxId != pod.Id {
@@ -445,6 +481,7 @@ func TestNRISynchronize(t *testing.T) {
 
 			// Verify that the returned updates match expectations
 			require.ElementsMatch(t, tc.expectedUpdates, updates)
+			require.Equal(t, tc.expectClaims, tc.driver.claimTracker.Len())
 		})
 	}
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -306,8 +306,7 @@ func TestNRISynchronize(t *testing.T) {
 		runtimeCtrs     []*api.Container
 		expectedUpdates []*api.ContainerUpdate
 		expectedError   string
-		expectStoreLen  int
-		expectClaims    int
+		postSyncCheck   func(t *testing.T, driver *CPUDriver)
 	}{
 		{
 			name: "empty runtime state clears the store",
@@ -324,8 +323,6 @@ func TestNRISynchronize(t *testing.T) {
 			runtimePods:     []*api.PodSandbox{},
 			runtimeCtrs:     []*api.Container{},
 			expectedUpdates: []*api.ContainerUpdate{},
-			expectStoreLen:  0,
-			expectClaims:    0,
 		},
 		{
 			name: "mixed containers across multiple pods",
@@ -355,8 +352,6 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-7"}}},
 				},
 			},
-			expectStoreLen: 2,
-			expectClaims:   1,
 		},
 		{
 			name: "only shared containers",
@@ -381,8 +376,6 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
 				},
 			},
-			expectStoreLen: 2,
-			expectClaims:   0,
 		},
 		{
 			name: "only guaranteed containers",
@@ -407,8 +400,6 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-3"}}},
 				},
 			},
-			expectStoreLen: 2,
-			expectClaims:   2,
 		},
 		{
 			name: "container with multiple claims",
@@ -428,8 +419,6 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-3"}}},
 				},
 			},
-			expectStoreLen: 1,
-			expectClaims:   2,
 		},
 		{
 			name: "malformed DRA env fails without committing partial synchronized state",
@@ -448,9 +437,32 @@ func TestNRISynchronize(t *testing.T) {
 				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
 				{Id: "p1-malformed", PodSandboxId: pod1.Id, Name: "malformed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "a-b")}},
 			},
-			expectedError:  "failed to parse cpuset value",
-			expectStoreLen: 1,
-			expectClaims:   0,
+			expectedError: "failed to parse cpuset value",
+			postSyncCheck: func(t *testing.T, driver *CPUDriver) {
+				sharedPod := &api.PodSandbox{Id: "post-sync-shared-pod-id", Name: "post-sync-shared-pod", Namespace: "my-ns", Uid: "post-sync-shared-pod-uid"}
+				sharedCtr := &api.Container{Id: "post-sync-shared", PodSandboxId: sharedPod.Id, Name: "post-sync-shared-ctr"}
+
+				adjust, updates, err := driver.CreateContainer(context.Background(), sharedPod, sharedCtr)
+				require.NoError(t, err)
+				require.Equal(t, &api.ContainerAdjustment{
+					Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
+				}, adjust)
+				require.Empty(t, updates)
+
+				guaranteedPod := &api.PodSandbox{Id: "post-sync-guaranteed-pod-id", Name: "post-sync-guaranteed-pod", Namespace: "my-ns", Uid: "post-sync-guaranteed-pod-uid"}
+				guaranteedCtr := &api.Container{
+					Id:           "post-sync-guaranteed",
+					PodSandboxId: guaranteedPod.Id,
+					Name:         "post-sync-guaranteed-ctr",
+					Env:          []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")},
+				}
+
+				adjust, _, err = driver.CreateContainer(context.Background(), guaranteedPod, guaranteedCtr)
+				require.NoError(t, err)
+				require.Equal(t, &api.ContainerAdjustment{
+					Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1"}}},
+				}, adjust)
+			},
 		},
 	}
 
@@ -461,27 +473,17 @@ func TestNRISynchronize(t *testing.T) {
 			if tc.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectedError)
-				require.Equal(t, tc.expectStoreLen, tc.driver.podConfigStore.Len())
-				require.Equal(t, tc.expectClaims, tc.driver.claimTracker.Len())
+				if tc.postSyncCheck != nil {
+					tc.postSyncCheck(t, tc.driver)
+				}
 				return
 			}
 			require.NoError(t, err)
 
-			// Verify that the store has been populated correctly
-			require.Equal(t, tc.expectStoreLen, tc.driver.podConfigStore.Len())
-			for _, pod := range tc.runtimePods {
-				for _, container := range tc.runtimeCtrs {
-					if container.PodSandboxId != pod.Id {
-						continue
-					}
-					state := tc.driver.podConfigStore.GetContainerState(types.UID(pod.Uid), container.Name)
-					require.NotNil(t, state)
-				}
-			}
-
-			// Verify that the returned updates match expectations
 			require.ElementsMatch(t, tc.expectedUpdates, updates)
-			require.Equal(t, tc.expectClaims, tc.driver.claimTracker.Len())
+			if tc.postSyncCheck != nil {
+				tc.postSyncCheck(t, tc.driver)
+			}
 		})
 	}
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -306,7 +306,6 @@ func TestNRISynchronize(t *testing.T) {
 		runtimeCtrs     []*api.Container
 		expectedUpdates []*api.ContainerUpdate
 		expectedError   string
-		postSyncCheck   func(t *testing.T, driver *CPUDriver)
 	}{
 		{
 			name: "empty runtime state clears the store",
@@ -421,48 +420,19 @@ func TestNRISynchronize(t *testing.T) {
 			},
 		},
 		{
-			name: "malformed DRA env fails without committing partial synchronized state",
-			driver: func() *CPUDriver {
-				driver := &CPUDriver{
-					podConfigStore:     store.NewPodConfig(),
-					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
-					claimTracker:       store.NewClaimTracker(),
-					cpuTopology:        topo,
-				}
-				driver.podConfigStore.SetContainerState(types.UID("existing-pod"), store.NewContainerState("existing-ctr", "existing-id"))
-				return driver
-			}(),
+			name: "malformed DRA env fails synchronize",
+			driver: &CPUDriver{
+				podConfigStore:     store.NewPodConfig(),
+				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+				claimTracker:       store.NewClaimTracker(),
+				cpuTopology:        topo,
+			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
 				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
 				{Id: "p1-malformed", PodSandboxId: pod1.Id, Name: "malformed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "a-b")}},
 			},
 			expectedError: "failed to parse cpuset value",
-			postSyncCheck: func(t *testing.T, driver *CPUDriver) {
-				sharedPod := &api.PodSandbox{Id: "post-sync-shared-pod-id", Name: "post-sync-shared-pod", Namespace: "my-ns", Uid: "post-sync-shared-pod-uid"}
-				sharedCtr := &api.Container{Id: "post-sync-shared", PodSandboxId: sharedPod.Id, Name: "post-sync-shared-ctr"}
-
-				adjust, updates, err := driver.CreateContainer(context.Background(), sharedPod, sharedCtr)
-				require.NoError(t, err)
-				require.Equal(t, &api.ContainerAdjustment{
-					Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
-				}, adjust)
-				require.Empty(t, updates)
-
-				guaranteedPod := &api.PodSandbox{Id: "post-sync-guaranteed-pod-id", Name: "post-sync-guaranteed-pod", Namespace: "my-ns", Uid: "post-sync-guaranteed-pod-uid"}
-				guaranteedCtr := &api.Container{
-					Id:           "post-sync-guaranteed",
-					PodSandboxId: guaranteedPod.Id,
-					Name:         "post-sync-guaranteed-ctr",
-					Env:          []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")},
-				}
-
-				adjust, _, err = driver.CreateContainer(context.Background(), guaranteedPod, guaranteedCtr)
-				require.NoError(t, err)
-				require.Equal(t, &api.ContainerAdjustment{
-					Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1"}}},
-				}, adjust)
-			},
 		},
 	}
 
@@ -473,17 +443,11 @@ func TestNRISynchronize(t *testing.T) {
 			if tc.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectedError)
-				if tc.postSyncCheck != nil {
-					tc.postSyncCheck(t, tc.driver)
-				}
 				return
 			}
 			require.NoError(t, err)
 
 			require.ElementsMatch(t, tc.expectedUpdates, updates)
-			if tc.postSyncCheck != nil {
-				tc.postSyncCheck(t, tc.driver)
-			}
 		})
 	}
 }


### PR DESCRIPTION
- Make NRI `Synchronize` fail closed when parsing driver-owned `DRA_CPUSET_*` env fails.
- Rebuild `ClaimTracker` in temporary state during synchronization.
- Commit synchronized state only after the full sync succeeds.
﻿
#190 made `CreateContainer` fail closed for malformed `DRA_CPUSET_*` env, but `Synchronize` still logged parse errors and skipped affected containers.
﻿
This can rebuild incomplete in-memory state after runtime/plugin restart. This follow-up keeps synchronization atomic: either runtime state is rebuilt successfully, or the previous state is preserved.
﻿
Follow-up for #185 / #190 review:
https://github.com/kubernetes-sigs/dra-driver-cpu/pull/190#issuecomment-4776903084