### PR TITLE
chore: apply modernize analysis improvements

### DIFF
--- a/internal/ctxlog/ctxlog.go
+++ b/internal/ctxlog/ctxlog.go
@@ -109,7 +109,7 @@ func (ref ObjectRef) String() string {
 }
 
 // MarshalLog implements logr.Marshaler.
-func (ref ObjectRef) MarshalLog() interface{} {
+func (ref ObjectRef) MarshalLog() any {
 	return ref
 }
 

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -337,8 +337,8 @@ func populateTopologyInfo(cpuInfo *CPUInfo, logger logr.Logger) error {
 
 	foundNode := false
 	for _, file := range files {
-		if strings.HasPrefix(file.Name(), "node") {
-			nodeID, err := strconv.Atoi(strings.TrimPrefix(file.Name(), "node"))
+		if after, ok := strings.CutPrefix(file.Name(), "node"); ok {
+			nodeID, err := strconv.Atoi(after)
 			if err != nil {
 				logger.V(2).Info("could not parse sysfs data for NUMA node ID", "entry", file.Name(), "err", err)
 				continue

--- a/pkg/device/attributes.go
+++ b/pkg/device/attributes.go
@@ -18,12 +18,11 @@ package device
 
 import (
 	resourceapi "k8s.io/api/resource/v1"
-	"k8s.io/utils/ptr"
 )
 
 // SetCompatibilityAttributes add attributes to enable compatibility (e.g. alignment) with other
 // DRA resource drivers leveraging attributes which are not kubernetes standard.
 // This is the "staging area" which enables attribute sharing until (or before) they become standard.
 func SetCompatibilityAttributes(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaID int64) {
-	attrs["dra.net/numaNode"] = resourceapi.DeviceAttribute{IntValue: ptr.To(numaID)}
+	attrs["dra.net/numaNode"] = resourceapi.DeviceAttribute{IntValue: new(numaID)}
 }

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/utils/cpuset"
-	"k8s.io/utils/ptr"
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
 )
 
@@ -212,9 +211,9 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resour
 		switch cp.cpuDeviceGroupBy {
 		case GROUP_BY_SOCKET:
 			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttributeSocketID:   {IntValue: ptr.To(int64(deviceInfo.socketID))},
-				AttributeNumCPUs:    {IntValue: ptr.To(availableCPUs)},
-				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
+				AttributeSocketID:   {IntValue: new(int64(deviceInfo.socketID))},
+				AttributeNumCPUs:    {IntValue: new(availableCPUs)},
+				AttributeSMTEnabled: {BoolValue: new(cp.cpuTopology.SMTEnabled)},
 			}
 			cp.setPCIeRootsAttribute(deviceAttrs, deviceInfo.cpus.UnsortedList()...)
 
@@ -222,14 +221,14 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resour
 				Name:                     deviceInfo.name,
 				Attributes:               deviceAttrs,
 				Capacity:                 deviceCapacity,
-				AllowMultipleAllocations: ptr.To(true),
+				AllowMultipleAllocations: new(true),
 			})
 		case GROUP_BY_NUMA_NODE:
 			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttributeNUMANodeID: {IntValue: ptr.To(int64(deviceInfo.numaNodeID))},
-				AttributeSocketID:   {IntValue: ptr.To(int64(deviceInfo.socketID))},
-				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
-				AttributeNumCPUs:    {IntValue: ptr.To(availableCPUs)},
+				AttributeNUMANodeID: {IntValue: new(int64(deviceInfo.numaNodeID))},
+				AttributeSocketID:   {IntValue: new(int64(deviceInfo.socketID))},
+				AttributeSMTEnabled: {BoolValue: new(cp.cpuTopology.SMTEnabled)},
+				AttributeNumCPUs:    {IntValue: new(availableCPUs)},
 			}
 			device.SetCompatibilityAttributes(deviceAttrs, int64(deviceInfo.numaNodeID))
 			cp.setPCIeRootsAttribute(deviceAttrs, deviceInfo.cpus.UnsortedList()...)
@@ -238,19 +237,19 @@ func (cp *CPUDriver) createGroupedCPUDeviceSlices(logger logr.Logger) [][]resour
 				Name:                     deviceInfo.name,
 				Attributes:               deviceAttrs,
 				Capacity:                 deviceCapacity,
-				AllowMultipleAllocations: ptr.To(true),
+				AllowMultipleAllocations: new(true),
 			})
 		case GROUP_BY_MACHINE:
 			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
-				AttributeNumCPUs:    {IntValue: ptr.To(availableCPUs)},
+				AttributeSMTEnabled: {BoolValue: new(cp.cpuTopology.SMTEnabled)},
+				AttributeNumCPUs:    {IntValue: new(availableCPUs)},
 			}
 			cp.setPCIeRootsAttribute(deviceAttrs, deviceInfo.cpus.UnsortedList()...)
 			devices = append(devices, resourceapi.Device{
 				Name:                     deviceInfo.name,
 				Attributes:               deviceAttrs,
 				Capacity:                 deviceCapacity,
-				AllowMultipleAllocations: ptr.To(true),
+				AllowMultipleAllocations: new(true),
 			})
 		}
 	}
@@ -270,13 +269,13 @@ func (cp *CPUDriver) createCPUDeviceSlices() [][]resourceapi.Device {
 	for _, deviceInfo := range cp.cpuDeviceInfos() {
 		cpu := deviceInfo.cpu
 		deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-			AttributeNUMANodeID: {IntValue: ptr.To(int64(cpu.NUMANodeID))},
-			AttributeSocketID:   {IntValue: ptr.To(int64(cpu.SocketID))},
-			AttributeSMTEnabled: {BoolValue: ptr.To(cp.cpuTopology.SMTEnabled)},
-			AttributeCacheL3ID:  {IntValue: ptr.To(int64(cpu.UncoreCacheID))},
-			AttributeCoreType:   {StringValue: ptr.To(cpu.CoreType.String())},
-			AttributeCoreID:     {IntValue: ptr.To(int64(cpu.CoreID))},
-			AttributeCPUID:      {IntValue: ptr.To(int64(cpu.CpuID))},
+			AttributeNUMANodeID: {IntValue: new(int64(cpu.NUMANodeID))},
+			AttributeSocketID:   {IntValue: new(int64(cpu.SocketID))},
+			AttributeSMTEnabled: {BoolValue: new(cp.cpuTopology.SMTEnabled)},
+			AttributeCacheL3ID:  {IntValue: new(int64(cpu.UncoreCacheID))},
+			AttributeCoreType:   {StringValue: new(cpu.CoreType.String())},
+			AttributeCoreID:     {IntValue: new(int64(cpu.CoreID))},
+			AttributeCPUID:      {IntValue: new(int64(cpu.CpuID))},
 		}
 		device.SetCompatibilityAttributes(deviceAttrs, int64(cpu.NUMANodeID))
 		cp.setPCIeRootsAttribute(deviceAttrs, cpu.CpuID)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -250,7 +250,7 @@ type nriRunner interface {
 
 func runNRIPluginWithRetry(ctx context.Context, plugin nriRunner, maxAttempts int) error {
 	logger := ctxlog.FromContext(ctx)
-	for i := 0; i < maxAttempts; i++ {
+	for i := range maxAttempts {
 		err := plugin.Run(ctx)
 		if ctx.Err() != nil {
 			logger.Info("NRI plugin stopped", "reason", "context cancelled")

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -111,8 +111,8 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 		}
 		key, value := parts[0], parts[1]
 		var claimUID types.UID
-		if strings.HasPrefix(key, cdiEnvVarPrefix+"_") {
-			uidStr := strings.TrimPrefix(key, cdiEnvVarPrefix+"_")
+		if after, ok := strings.CutPrefix(key, cdiEnvVarPrefix+"_"); ok {
+			uidStr := after
 			claimUID = types.UID(uidStr)
 		} else {
 			continue

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -181,14 +181,8 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 
 				numCPUs := availableCPUs.Size()
 				// Ensure at least 1 CPU is available for the shared pool
-				maxExclusiveCpus := numCPUs - 1
-				if maxExclusiveCpus < 0 {
-					maxExclusiveCpus = 0
-				}
-				numPods := maxExclusiveCpus / cpusPerClaim
-				if numPods > maxExclusivePods {
-					numPods = maxExclusivePods
-				}
+				maxExclusiveCpus := max(numCPUs-1, 0)
+				numPods := min(maxExclusiveCpus/cpusPerClaim, maxExclusivePods)
 
 				fxt.Log.Info("Creating pods requesting exclusive CPUs", "numPods", numPods, "cpusPerClaim", cpusPerClaim)
 				var exclPods []*v1.Pod
@@ -203,7 +197,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 					},
 				}
 				createdClaimTemplate, err := fxt.K8SClientset.ResourceV1().ResourceClaimTemplates(fxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
-				for i := 0; i < numPods; i++ {
+				for i := range numPods {
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 					pod := makeTesterPodWithExclusiveCPUClaim(fxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, int64(cpusPerClaim), targetNode.Name)
 					createdPod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, pod)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
-	"k8s.io/utils/ptr"
 )
 
 func TestE2E(t *testing.T) {
@@ -178,7 +177,7 @@ func makeTesterPodWithExclusiveCPUClaim(ns, image, cpuClaimTemplateName string, 
 			ResourceClaims: []v1.PodResourceClaim{
 				{
 					Name:                      "tester-container-1-claim",
-					ResourceClaimTemplateName: ptr.To(cpuClaimTemplateName),
+					ResourceClaimTemplateName: new(cpuClaimTemplateName),
 				},
 			},
 			RestartPolicy: v1.RestartPolicyAlways,
@@ -221,8 +220,8 @@ func mustCreateBestEffortPod(ctx context.Context, fxt *fixture.Fixture, nodeName
 
 func findArgInContainer(container *v1.Container, prefix string) (string, bool) {
 	for _, arg := range container.Args {
-		if strings.HasPrefix(arg, prefix) {
-			return strings.TrimPrefix(arg, prefix), true
+		if after, ok := strings.CutPrefix(arg, prefix); ok {
+			return after, true
 		}
 	}
 	return "", false
@@ -263,7 +262,7 @@ func makeTesterPodWithNamedClaim(ns, image, claimName string, nodeName string) *
 			ResourceClaims: []v1.PodResourceClaim{
 				{
 					Name:              "cpu-claim",
-					ResourceClaimName: ptr.To(claimName),
+					ResourceClaimName: new(claimName),
 				},
 			},
 			RestartPolicy: v1.RestartPolicyAlways,

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/cpuset"
-	"k8s.io/utils/ptr"
 )
 
 var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
@@ -170,7 +169,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 					ResourceClaims: []v1.PodResourceClaim{
 						{
 							Name:              "cpu",
-							ResourceClaimName: ptr.To(claim.Name),
+							ResourceClaimName: new(claim.Name),
 						},
 					},
 				},
@@ -232,7 +231,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 					ResourceClaims: []v1.PodResourceClaim{
 						{
 							Name:              "cpu",
-							ResourceClaimName: ptr.To(claim.Name),
+							ResourceClaimName: new(claim.Name),
 						},
 					},
 				},

--- a/test/image/dracputester/app.go
+++ b/test/image/dracputester/app.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2025 The Kubernetes Authors.
 

--- a/test/image/dracputester/app_test.go
+++ b/test/image/dracputester/app_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2025 The Kubernetes Authors.
 

--- a/tools/gen-pcie-testdata/main.go
+++ b/tools/gen-pcie-testdata/main.go
@@ -189,7 +189,7 @@ func detectCPUModel() string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		name, value, ok := strings.Cut(line, ":")
 		if !ok {
 			continue


### PR DESCRIPTION
Apply modernize analysis improvements and skip dracputester files on non linux platforms to allow tools like modernize to run on macOS as well.