### PR TITLE
Add PR and issue templates for dra-driver-cpu

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,77 @@
+---
+name: Bug Report
+about: Report a bug encountered while using DRA Driver CPU
+labels: kind/bug
+---
+
+<!--
+Please use this template while reporting a bug and provide as much info as possible.
+Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately via:
+https://kubernetes.io/security/
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Context / setup details**:
+
+<!--
+Describe the workload shape and any config that may affect driver behavior.
+For example: ResourceClaim type, pod/container resources, CDI/NRI settings,
+cpuManagerPolicy, cgroup version, etc.
+-->
+
+**Relevant logs or outputs**:
+
+<!--
+Please include relevant snippets from:
+- DRA driver logs
+- kubelet logs (if relevant)
+- container runtime logs (if relevant)
+- `kubectl describe pod`, `kubectl get resourceclaims`, etc.
+-->
+
+```text
+# paste logs/output here
+```
+
+**Question / what you want to verify**:
+
+<!--
+If you are unsure this is a bug, describe what behavior or configuration you
+want maintainers to validate.
+-->
+
+**Diagnostics (`dracpu-gatherinfo`)**:
+
+<!--
+Please run `dracpu-gatherinfo` from the affected driver pod and attach the output.
+Single node example:
+
+kubectl exec -n dra-driver-cpu <dracpu-pod> -- /dracpu-gatherinfo --stdout
+
+For multi-node issues, collect one report per affected node.
+For more details, see:
+https://github.com/kubernetes-sigs/dra-driver-cpu/blob/main/docs/gatherinfo.md
+-->
+
+```text
+# paste dracpu-gatherinfo output here
+```
+
+**Environment**:
+- DRA driver version/tag (image tag or commit SHA):
+- DRA driver mode (`grouped` or `individual`):
+- DRA grouped mode setting (`numanode` or `socket`, if applicable):
+- Container runtime and version (optional):
+- Kubernetes version (use `kubectl version`):
+- Cloud provider or hardware configuration:
+- OS (e.g. `cat /etc/os-release`):
+- Kernel (e.g. `uname -a`):
+- Network plugin and version (if this is a network-related bug):
+- Others:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to DRA Driver CPU
+labels: kind/feature
+---
+
+<!-- Please only use this template for submitting enhancement requests. -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!--
+Thanks for contributing to dra-driver-cpu.
+
+Please fill in the sections below so reviewers can quickly understand scope,
+risk, and validation. If a section does not apply, write "N/A".
+-->
+
+## What type of PR is this?
+
+<!-- Add one or more labels in the PR comments, for example:
+/kind bug
+/kind feature
+/kind documentation
+/kind cleanup
+/kind deprecation
+/kind regression
+-->
+
+## What this PR does / why we need it
+
+## Which issue(s) this PR is related to
+
+<!--
+Use "Fixes #<issue>" when applicable.
+For cross-repo issues, include the full URL.
+-->
+
+## Special notes for reviewers
+
+<!--
+Call out anything that is useful for review:
+- API or behavior changes
+- migration impact
+- compatibility concerns
+- follow-up work
+-->
+
+## Release note
+
+<!--
+If this change is not user-facing, write:
+NONE
+-->
+
+```release-note
+
+```
+
+## Documentation updates
+
+<!--
+List docs changed by this PR or write NONE.
+Example:
+- README updates
+- Helm chart docs
+- release process docs
+-->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: 0.7.22
     hooks:
       - id: mdformat
-        exclude: (\.chglog/.*|deployment/helm/.*)\.md
+        exclude: (\.chglog/.*|deployment/helm/.*|\.github/ISSUE_TEMPLATE/.*)\.md
         additional_dependencies:
           - mdformat-toc
           - mdformat-tables


### PR DESCRIPTION
This PR adds contribution templates under `.github/` to standardize how changes and issues are proposed in `dra-driver-cpu`. Issue and PR quality currently varies by submitter, which slows triage and review. These templates provide a lightweight, consistent structure while still following Kubernetes SIG conventions where useful.

Fixes: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/208
