### PR TITLE
e2e: add Gomega matchers

### DIFF
--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
+	cpusetmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/cpuset"
 	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
@@ -107,7 +108,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 			groupBy = val
 		}
 		rootFxt.Log.Info("daemonset --reserved-cpus configuration", "cpus", dsReservedCPUs.String())
-		gomega.Expect(dsReservedCPUs.Equals(reservedCPUs)).To(gomega.BeTrue(), "daemonset reserved cpus %v do not match test reserved cpus %v", dsReservedCPUs.String(), reservedCPUs.String())
+		gomega.Expect(dsReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
 		rootFxt.Log.Info("daemonset --cpu-device-mode configuration", "mode", cpuDeviceMode, "groupBy", groupBy)
 
 		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
@@ -125,7 +126,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 		allocatableCPUs := makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
 		availableCPUs = allocatableCPUs.Difference(reservedCPUs)
 		if reservedCPUs.Size() > 0 {
-			gomega.Expect(availableCPUs.Intersection(reservedCPUs).Size()).To(gomega.BeZero(), "available cpus %v overlap with reserved cpus %v", availableCPUs.String(), reservedCPUs.String())
+			gomega.Expect(availableCPUs).To(cpusetmatchers.HaveNoOverlapWith(reservedCPUs))
 		}
 		rootFxt.Log.Info("checking worker node", "nodeName", infoPod.Spec.NodeName, "coreCount", len(targetNodeCPUInfo.CPUs), "allocatableCPUs", allocatableCPUs.String(), "reservedCPUs", reservedCPUs.String(), "availableCPUs", availableCPUs.String())
 	})
@@ -214,12 +215,12 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				for i, pod := range exclPods {
 					alloc := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, pod)
 					fxt.Log.Info("Checking exclusive CPU allocation", "pod", e2epod.Identify(pod), "cpuAllocated", alloc.CPUAssigned.String())
-					gomega.Expect(alloc.CPUAssigned.Size()).To(gomega.Equal(cpusPerClaim), "Pod %d did not get %d CPUs", i, cpusPerClaim)
-					gomega.Expect(alloc.CPUAssigned.IsSubsetOf(availableCPUs)).To(gomega.BeTrue(), "Pod %d got CPUs outside available set", i)
-					gomega.Expect(allAllocatedCPUs.Intersection(alloc.CPUAssigned).Size()).To(gomega.Equal(0), "Pod %d has overlapping CPUs", i)
+					gomega.Expect(alloc.CPUAssigned).To(cpusetmatchers.HaveSize(cpusPerClaim), "Pod %d did not get %d CPUs", i, cpusPerClaim)
+					gomega.Expect(alloc.CPUAssigned).To(cpusetmatchers.BeSubsetOf(availableCPUs), "Pod %d got CPUs outside available set", i)
+					gomega.Expect(alloc.CPUAssigned).To(cpusetmatchers.HaveNoOverlapWith(allAllocatedCPUs), "Pod %d has overlapping CPUs", i)
 					allAllocatedCPUs = allAllocatedCPUs.Union(alloc.CPUAssigned)
 				}
-				gomega.Expect(allAllocatedCPUs.Size()).To(gomega.Equal(numPods * cpusPerClaim))
+				gomega.Expect(allAllocatedCPUs).To(cpusetmatchers.HaveSize(numPods * cpusPerClaim))
 				rootFxt.Log.Info("All exclusive allocation", "pod", "exclusive CPUs", allAllocatedCPUs.String(), "expected Shared CPUs", availableCPUs.Difference(allAllocatedCPUs).String())
 
 				fixture.By("checking the shared pool does not include anymore the exclusively allocated CPUs")
@@ -298,8 +299,8 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				fixture.By("verifying the pod got 2 distinct CPUs with no overlap")
 				alloc := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod)
 				fxt.Log.Info("multi-request claim allocation", "cpuAssigned", alloc.CPUAssigned.String())
-				gomega.Expect(alloc.CPUAssigned.Size()).To(gomega.Equal(2), "expected 2 distinct CPUs allocated")
-				gomega.Expect(alloc.CPUAssigned.IsSubsetOf(availableCPUs)).To(gomega.BeTrue(), "allocated CPUs must be within available set")
+				gomega.Expect(alloc.CPUAssigned).To(cpusetmatchers.HaveSize(2), "expected 2 distinct CPUs allocated")
+				gomega.Expect(alloc.CPUAssigned).To(cpusetmatchers.BeSubsetOf(availableCPUs), "allocated CPUs must be within available set")
 
 			})
 
@@ -356,7 +357,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 					alloc := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, pod)
 					expectedSet := claimsAndCPUSets[i].cpuset
 					fxt.Log.Info("pod allocation verification", "pod", pod.Name, "assigned", alloc.CPUAssigned.String(), "expected", expectedSet.String())
-					gomega.Expect(alloc.CPUAssigned.Equals(expectedSet)).To(gomega.BeTrue(), "assigned CPU set %s does not match expected %s", alloc.CPUAssigned.String(), expectedSet.String())
+					gomega.Expect(alloc.CPUAssigned).To(cpusetmatchers.Equal(expectedSet))
 				}
 
 				fixture.By("creating a second best-effort pod")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gcustom"
 	"github.com/onsi/gomega/types"
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -97,12 +98,12 @@ func waitForRunningDriverPods(ctx context.Context, client kubernetes.Interface) 
 	return pods
 }
 
-func BeFailedToCreate(fxt *fixture.Fixture) types.GomegaMatcher {
+func BeFailedToCreate(logr logr.Logger) types.GomegaMatcher {
 	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
 		if actual == nil {
 			return false, errors.New("nil Pod")
 		}
-		logger := fxt.Log.WithValues("podUID", actual.UID, "namespace", actual.Namespace, "name", actual.Name)
+		logger := logr.WithValues("podUID", actual.UID, "namespace", actual.Namespace, "name", actual.Name)
 		if actual.Status.Phase != v1.PodPending {
 			logger.Info("unexpected phase", "phase", actual.Status.Phase)
 			return false, nil
@@ -130,7 +131,7 @@ func EventuallyFailedToCreate(ctx context.Context, fxt *fixture.Fixture, pod *v1
 			return nil
 		}
 		return pod
-	}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(BeFailedToCreate(fxt))
+	}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(BeFailedToCreate(fxt.Log))
 }
 
 func findWaitingContainerStatus(statuses []v1.ContainerStatus) *v1.ContainerStatus {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -28,12 +27,10 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/api/v1alpha1"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
+	podmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/pod"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/onsi/gomega/gcustom"
-	"github.com/onsi/gomega/types"
-	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -54,15 +51,14 @@ func TestE2E(t *testing.T) {
 // shared code which is not ready yet to be moved into a test/pkg/... package
 
 const (
-	driverName                 = "dra.cpu"
-	reasonCreateContainerError = "CreateContainerError"
-	argReservedCPUs            = "--reserved-cpus="
-	argCPUDeviceMode           = "--cpu-device-mode="
-	argGroupBy                 = "--group-by="
-	daemonSetNamespace         = "kube-system"
-	daemonSetLabel             = "app=dracpu"
-	driverPodPollInterval      = 2 * time.Second
-	driverPodPollTimeout       = 2 * time.Minute
+	driverName            = "dra.cpu"
+	argReservedCPUs       = "--reserved-cpus="
+	argCPUDeviceMode      = "--cpu-device-mode="
+	argGroupBy            = "--group-by="
+	daemonSetNamespace    = "kube-system"
+	daemonSetLabel        = "app=dracpu"
+	driverPodPollInterval = 2 * time.Second
+	driverPodPollTimeout  = 2 * time.Minute
 )
 
 func listDriverPods(ctx context.Context, client kubernetes.Interface) ([]v1.Pod, error) {
@@ -98,30 +94,6 @@ func waitForRunningDriverPods(ctx context.Context, client kubernetes.Interface) 
 	return pods
 }
 
-func BeFailedToCreate(logr logr.Logger) types.GomegaMatcher {
-	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
-		if actual == nil {
-			return false, errors.New("nil Pod")
-		}
-		logger := logr.WithValues("podUID", actual.UID, "namespace", actual.Namespace, "name", actual.Name)
-		if actual.Status.Phase != v1.PodPending {
-			logger.Info("unexpected phase", "phase", actual.Status.Phase)
-			return false, nil
-		}
-		cntSt := findWaitingContainerStatus(actual.Status.ContainerStatuses)
-		if cntSt == nil {
-			logger.Info("no container in waiting state")
-			return false, nil
-		}
-		if cntSt.State.Waiting.Reason != reasonCreateContainerError {
-			logger.Info("container waiting for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Waiting.Reason)
-			return false, nil
-		}
-		logger.Info("container creation error", "containerName", cntSt.Name)
-		return true, nil
-	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} was not in failed phase")
-}
-
 func EventuallyFailedToCreate(ctx context.Context, fxt *fixture.Fixture, pod *v1.Pod) {
 	ginkgo.GinkgoHelper()
 
@@ -131,17 +103,7 @@ func EventuallyFailedToCreate(ctx context.Context, fxt *fixture.Fixture, pod *v1
 			return nil
 		}
 		return pod
-	}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(BeFailedToCreate(fxt.Log))
-}
-
-func findWaitingContainerStatus(statuses []v1.ContainerStatus) *v1.ContainerStatus {
-	for idx := range statuses {
-		cntSt := &statuses[idx]
-		if cntSt.State.Waiting != nil {
-			return cntSt
-		}
-	}
-	return nil
+	}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(podmatchers.BeFailedToCreate(fxt.Log))
 }
 
 func makeCPUSetFromDiscoveredCPUInfo(cpuInfo discovery.DRACPUInfo) cpuset.CPUSet {

--- a/test/e2e/nri_reconciliation_test.go
+++ b/test/e2e/nri_reconciliation_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
+	cpusetmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/cpuset"
 	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
@@ -128,7 +129,7 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 		ginkgo.By("Verifying Pod 1 has correct exclusive CPU mask")
 		alloc1 := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod1)
 		fxt.Log.Info("Pod 1 CPU allocation", "cpuAssigned", alloc1.CPUAssigned.String())
-		gomega.Expect(alloc1.CPUAssigned.Size()).To(gomega.Equal(2), "Pod 1 did not get exclusive CPUs")
+		gomega.Expect(alloc1.CPUAssigned).To(cpusetmatchers.HaveSize(2), "Pod 1 did not get exclusive CPUs")
 		exclusiveCPUs := alloc1.CPUAssigned
 
 		ginkgo.By("Stopping cpu dra driver pod on target node")
@@ -198,7 +199,7 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 
 		ginkgo.By("Verifying Pod 1 still has correct exclusive CPU mask while NRI is down")
 		alloc1Down := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod1)
-		gomega.Expect(alloc1Down.CPUAssigned).To(gomega.Equal(exclusiveCPUs), "Pod 1 CPU mask changed after NRI stopped")
+		gomega.Expect(alloc1Down.CPUAssigned).To(cpusetmatchers.Equal(exclusiveCPUs), "Pod 1 CPU mask changed after NRI stopped")
 
 		ginkgo.By("Creating Pod 2 (Best Effort) on target node")
 		pod2 := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
@@ -210,7 +211,7 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 		alloc2 := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod2)
 		fxt.Log.Info("Pod 2 CPU allocation (without NRI)", "cpuAssigned", alloc2.CPUAssigned.String())
 		// Since NRI is down, pod2 is not restricted to shared pool CPUs and gets all online CPUs.
-		gomega.Expect(alloc2.CPUAffinity).To(gomega.Equal(allocatableCPUs), "Pod 2 CPU mask not equal to all CPUs")
+		gomega.Expect(alloc2.CPUAffinity).To(cpusetmatchers.Equal(allocatableCPUs), "Pod 2 CPU mask not equal to all CPUs")
 
 		ginkgo.By("Bringing up the cpu dra driver on target node")
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -245,14 +246,14 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 
 		ginkgo.By("Verifying Pod 1 still has correct exclusive CPU mask after NRI restart")
 		alloc1Up := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod1)
-		gomega.Expect(alloc1Up.CPUAssigned).To(gomega.Equal(exclusiveCPUs), "Pod 1 CPU mask changed after NRI restarted")
+		gomega.Expect(alloc1Up.CPUAssigned).To(cpusetmatchers.Equal(exclusiveCPUs), "Pod 1 CPU mask changed after NRI restarted")
 
 		ginkgo.By("Verifying Pod 2 CPU mask IS restricted to shared pool (excludes Pod 1 CPUs)")
 		gomega.Eventually(func(g gomega.Gomega) {
 			alloc2Updated := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod2)
 			fxt.Log.Info("Pod 2 CPU allocation (after NRI recovery)", "cpuAssigned", alloc2Updated.CPUAssigned.String())
 			// pod2 must NOT contain the exclusive CPUs now
-			g.Expect(alloc2Updated.CPUAssigned.Intersection(exclusiveCPUs).IsEmpty()).To(gomega.BeTrue(), "Pod 2 still has access to exclusive CPUs")
+			g.Expect(alloc2Updated.CPUAssigned).To(cpusetmatchers.HaveNoOverlapWith(exclusiveCPUs), "Pod 2 still has access to exclusive CPUs")
 		}, pollTimeoutRule, pollIntervalRule).Should(gomega.Succeed(), "timed out waiting for Pod 2 CPU mask update")
 	})
 })

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
+	cpusetmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/cpuset"
 	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
@@ -83,7 +84,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 		if val, ok := findArgInContainer(cnt, argGroupBy); ok {
 			groupBy = val
 		}
-		gomega.Expect(dsReservedCPUs.Equals(reservedCPUs)).To(gomega.BeTrue(), "daemonset reserved cpus %v do not match test reserved cpus %v", dsReservedCPUs.String(), reservedCPUs.String())
+		gomega.Expect(dsReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
 
 		rootFxt.Log.Info("daemonset configuration", "reservedCPUs", dsReservedCPUs.String(), "deviceMode", cpuDeviceMode, "groupBy", groupBy)
 
@@ -103,7 +104,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 		allocatableCPUs := makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
 		availableCPUs = allocatableCPUs.Difference(reservedCPUs)
 		if reservedCPUs.Size() > 0 {
-			gomega.Expect(availableCPUs.Intersection(reservedCPUs).Size()).To(gomega.BeZero(), "available cpus %v overlap with reserved cpus %v", availableCPUs.String(), reservedCPUs.String())
+			gomega.Expect(availableCPUs).To(cpusetmatchers.HaveNoOverlapWith(reservedCPUs))
 		}
 		rootFxt.Log.Info("checking worker node", "nodeName", infoPod.Spec.NodeName, "coreCount", len(targetNodeCPUInfo.CPUs), "allocatableCPUs", allocatableCPUs.String(), "reservedCPUs", reservedCPUs.String(), "availableCPUs", availableCPUs.String())
 	})

--- a/test/pkg/matchers/cpuset/cpuset.go
+++ b/test/pkg/matchers/cpuset/cpuset.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpuset
+
+import (
+	"github.com/onsi/gomega/gcustom"
+	"github.com/onsi/gomega/types"
+	"k8s.io/utils/cpuset"
+)
+
+// Equal succeeds if actual.Equals(expected) is true.
+func Equal(expected cpuset.CPUSet) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(actual cpuset.CPUSet) (bool, error) {
+		return actual.Equals(expected), nil
+	}).WithTemplate("Expected CPUSet\n\t{{.FormattedActual}}\nto equal\n\t{{format .Data}}", expected)
+}
+
+// BeSubsetOf succeeds if actual.IsSubsetOf(superset) is true.
+func BeSubsetOf(superset cpuset.CPUSet) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(actual cpuset.CPUSet) (bool, error) {
+		return actual.IsSubsetOf(superset), nil
+	}).WithTemplate("Expected CPUSet\n\t{{.FormattedActual}}\nto be a subset of\n\t{{format .Data}}", superset)
+}
+
+// HaveNoOverlapWith succeeds if actual.Intersection(other) is empty.
+func HaveNoOverlapWith(other cpuset.CPUSet) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(actual cpuset.CPUSet) (bool, error) {
+		return actual.Intersection(other).IsEmpty(), nil
+	}).WithTemplate("Expected CPUSet\n\t{{.FormattedActual}}\nto have no overlap with\n\t{{format .Data}}", other)
+}
+
+// HaveSize succeeds if actual.Size() equals the expected count.
+func HaveSize(expected int) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(actual cpuset.CPUSet) (bool, error) {
+		return actual.Size() == expected, nil
+	}).WithTemplate("Expected CPUSet\n\t{{.FormattedActual}}\nto have size {{.Data}} but got size {{.Actual.Size}}", expected)
+}

--- a/test/pkg/matchers/pod/pod.go
+++ b/test/pkg/matchers/pod/pod.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"errors"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega/gcustom"
+	"github.com/onsi/gomega/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+const ReasonCreateContainerError = "CreateContainerError"
+
+// BeFailedToCreate succeeds if the pod is Pending with a container in
+// CreateContainerError waiting state.
+func BeFailedToCreate(logr logr.Logger) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(actual *v1.Pod) (bool, error) {
+		if actual == nil {
+			return false, errors.New("nil Pod")
+		}
+		logger := logr.WithValues("podUID", actual.UID, "namespace", actual.Namespace, "name", actual.Name)
+		if actual.Status.Phase != v1.PodPending {
+			logger.Info("unexpected phase", "phase", actual.Status.Phase)
+			return false, nil
+		}
+		cntSt := findWaitingContainerStatus(actual.Status.ContainerStatuses)
+		if cntSt == nil {
+			logger.Info("no container in waiting state")
+			return false, nil
+		}
+		if cntSt.State.Waiting.Reason != ReasonCreateContainerError {
+			logger.Info("container waiting for different reason", "containerName", cntSt.Name, "reason", cntSt.State.Waiting.Reason)
+			return false, nil
+		}
+		logger.Info("container creation error", "containerName", cntSt.Name)
+		return true, nil
+	}).WithTemplate("Pod {{.Actual.Namespace}}/{{.Actual.Name}} UID {{.Actual.UID}} was not in failed phase")
+}
+
+func findWaitingContainerStatus(statuses []v1.ContainerStatus) *v1.ContainerStatus {
+	for idx := range statuses {
+		cntSt := &statuses[idx]
+		if cntSt.State.Waiting != nil {
+			return cntSt
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR introduces custom Gomega matchers for `cpuset.CPUSet` to 
encapsulate recurring e2e assertion patterns, as part of [#132](https://github.com/kubernetes-sigs/dra-driver-cpu/issues/132).