### PR TITLE
Validate DRA env against prepared claims

### DIFF
--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -128,6 +128,19 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 	return allocations, nil
 }
 
+func (cp *CPUDriver) validatePreparedClaimAllocations(claimAllocations map[types.UID]cpuset.CPUSet) error {
+	for uid, cpus := range claimAllocations {
+		preparedCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(uid)
+		if !ok {
+			return fmt.Errorf("claim %q is not prepared by this driver", uid)
+		}
+		if !preparedCPUs.Equals(cpus) {
+			return fmt.Errorf("claim %q has cpuset %q, expected prepared cpuset %q", uid, cpus.String(), preparedCPUs.String())
+		}
+	}
+	return nil
+}
+
 func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) []*api.ContainerUpdate {
 	updates := []*api.ContainerUpdate{}
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
@@ -175,6 +188,12 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		logger.V(2).Info("no guaranteed CPUs found, using shared CPUs", "sharedCPUs", sharedCPUs.String())
 		adjust.SetLinuxCPUSetCPUs(sharedCPUs.String())
 	} else {
+		// NRI invokes CreateContainer for all containers. Only trust DRA env
+		// entries that match a claim prepared by this driver.
+		if err := cp.validatePreparedClaimAllocations(claimAllocations); err != nil {
+			return nil, nil, err
+		}
+
 		guaranteedCPUs := cpuset.New()
 		claimUIDs := []types.UID{}
 		for uid, cpus := range claimAllocations {

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -128,15 +128,13 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 	return allocations, nil
 }
 
-func (cp *CPUDriver) validatePreparedClaimAllocations(claimAllocations map[types.UID]cpuset.CPUSet) error {
-	for uid, cpus := range claimAllocations {
-		preparedCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(uid)
-		if !ok {
-			return fmt.Errorf("claim %q is not prepared by this driver", uid)
-		}
-		if !preparedCPUs.Equals(cpus) {
-			return fmt.Errorf("claim %q has cpuset %q, expected prepared cpuset %q", uid, cpus.String(), preparedCPUs.String())
-		}
+func (cp *CPUDriver) validatePreparedClaimAllocation(uid types.UID, cpus cpuset.CPUSet) error {
+	preparedCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(uid)
+	if !ok {
+		return fmt.Errorf("claim %q is not prepared by this driver", uid)
+	}
+	if !preparedCPUs.Equals(cpus) {
+		return fmt.Errorf("claim %q has cpuset %q, expected prepared cpuset %q", uid, cpus.String(), preparedCPUs.String())
 	}
 	return nil
 }
@@ -190,14 +188,14 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 	} else {
 		// NRI invokes CreateContainer for all containers. Only trust DRA env
 		// entries that match a claim prepared by this driver.
-		if err := cp.validatePreparedClaimAllocations(claimAllocations); err != nil {
-			return nil, nil, err
-		}
-
 		guaranteedCPUs := cpuset.New()
 		claimUIDs := []types.UID{}
 		for uid, cpus := range claimAllocations {
 			cLogger := logger.WithValues("claimUID", uid)
+			if err := cp.validatePreparedClaimAllocation(uid, cpus); err != nil {
+				return nil, nil, err
+			}
+
 			err := cp.claimTracker.SetOwner(cLogger, uid, types.UID(pod.Uid), ctr.Name)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -134,7 +134,7 @@ func (cp *CPUDriver) validatePreparedClaimAllocation(uid types.UID, cpus cpuset.
 		return fmt.Errorf("claim %q is not prepared by this driver", uid)
 	}
 	if !preparedCPUs.Equals(cpus) {
-		return fmt.Errorf("claim %q has cpuset %q, expected prepared cpuset %q", uid, cpus.String(), preparedCPUs.String())
+		return fmt.Errorf("validation failed for claim %q: cpuset mismatch (expected %q, got %q)", uid, preparedCPUs.String(), cpus.String())
 	}
 	return nil
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -136,11 +136,15 @@ func TestCreateContainer(t *testing.T) {
 		expectedErrorContains       string
 	}{
 		{
-			name:               "guaranteed container triggers container adjustment with cpus in resource claim",
-			podConfigStore:     store.NewPodConfig(),
-			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
-			claimTracker:       store.NewClaimTracker(),
-			container:          newTestContainer(claimUID, "0-3"),
+			name:           "guaranteed container triggers container adjustment with cpus in resource claim",
+			podConfigStore: store.NewPodConfig(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				store := store.NewCPUAllocation(topo, cpuset.New())
+				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
+				return store
+			}(),
+			claimTracker: store.NewClaimTracker(),
+			container:    newTestContainer(claimUID, "0-3"),
 			expectedContainerAdjustment: &api.ContainerAdjustment{
 				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-3"}}},
 			},
@@ -154,6 +158,21 @@ func TestCreateContainer(t *testing.T) {
 			container:          newTestContainer("", ""),
 			expectedContainerAdjustment: &api.ContainerAdjustment{
 				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
+			},
+			expectedContainerUpdates: []*api.ContainerUpdate{},
+		},
+		{
+			name:           "shared container created after guaranteed allocation uses shared pool",
+			podConfigStore: store.NewPodConfig(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				store := store.NewCPUAllocation(topo, cpuset.New())
+				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
+				return store
+			}(),
+			claimTracker: store.NewClaimTracker(),
+			container:    newTestContainer("", ""),
+			expectedContainerAdjustment: &api.ContainerAdjustment{
+				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "4-7"}}},
 			},
 			expectedContainerUpdates: []*api.ContainerUpdate{},
 		},
@@ -198,6 +217,29 @@ func TestCreateContainer(t *testing.T) {
 				Env:          []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, "a-b")},
 			},
 			expectedErrorContains: "failed to parse cpuset value",
+		},
+		{
+			name:               "container with DRA env for unprepared claim fails closed",
+			podConfigStore:     store.NewPodConfig(),
+			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+			claimTracker:       store.NewClaimTracker(),
+			container:          newTestContainer(claimUID, "0-3"),
+			expectedErrorContains: fmt.Sprintf(
+				"claim %q is not prepared by this driver",
+				claimUID,
+			),
+		},
+		{
+			name:           "container with DRA env that differs from prepared allocation fails closed",
+			podConfigStore: store.NewPodConfig(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				store := store.NewCPUAllocation(topo, cpuset.New())
+				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(0, 1))
+				return store
+			}(),
+			claimTracker:          store.NewClaimTracker(),
+			container:             newTestContainer(claimUID, "0-3"),
+			expectedErrorContains: fmt.Sprintf("claim %q has cpuset", claimUID),
 		},
 	}
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -237,9 +237,14 @@ func TestCreateContainer(t *testing.T) {
 				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(0, 1))
 				return store
 			}(),
-			claimTracker:          store.NewClaimTracker(),
-			container:             newTestContainer(claimUID, "0-3"),
-			expectedErrorContains: fmt.Sprintf("claim %q has cpuset", claimUID),
+			claimTracker: store.NewClaimTracker(),
+			container:    newTestContainer(claimUID, "0-3"),
+			expectedErrorContains: fmt.Sprintf(
+				"validation failed for claim %q: cpuset mismatch (expected %q, got %q)",
+				claimUID,
+				"0-1",
+				"0-3",
+			),
 		},
 	}
 


### PR DESCRIPTION
- Validate `DRA_CPUSET_*` env entries against claims prepared by this driver.
- Reject containers whose DRA env references an unprepared claim or mismatched cpuset.
- Keep ordinary non-DRA containers in the shared CPU pool.
﻿
NRI `CreateContainer` runs for every container, not only containers prepared through DRA. A container-provided `DRA_CPUSET_*` env should not be trusted unless it matches driver-owned prepare state.
﻿
This addresses the #190 follow-up while preserving the intended shared-pool behavior for non-DRA containers.
﻿
Follow-up:
https://github.com/kubernetes-sigs/dra-driver-cpu/pull/190#issuecomment-4776903084