### PR TITLE
remove legacy install.yaml from release artifacts and update related documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,33 +166,17 @@ delete-kind-cluster: ## delete kind cluster
 dist:
 	@mkdir -p dist
 
-manifests-legacy: dist install-yq ## create the install manifest (legacy, pre-helm)
-	@cd dist && cp -a ../manifests/base/*.part.yaml .
-ifeq ($(OVERRIDE_IMAGE),true)
-	@$(YQ) -i '.spec.template.spec.containers[0].image = "${IMAGE}"' dist/daemonset-dracpu.part.yaml
-	@$(YQ) -i '.spec.template.spec.containers[0].imagePullPolicy = "IfNotPresent"' dist/daemonset-dracpu.part.yaml
-	@$(YQ) -i '.spec.template.metadata.labels["build"] = "${GIT_VERSION}"' dist/daemonset-dracpu.part.yaml
-endif
-	@$(YQ) '.' \
-		dist/clusterrole-dracpu.part.yaml \
-		dist/serviceaccount-dracpu.part.yaml \
-		dist/clusterrolebinding-dracpu.part.yaml \
-		dist/daemonset-dracpu.part.yaml \
-		dist/deviceclass-dracpu.part.yaml \
-		> dist/install.yaml
-	@rm dist/*.part.yaml
-
-manifests: dist install-helm ## create the install manifest
+manifests: dist install-helm ## create rendered helm manifest
 ifeq ($(OVERRIDE_IMAGE),true)
 	$(HELM) template dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
 		--set podLabels.build=${GIT_VERSION} \
 		--set image.repository=${IMAGE_REPO} \
 		--set image.tag=${TAG} \
 		--set image.pullPolicy=IfNotPresent \
-		> dist/install.yaml
+		> dist/helm-manifest.yaml
 else
 	$(HELM) template dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \
-		> dist/install.yaml
+		> dist/helm-manifest.yaml
 endif
 
 ci-kind-setup: ensure-kind-node-image install-helm build-image build-test-image ## setup a CI cluster from scratch using reserved CPUs

--- a/README.md
+++ b/README.md
@@ -446,14 +446,14 @@ helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driv
 
 See the [Helm chart README](deployment/helm/dra-driver-cpu/README.md) for the full list of configuration options.
 
-#### Installation via install.yaml (deprecated)
+#### Installation via rendered manifest (deprecated)
 
-> **Deprecated:** `install.yaml` is deprecated in favor of the Helm chart and will be removed in a future release.
+> **Deprecated:** Manifest-based installation is deprecated in favor of the Helm chart and will be removed in a future release.
 > New users should use the Helm-based installation above.
 
 ```bash
 make manifests
-kubectl apply -f dist/install.yaml
+kubectl apply -f dist/helm-manifest.yaml
 ```
 
 ### Migrating from install.yaml to Helm
@@ -463,8 +463,9 @@ Because the DaemonSet label selectors differ between `install.yaml` (`app: dracp
 in-place migration is not possible. The only practical migration path is a delete and reinstall:
 
 ```bash
-# Step 1: remove the install.yaml-managed resources
-kubectl delete -f dist/install.yaml
+# Step 1: remove the legacy manifest-managed resources
+# (use the same manifest file that was originally applied)
+kubectl delete -f <legacy-manifest>.yaml
 
 # Step 2: install the Helm-managed release
 helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu -n kube-system

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,7 +74,7 @@ Before publishing the release, verify the images are available at k8s-registry:
   ```sh
   rm -rf ./dist
   REGISTRY=registry.k8s.io TAG=vX.Y.Z make manifests OVERRIDE_IMAGE=true
-  ls ./dist   # to confirm the generated artifacts
+  ls ./dist   # expect dist/helm-manifest.yaml
   ```
 - Run a local E2E test in Kind (see references in `README.md`) using the generated manifests from the `dist/` directory to ensure they pull the correct images and function as expected.
 
@@ -85,7 +85,7 @@ Before publishing the release, verify the images are available at k8s-registry:
 - Paste the final changelog into the release description.
 - Publish the release.
 
-**Note:** The project uses Helm charts for deployment. Release artifacts are automatically published to the Helm chart registry and should not include `install.yaml` manifests.
+**Note:** The project uses Helm charts for deployment. Release artifacts are automatically published to the Helm chart registry.
 
 ## 5. Post-Release Tasks
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,8 +83,9 @@ Before publishing the release, verify the images are available at k8s-registry:
 - Go to the [Releases page](https://github.com/kubernetes-sigs/dra-driver-cpu/releases) on GitHub.
 - Find the new tag and click "Edit tag" (or "Draft a new release" and select the tag).
 - Paste the final changelog into the release description.
-- Upload the generated manifests (`dist/install.yaml`) as release artifacts.
 - Publish the release.
+
+**Note:** The project uses Helm charts for deployment. Release artifacts are automatically published to the Helm chart registry and should not include `install.yaml` manifests.
 
 ## 5. Post-Release Tasks
 


### PR DESCRIPTION
This PR removes `install.yaml` from the release process and legacy generation paths to reduce confusion and keep Helm as the preferred distribution method. Maintaining both Helm and `install.yaml` was confusing and risked drift. This change keeps the project focused on Helm and avoids stale legacy artifacts in release workflows.

Fixes:  #191 