### PR TITLE
chore: add modernize target to run as an optional prow job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,9 @@ lint:  ## run the linter against the codebase
 modernize: ## run modernize to report suggested code modernizations
 	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@$(GOPLS_VERSION) -diff ./...
 
+modernize-fix: ## apply modernize suggestions
+	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@$(GOPLS_VERSION) -fix ./...
+
 # dependencies
 .PHONY: install-yq
 install-yq: $(OUT_DIR)  ## make sure the yq tool is available locally

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ GOLANGCI_LINT_VERSION ?= 2.12.2
 HELM_DOCS_VERSION ?= 1.14.2
 HELM_SCHEMA_VERSION ?= 2.3.1
 KIND_K8S_VERSION ?= v1.36.0
+GOPLS_VERSION ?= v0.22.0
 # paths
 YQ = $(OUT_DIR)/yq
 GOLANGCI_LINT = $(OUT_DIR)/golangci-lint
@@ -233,6 +234,9 @@ test-e2e-kind: ci-kind-setup test-e2e ## run e2e test against a purpose-built ki
 
 lint:  ## run the linter against the codebase
 	$(GOLANGCI_LINT) run ./... $(GOLANGCI_LINT_EXTRA_ARGS)
+
+modernize: ## run modernize to report suggested code modernizations
+	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@$(GOPLS_VERSION) -diff ./...
 
 # dependencies
 .PHONY: install-yq


### PR DESCRIPTION
As per request from @ffromani at https://github.com/kubernetes-sigs/dra-driver-cpu/pull/201#issuecomment-4796324377

Add non gating makefile target that reports modernization suggestions via `golang.org/x/tools/gopls` tool. The intention is to use it in an optional Prow job and also add modernize-fix target to fix suggested improvements.

The other part to this is https://github.com/kubernetes/test-infra/pull/37330. The idea is that Prow job will show the diff (if there is any) by failing but it should not block the Tide from merging the PR. In other words, we treat the job as a suggestion signal and not a blocker. 


