### PR TITLE
image: replace staging with production images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(OUT_DIR):  ## creates the output directory (used internally)
 CLUSTER_NAME=dra-driver-cpu
 IMAGE_NAME=dra-driver-cpu
 # docker image registry, default to upstream
-REGISTRY ?= us-central1-docker.pkg.dev/k8s-staging-images
+REGISTRY ?= registry.k8s.io/k8s-staging-images
 # this is an intentionally non-existent registry to be used only by local CI using the local image loading
 REGISTRY_CI := dev.kind.local/ci
 IMAGE_REPO := ${REGISTRY}/${IMAGE_NAME}/${IMAGE_NAME}

--- a/README.md
+++ b/README.md
@@ -440,7 +440,8 @@ make kind-cluster
 The recommended way to install the driver is via the provided Helm chart:
 
 ```bash
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu -n kube-system
+
 ```
 
 See the [Helm chart README](deployment/helm/dra-driver-cpu/README.md) for the full list of configuration options.
@@ -466,7 +467,7 @@ in-place migration is not possible. The only practical migration path is a delet
 kubectl delete -f dist/install.yaml
 
 # Step 2: install the Helm-managed release
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu -n kube-system
 ```
 
 **Disruption:** Deleting the DaemonSet terminates the driver pods on all nodes simultaneously. During

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -3,6 +3,11 @@
 Kubernetes DRA driver for managing CPU resources with topology-aware allocation, exclusive CPU assignment, and shared CPU pool management via the Dynamic Resource Allocation framework.
 
 ## Installation
+From a stable release:
+
+```bash
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system
+```
 
 From a local checkout:
 
@@ -13,7 +18,7 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system
 To override values at install time:
 
 ```bash
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system \
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system \
   --set args.cpuDeviceMode=individual \
   --set args.reservedCPUs="0-1"
 ```
@@ -21,8 +26,8 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system \
 Parameters can be set at install time using `--set` or a custom values file:
 
 ```bash
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system --set args.logLevel=4
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f my-values.yaml
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system --set args.logLevel=4
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system -f my-values.yaml
 ```
 
 ## Values
@@ -39,7 +44,7 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f m
 | healthzPath | string | `"/healthz"` | Path for liveness and readiness probes |
 | healthzPort | int | `8080` | Port the HTTP server binds to; used for the container port and probes |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu"` | Container image repository |
+| image.repository | string | `"registry.k8s.io/dra-driver-cpu/dra-driver-cpu"` | Container image repository |
 | image.tag | string | `""` | Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time |
 | imagePullSecrets | list | `[]` | List of image pull secrets |
 | nameOverride | string | `""` | Override the chart name |

--- a/deployment/helm/dra-driver-cpu/README.md.gotmpl
+++ b/deployment/helm/dra-driver-cpu/README.md.gotmpl
@@ -3,6 +3,11 @@
 {{ template "chart.description" . }}
 
 ## Installation
+From a stable release:
+
+```bash
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system
+```
 
 From a local checkout:
 
@@ -13,7 +18,7 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system
 To override values at install time:
 
 ```bash
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system \
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system \
   --set args.cpuDeviceMode=individual \
   --set args.reservedCPUs="0-1"
 ```
@@ -21,8 +26,8 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system \
 Parameters can be set at install time using `--set` or a custom values file:
 
 ```bash
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system --set args.logLevel=4
-helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f my-values.yaml
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system --set args.logLevel=4
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu --version 0.2.0 -n kube-system -f my-values.yaml
 ```
 
 {{ template "chart.valuesSection" . }}

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -20,7 +20,7 @@ fullnameOverride: ""
 # @schema additionalProperties:false
 image:
   # -- Container image repository
-  repository: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu # @schema required:true
+  repository: registry.k8s.io/dra-driver-cpu/dra-driver-cpu # @schema required:true
   # -- Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time
   tag: ""
   # -- Image pull policy


### PR DESCRIPTION
The default registries are  pointing to the staging registry `us-central1-docker.pkg.dev/k8s-staging-images.` We should instead advertise the production registry `registry.k8s.io` so that users pull from the canonical location by default.