### PR TITLE
use exact CPUDetails queries for asymmetric topology

### DIFF
--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -330,8 +330,8 @@ func populateTopologyInfo(cpuInfo *CPUInfo, logger logr.Logger) error {
 
 	foundNode := false
 	for _, file := range files {
-		if strings.HasPrefix(file.Name(), "node") {
-			nodeID, err := strconv.Atoi(strings.TrimPrefix(file.Name(), "node"))
+		if nodeName, ok := strings.CutPrefix(file.Name(), "node"); ok {
+			nodeID, err := strconv.Atoi(nodeName)
 			if err != nil {
 				logger.V(2).Info("could not parse sysfs data for NUMA node ID", "entry", file.Name(), "err", err)
 				continue

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -163,12 +163,7 @@ func (s *SystemCPUInfo) GetCPUTopology(logger logr.Logger) (*CPUTopology, error)
 	cpuDetails := make(CPUDetails)
 	sockets := sets.NewInt()
 	numaNodes := sets.NewInt()
-	type coreIdent struct {
-		SocketID  int
-		ClusterID int
-		CoreID    int
-	}
-	cores := sets.New[coreIdent]()
+	cores := sets.New[CoreKey]()
 	uncoreCaches := sets.NewInt()
 
 	for i := range cpuInfos {
@@ -176,9 +171,7 @@ func (s *SystemCPUInfo) GetCPUTopology(logger logr.Logger) (*CPUTopology, error)
 		cpuDetails[info.CpuID] = info
 		sockets.Insert(info.SocketID)
 		numaNodes.Insert(info.NUMANodeID)
-		// A core is unique by socket, cluster, and core id
-		coreKey := coreIdent{SocketID: info.SocketID, ClusterID: info.ClusterID, CoreID: info.CoreID}
-		cores.Insert(coreKey)
+		cores.Insert(info.CoreKey())
 		if info.UncoreCacheID != -1 {
 			uncoreCaches.Insert(info.UncoreCacheID)
 		}
@@ -431,17 +424,10 @@ func populateTopologyInfo(cpuInfo *CPUInfo, logger logr.Logger) error {
 
 // TODO: Handle more complex sibling relationships (e.g. 4-way SMT) if needed in the future. For now we only handle 2-way hyperthreading which is the most common case.
 func populateCpuSiblings(cpuInfos []CPUInfo) {
-	// Define a key struct to identify a unique physical core.
-	type coreLocation struct {
-		socket  int
-		cluster int
-		core    int
-	}
-
 	// Map each physical core to the list of logical CPUs (siblings) on it.
-	coreToCPU := make(map[coreLocation][]int)
+	coreToCPU := make(map[CoreKey][]int)
 	for _, info := range cpuInfos {
-		key := coreLocation{socket: info.SocketID, cluster: info.ClusterID, core: info.CoreID}
+		key := info.CoreKey()
 		coreToCPU[key] = append(coreToCPU[key], info.CpuID)
 	}
 
@@ -518,9 +504,9 @@ func combinePath(value string, combineWith ...string) string {
 	}
 }
 
-// TODO: Refactor topology representation to handle asymmetric CPU distributions.
-// The current funcs CPUsPerCore, CPUsPerSocket, CPUsPerUncore assume symmetry
-// and would be inaccurate if CPUs are offlined asymmetrically or on heterogeneous systems.
+// These helpers assume symmetric CPU distributions. Allocation code should
+// prefer exact CPUDetails queries because CPUs can be offlined asymmetrically
+// or grouped unevenly on heterogeneous systems.
 // See https://github.com/kubernetes-sigs/dra-driver-cpu/pull/16#discussion_r2588301122
 func (t *CPUTopology) CPUsPerCore() int {
 	if t.NumCores == 0 {

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cpuinfo
 
 import (
+	"fmt"
 	"sort"
 
 	"k8s.io/utils/cpuset"
@@ -48,6 +49,10 @@ func (k CoreKey) Less(other CoreKey) bool {
 		return k.SocketID < other.SocketID
 	}
 	return k.ClusterID < other.ClusterID
+}
+
+func (k CoreKey) String() string {
+	return fmt.Sprintf("socket=%d,cluster=%d,core=%d", k.SocketID, k.ClusterID, k.CoreID)
 }
 
 func (i CPUInfo) CoreKey() CoreKey {

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -18,6 +18,7 @@ package cpuinfo
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 
 	"k8s.io/utils/cpuset"
@@ -222,12 +223,7 @@ func (d CPUDetails) CoresInSockets(ids ...int) cpuset.CPUSet {
 // socket IDs.
 func (d CPUDetails) CoreKeysInSockets(ids ...int) []CoreKey {
 	return d.coreKeysFor(func(info CPUInfo) bool {
-		for _, id := range ids {
-			if info.SocketID == id {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(ids, info.SocketID)
 	})
 }
 
@@ -263,12 +259,7 @@ func (d CPUDetails) CoresInNUMANodes(ids ...int) cpuset.CPUSet {
 // NUMA node IDs.
 func (d CPUDetails) CoreKeysInNUMANodes(ids ...int) []CoreKey {
 	return d.coreKeysFor(func(info CPUInfo) bool {
-		for _, id := range ids {
-			if info.NUMANodeID == id {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(ids, info.NUMANodeID)
 	})
 }
 
@@ -311,12 +302,7 @@ func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
 
 func (d CPUDetails) coreKeysInUncoreCache(ids ...int) []CoreKey {
 	return d.coreKeysFor(func(info CPUInfo) bool {
-		for _, id := range ids {
-			if info.UncoreCacheID == id {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(ids, info.UncoreCacheID)
 	})
 }
 

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -17,6 +17,10 @@ limitations under the License.
 package cpuinfo
 
 import (
+	"fmt"
+	"slices"
+	"sort"
+
 	"k8s.io/utils/cpuset"
 )
 
@@ -28,6 +32,41 @@ import (
 
 // CPUDetails is a map from CPU ID to Core ID, Socket ID, and NUMA ID.
 type CPUDetails map[int]CPUInfo
+
+// CoreKey identifies a physical core within the topology. CoreID alone is not
+// globally unique on all systems, so callers that need core-level precision
+// should use this key instead of the raw CoreID.
+type CoreKey struct {
+	SocketID  int
+	ClusterID int
+	CoreID    int
+}
+
+// Less provides a deterministic tie-breaker for sorted CoreKey slices. The
+// ordering is CoreID-first to stay aligned with the existing CPUManager-style
+// traversal, where callers already group by socket or NUMA before ordering
+// cores.
+func (k CoreKey) Less(other CoreKey) bool {
+	if k.CoreID != other.CoreID {
+		return k.CoreID < other.CoreID
+	}
+	if k.SocketID != other.SocketID {
+		return k.SocketID < other.SocketID
+	}
+	return k.ClusterID < other.ClusterID
+}
+
+func (k CoreKey) String() string {
+	return fmt.Sprintf("socket=%d,cluster=%d,core=%d", k.SocketID, k.ClusterID, k.CoreID)
+}
+
+func (i CPUInfo) CoreKey() CoreKey {
+	return CoreKey{
+		SocketID:  i.SocketID,
+		ClusterID: i.ClusterID,
+		CoreID:    i.CoreID,
+	}
+}
 
 func (d CPUDetails) KeepOnly(cpus cpuset.CPUSet) CPUDetails {
 	result := CPUDetails{}
@@ -66,13 +105,27 @@ func (d CPUDetails) CPUsInNUMANodes(ids ...int) cpuset.CPUSet {
 // core IDs in this CPUDetails.
 // TODO: CoreID is only unique within a socket. On multi-socket systems where CoreIDs repeat
 // across sockets, this method may return CPUs from multiple sockets for the same CoreID.
-// Consider refactoring core-level methods to use CoreKey{SocketID, CoreID} for correct
+// Consider refactoring core-level methods to use CoreKey{SocketID, ClusterID, CoreID} for correct
 // disambiguation, similar to CPUTopology.CPUsByCore.
 func (d CPUDetails) CPUsInCores(ids ...int) cpuset.CPUSet {
 	var cpuIDs []int
 	for _, id := range ids {
 		for cpu, info := range d {
 			if info.CoreID == id {
+				cpuIDs = append(cpuIDs, cpu)
+			}
+		}
+	}
+	return cpuset.New(cpuIDs...)
+}
+
+// CPUsInCoreKeys returns all logical CPUs associated with the given physical
+// core keys.
+func (d CPUDetails) CPUsInCoreKeys(keys ...CoreKey) cpuset.CPUSet {
+	var cpuIDs []int
+	for _, key := range keys {
+		for cpu, info := range d {
+			if info.CoreKey() == key {
 				cpuIDs = append(cpuIDs, cpu)
 			}
 		}
@@ -170,6 +223,14 @@ func (d CPUDetails) CoresInSockets(ids ...int) cpuset.CPUSet {
 	return cpuset.New(coreIDs...)
 }
 
+// CoreKeysInSockets returns all physical core keys associated with the given
+// socket IDs.
+func (d CPUDetails) CoreKeysInSockets(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		return slices.Contains(ids, info.SocketID)
+	})
+}
+
 // NUMANodesInSockets returns all of the logical NUMANode IDs associated with
 // the given socket IDs in this CPUDetails.
 func (d CPUDetails) NUMANodesInSockets(ids ...int) cpuset.CPUSet {
@@ -198,6 +259,14 @@ func (d CPUDetails) CoresInNUMANodes(ids ...int) cpuset.CPUSet {
 	return cpuset.New(coreIDs...)
 }
 
+// CoreKeysInNUMANodes returns all physical core keys associated with the given
+// NUMA node IDs.
+func (d CPUDetails) CoreKeysInNUMANodes(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		return slices.Contains(ids, info.NUMANodeID)
+	})
+}
+
 // CoresNeededInUncoreCache returns either the full list of all available unique core IDs associated with the given
 // UnCoreCache IDs in this CPUDetails or subset that matches the ask.
 func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpuset.CPUSet {
@@ -207,6 +276,21 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 	}
 	tmpCoreIDs := coreIDs.List()
 	return cpuset.New(tmpCoreIDs[:numCoresNeeded]...)
+}
+
+// CoreKeysNeededForCPUsInUncoreCache returns the ordered prefix of core keys
+// from the given UncoreCache IDs whose CPUs first satisfy numCPUsNeeded. This
+// is a deterministic best-effort heuristic, not a search for the globally
+// smallest-cardinality subset of cores.
+func (d CPUDetails) CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded int, ids ...int) []CoreKey {
+	var result []CoreKey
+	for _, key := range d.coreKeysInUncoreCache(ids...) {
+		result = append(result, key)
+		if d.CPUsInCoreKeys(result...).Size() >= numCPUsNeeded {
+			return result
+		}
+	}
+	return result
 }
 
 // Helper function that just gets the cores
@@ -220,4 +304,28 @@ func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
 		}
 	}
 	return cpuset.New(coreIDs...)
+}
+
+func (d CPUDetails) coreKeysInUncoreCache(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		return slices.Contains(ids, info.UncoreCacheID)
+	})
+}
+
+func (d CPUDetails) coreKeysFor(include func(CPUInfo) bool) []CoreKey {
+	seen := map[CoreKey]struct{}{}
+	for _, info := range d {
+		if include(info) {
+			seen[info.CoreKey()] = struct{}{}
+		}
+	}
+
+	coreKeys := make([]CoreKey, 0, len(seen))
+	for key := range seen {
+		coreKeys = append(coreKeys, key)
+	}
+	sort.Slice(coreKeys, func(i, j int) bool {
+		return coreKeys[i].Less(coreKeys[j])
+	})
+	return coreKeys
 }

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cpuinfo
 
 import (
+	"sort"
+
 	"k8s.io/utils/cpuset"
 )
 
@@ -28,6 +30,33 @@ import (
 
 // CPUDetails is a map from CPU ID to Core ID, Socket ID, and NUMA ID.
 type CPUDetails map[int]CPUInfo
+
+// CoreKey identifies a physical core within the topology. CoreID alone is not
+// globally unique on all systems, so callers that need core-level precision
+// should use this key instead of the raw CoreID.
+type CoreKey struct {
+	SocketID  int
+	ClusterID int
+	CoreID    int
+}
+
+func (k CoreKey) Less(other CoreKey) bool {
+	if k.CoreID != other.CoreID {
+		return k.CoreID < other.CoreID
+	}
+	if k.SocketID != other.SocketID {
+		return k.SocketID < other.SocketID
+	}
+	return k.ClusterID < other.ClusterID
+}
+
+func (i CPUInfo) CoreKey() CoreKey {
+	return CoreKey{
+		SocketID:  i.SocketID,
+		ClusterID: i.ClusterID,
+		CoreID:    i.CoreID,
+	}
+}
 
 func (d CPUDetails) KeepOnly(cpus cpuset.CPUSet) CPUDetails {
 	result := CPUDetails{}
@@ -66,13 +95,27 @@ func (d CPUDetails) CPUsInNUMANodes(ids ...int) cpuset.CPUSet {
 // core IDs in this CPUDetails.
 // TODO: CoreID is only unique within a socket. On multi-socket systems where CoreIDs repeat
 // across sockets, this method may return CPUs from multiple sockets for the same CoreID.
-// Consider refactoring core-level methods to use CoreKey{SocketID, CoreID} for correct
+// Consider refactoring core-level methods to use CoreKey{SocketID, ClusterID, CoreID} for correct
 // disambiguation, similar to CPUTopology.CPUsByCore.
 func (d CPUDetails) CPUsInCores(ids ...int) cpuset.CPUSet {
 	var cpuIDs []int
 	for _, id := range ids {
 		for cpu, info := range d {
 			if info.CoreID == id {
+				cpuIDs = append(cpuIDs, cpu)
+			}
+		}
+	}
+	return cpuset.New(cpuIDs...)
+}
+
+// CPUsInCoreKeys returns all logical CPUs associated with the given physical
+// core keys.
+func (d CPUDetails) CPUsInCoreKeys(keys ...CoreKey) cpuset.CPUSet {
+	var cpuIDs []int
+	for _, key := range keys {
+		for cpu, info := range d {
+			if info.CoreKey() == key {
 				cpuIDs = append(cpuIDs, cpu)
 			}
 		}
@@ -170,6 +213,19 @@ func (d CPUDetails) CoresInSockets(ids ...int) cpuset.CPUSet {
 	return cpuset.New(coreIDs...)
 }
 
+// CoreKeysInSockets returns all physical core keys associated with the given
+// socket IDs.
+func (d CPUDetails) CoreKeysInSockets(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		for _, id := range ids {
+			if info.SocketID == id {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 // NUMANodesInSockets returns all of the logical NUMANode IDs associated with
 // the given socket IDs in this CPUDetails.
 func (d CPUDetails) NUMANodesInSockets(ids ...int) cpuset.CPUSet {
@@ -198,6 +254,19 @@ func (d CPUDetails) CoresInNUMANodes(ids ...int) cpuset.CPUSet {
 	return cpuset.New(coreIDs...)
 }
 
+// CoreKeysInNUMANodes returns all physical core keys associated with the given
+// NUMA node IDs.
+func (d CPUDetails) CoreKeysInNUMANodes(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		for _, id := range ids {
+			if info.NUMANodeID == id {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 // CoresNeededInUncoreCache returns either the full list of all available unique core IDs associated with the given
 // UnCoreCache IDs in this CPUDetails or subset that matches the ask.
 func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpuset.CPUSet {
@@ -207,6 +276,19 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 	}
 	tmpCoreIDs := coreIDs.List()
 	return cpuset.New(tmpCoreIDs[:numCoresNeeded]...)
+}
+
+// CoreKeysNeededForCPUsInUncoreCache returns the smallest ordered set of core
+// keys from the given UncoreCache IDs whose CPUs can satisfy numCPUsNeeded.
+func (d CPUDetails) CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded int, ids ...int) []CoreKey {
+	var result []CoreKey
+	for _, key := range d.coreKeysInUncoreCache(ids...) {
+		result = append(result, key)
+		if d.CPUsInCoreKeys(result...).Size() >= numCPUsNeeded {
+			return result
+		}
+	}
+	return result
 }
 
 // Helper function that just gets the cores
@@ -220,4 +302,33 @@ func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
 		}
 	}
 	return cpuset.New(coreIDs...)
+}
+
+func (d CPUDetails) coreKeysInUncoreCache(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		for _, id := range ids {
+			if info.UncoreCacheID == id {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (d CPUDetails) coreKeysFor(include func(CPUInfo) bool) []CoreKey {
+	seen := map[CoreKey]struct{}{}
+	for _, info := range d {
+		if include(info) {
+			seen[info.CoreKey()] = struct{}{}
+		}
+	}
+
+	coreKeys := make([]CoreKey, 0, len(seen))
+	for key := range seen {
+		coreKeys = append(coreKeys, key)
+	}
+	sort.Slice(coreKeys, func(i, j int) bool {
+		return coreKeys[i].Less(coreKeys[j])
+	})
+	return coreKeys
 }

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -42,6 +42,10 @@ type CoreKey struct {
 	CoreID    int
 }
 
+// Less provides a deterministic tie-breaker for sorted CoreKey slices. The
+// ordering is CoreID-first to stay aligned with the existing CPUManager-style
+// traversal, where callers already group by socket or NUMA before ordering
+// cores.
 func (k CoreKey) Less(other CoreKey) bool {
 	if k.CoreID != other.CoreID {
 		return k.CoreID < other.CoreID
@@ -274,8 +278,10 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 	return cpuset.New(tmpCoreIDs[:numCoresNeeded]...)
 }
 
-// CoreKeysNeededForCPUsInUncoreCache returns the smallest ordered set of core
-// keys from the given UncoreCache IDs whose CPUs can satisfy numCPUsNeeded.
+// CoreKeysNeededForCPUsInUncoreCache returns the ordered prefix of core keys
+// from the given UncoreCache IDs whose CPUs first satisfy numCPUsNeeded. This
+// is a deterministic best-effort heuristic, not a search for the globally
+// smallest-cardinality subset of cores.
 func (d CPUDetails) CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded int, ids ...int) []CoreKey {
 	var result []CoreKey
 	for _, key := range d.coreKeysInUncoreCache(ids...) {

--- a/pkg/cpuinfo/cpuinfo_utils_test.go
+++ b/pkg/cpuinfo/cpuinfo_utils_test.go
@@ -118,6 +118,20 @@ func TestCoreKeyString(t *testing.T) {
 	}))
 }
 
+func TestCoreKeyLess(t *testing.T) {
+	left := CoreKey{SocketID: 1, ClusterID: 1, CoreID: 2}
+	right := CoreKey{SocketID: 0, ClusterID: 0, CoreID: 3}
+	assert.True(t, left.Less(right), "CoreID should take precedence over socket/cluster ordering")
+
+	left = CoreKey{SocketID: 0, ClusterID: 1, CoreID: 2}
+	right = CoreKey{SocketID: 1, ClusterID: 0, CoreID: 2}
+	assert.True(t, left.Less(right), "SocketID should break ties before ClusterID")
+
+	left = CoreKey{SocketID: 0, ClusterID: 0, CoreID: 2}
+	right = CoreKey{SocketID: 0, ClusterID: 1, CoreID: 2}
+	assert.True(t, left.Less(right), "ClusterID should break ties when core and socket match")
+}
+
 func TestCPUsInSockets(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1, 2, 3).Equals(testCPUDetails.CPUsInSockets(0)))
 	assert.True(t, cpuset.New(4, 5, 6, 7).Equals(testCPUDetails.CPUsInSockets(1)))
@@ -194,4 +208,20 @@ func TestCoreKeysNeededForCPUsInUncoreCache(t *testing.T) {
 		{SocketID: 0, ClusterID: 0, CoreID: 0},
 		{SocketID: 1, ClusterID: 0, CoreID: 0},
 	}, details.CoreKeysNeededForCPUsInUncoreCache(3, 0))
+}
+
+func TestCoreKeysNeededForCPUsInUncoreCacheUsesOrderedPrefix(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 1, UncoreCacheID: 0},
+		2: {CpuID: 2, SocketID: 0, ClusterID: 0, CoreID: 1, UncoreCacheID: 0},
+	}
+
+	// The helper intentionally returns the first ordered prefix whose CPUs satisfy
+	// the request. It does not search for the globally smallest-cardinality subset
+	// of cores.
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 0, ClusterID: 0, CoreID: 1},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(2, 0))
 }

--- a/pkg/cpuinfo/cpuinfo_utils_test.go
+++ b/pkg/cpuinfo/cpuinfo_utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cpuinfo
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -95,6 +96,42 @@ func TestCPUsInCores(t *testing.T) {
 	assert.True(t, cpuset.New().Equals(testCPUDetails.CPUsInCores(10)))
 }
 
+func TestCPUsInCoreKeys(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 0},
+		2: {CpuID: 2, SocketID: 1, ClusterID: 0, CoreID: 0},
+		3: {CpuID: 3, SocketID: 1, ClusterID: 0, CoreID: 0},
+		4: {CpuID: 4, SocketID: 1, ClusterID: 1, CoreID: 0},
+	}
+
+	assert.True(t, cpuset.New(0, 1).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 0, ClusterID: 0, CoreID: 0})))
+	assert.True(t, cpuset.New(2, 3).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 0, CoreID: 0})))
+	assert.True(t, cpuset.New(4).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 1, CoreID: 0})))
+}
+
+func TestCoreKeyString(t *testing.T) {
+	assert.Equal(t, "socket=1,cluster=2,core=3", fmt.Sprint(CoreKey{
+		SocketID:  1,
+		ClusterID: 2,
+		CoreID:    3,
+	}))
+}
+
+func TestCoreKeyLess(t *testing.T) {
+	left := CoreKey{SocketID: 1, ClusterID: 1, CoreID: 2}
+	right := CoreKey{SocketID: 0, ClusterID: 0, CoreID: 3}
+	assert.True(t, left.Less(right), "CoreID should take precedence over socket/cluster ordering")
+
+	left = CoreKey{SocketID: 0, ClusterID: 1, CoreID: 2}
+	right = CoreKey{SocketID: 1, ClusterID: 0, CoreID: 2}
+	assert.True(t, left.Less(right), "SocketID should break ties before ClusterID")
+
+	left = CoreKey{SocketID: 0, ClusterID: 0, CoreID: 2}
+	right = CoreKey{SocketID: 0, ClusterID: 1, CoreID: 2}
+	assert.True(t, left.Less(right), "ClusterID should break ties when core and socket match")
+}
+
 func TestCPUsInSockets(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1, 2, 3).Equals(testCPUDetails.CPUsInSockets(0)))
 	assert.True(t, cpuset.New(4, 5, 6, 7).Equals(testCPUDetails.CPUsInSockets(1)))
@@ -154,4 +191,37 @@ func TestCoresInUncoreCache(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1).Equals(testCPUDetails.coresInUncoreCache(0)))
 	assert.True(t, cpuset.New(2, 3).Equals(testCPUDetails.coresInUncoreCache(1)))
 	assert.True(t, cpuset.New().Equals(testCPUDetails.coresInUncoreCache(2)))
+}
+
+func TestCoreKeysNeededForCPUsInUncoreCache(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		2: {CpuID: 2, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		3: {CpuID: 3, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+	}
+
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(1, 0))
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(3, 0))
+}
+
+func TestCoreKeysNeededForCPUsInUncoreCacheUsesOrderedPrefix(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 1, UncoreCacheID: 0},
+		2: {CpuID: 2, SocketID: 0, ClusterID: 0, CoreID: 1, UncoreCacheID: 0},
+	}
+
+	// The helper intentionally returns the first ordered prefix whose CPUs satisfy
+	// the request. It does not search for the globally smallest-cardinality subset
+	// of cores.
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 0, ClusterID: 0, CoreID: 1},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(2, 0))
 }

--- a/pkg/cpuinfo/cpuinfo_utils_test.go
+++ b/pkg/cpuinfo/cpuinfo_utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cpuinfo
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -107,6 +108,14 @@ func TestCPUsInCoreKeys(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 0, ClusterID: 0, CoreID: 0})))
 	assert.True(t, cpuset.New(2, 3).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 0, CoreID: 0})))
 	assert.True(t, cpuset.New(4).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 1, CoreID: 0})))
+}
+
+func TestCoreKeyString(t *testing.T) {
+	assert.Equal(t, "socket=1,cluster=2,core=3", fmt.Sprint(CoreKey{
+		SocketID:  1,
+		ClusterID: 2,
+		CoreID:    3,
+	}))
 }
 
 func TestCPUsInSockets(t *testing.T) {

--- a/pkg/cpuinfo/cpuinfo_utils_test.go
+++ b/pkg/cpuinfo/cpuinfo_utils_test.go
@@ -95,6 +95,20 @@ func TestCPUsInCores(t *testing.T) {
 	assert.True(t, cpuset.New().Equals(testCPUDetails.CPUsInCores(10)))
 }
 
+func TestCPUsInCoreKeys(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 0},
+		2: {CpuID: 2, SocketID: 1, ClusterID: 0, CoreID: 0},
+		3: {CpuID: 3, SocketID: 1, ClusterID: 0, CoreID: 0},
+		4: {CpuID: 4, SocketID: 1, ClusterID: 1, CoreID: 0},
+	}
+
+	assert.True(t, cpuset.New(0, 1).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 0, ClusterID: 0, CoreID: 0})))
+	assert.True(t, cpuset.New(2, 3).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 0, CoreID: 0})))
+	assert.True(t, cpuset.New(4).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 1, CoreID: 0})))
+}
+
 func TestCPUsInSockets(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1, 2, 3).Equals(testCPUDetails.CPUsInSockets(0)))
 	assert.True(t, cpuset.New(4, 5, 6, 7).Equals(testCPUDetails.CPUsInSockets(1)))
@@ -154,4 +168,21 @@ func TestCoresInUncoreCache(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1).Equals(testCPUDetails.coresInUncoreCache(0)))
 	assert.True(t, cpuset.New(2, 3).Equals(testCPUDetails.coresInUncoreCache(1)))
 	assert.True(t, cpuset.New().Equals(testCPUDetails.coresInUncoreCache(2)))
+}
+
+func TestCoreKeysNeededForCPUsInUncoreCache(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		2: {CpuID: 2, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		3: {CpuID: 3, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+	}
+
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(1, 0))
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(3, 0))
 }

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -96,7 +96,7 @@ type numaOrSocketsFirstFuncs interface {
 	takeFullSecondLevel()
 	sortAvailableNUMANodes() []int
 	sortAvailableSockets() []int
-	sortAvailableCores() []int
+	sortAvailableCores() []topology.CoreKey
 }
 
 type numaFirst struct{ acc *cpuAccumulator }
@@ -151,11 +151,11 @@ func (n *numaFirst) sortAvailableSockets() []int {
 
 // If NUMA nodes are higher in the memory hierarchy than sockets, then
 // cores sit directly below sockets in the memory hierarchy.
-func (n *numaFirst) sortAvailableCores() []int {
-	var result []int
+func (n *numaFirst) sortAvailableCores() []topology.CoreKey {
+	var result []topology.CoreKey
 	for _, socket := range n.acc.sortAvailableSockets() {
-		cores := n.acc.details.CoresInSockets(socket).UnsortedList()
-		n.acc.sort(cores, n.acc.details.CPUsInCores)
+		cores := n.acc.details.CoreKeysInSockets(socket)
+		n.acc.sortCoreKeys(cores, n.acc.details.CPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -196,11 +196,11 @@ func (s *socketsFirst) sortAvailableSockets() []int {
 
 // If sockets are higher in the memory hierarchy than NUMA nodes, then cores
 // sit directly below NUMA Nodes in the memory hierarchy.
-func (s *socketsFirst) sortAvailableCores() []int {
-	var result []int
+func (s *socketsFirst) sortAvailableCores() []topology.CoreKey {
+	var result []topology.CoreKey
 	for _, numa := range s.acc.sortAvailableNUMANodes() {
-		cores := s.acc.details.CoresInNUMANodes(numa).UnsortedList()
-		s.acc.sort(cores, s.acc.details.CPUsInCores)
+		cores := s.acc.details.CoreKeysInNUMANodes(numa)
+		s.acc.sortCoreKeys(cores, s.acc.details.CPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -333,7 +333,7 @@ func (a *cpuAccumulator) isNUMANodeFree(numaID int) bool {
 // Returns true if the supplied socket is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
 func (a *cpuAccumulator) isSocketFree(socketID int) bool {
-	return a.details.CPUsInSockets(socketID).Size() == a.topo.CPUsPerSocket()
+	return a.details.CPUsInSockets(socketID).Size() == a.topo.CPUDetails.CPUsInSockets(socketID).Size()
 }
 
 // Returns true if the supplied UnCoreCache is fully available,
@@ -344,8 +344,8 @@ func (a *cpuAccumulator) isUncoreCacheFree(uncoreID int) bool {
 
 // Returns true if the supplied core is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
-func (a *cpuAccumulator) isCoreFree(coreID int) bool {
-	return a.details.CPUsInCores(coreID).Size() == a.topo.CPUsPerCore()
+func (a *cpuAccumulator) isCoreFree(core topology.CoreKey) bool {
+	return a.details.CPUsInCoreKeys(core).Size() == a.topo.CPUDetails.CPUsInCoreKeys(core).Size()
 }
 
 // Returns free NUMA Node IDs as a slice sorted by sortAvailableNUMANodes().
@@ -382,8 +382,8 @@ func (a *cpuAccumulator) freeUncoreCache() []int {
 }
 
 // Returns free core IDs as a slice sorted by sortAvailableCores().
-func (a *cpuAccumulator) freeCores() []int {
-	free := []int{}
+func (a *cpuAccumulator) freeCores() []topology.CoreKey {
+	free := []topology.CoreKey{}
 	for _, core := range a.sortAvailableCores() {
 		if a.isCoreFree(core) {
 			free = append(free, core)
@@ -415,6 +415,21 @@ func (a *cpuAccumulator) sort(ids []int, getCPUs func(ids ...int) cpuset.CPUSet)
 				return false
 			}
 			return ids[i] < ids[j]
+		})
+}
+
+func (a *cpuAccumulator) sortCoreKeys(keys []topology.CoreKey, getCPUs func(keys ...topology.CoreKey) cpuset.CPUSet) {
+	sort.Slice(keys,
+		func(i, j int) bool {
+			iCPUs := getCPUs(keys[i])
+			jCPUs := getCPUs(keys[j])
+			if iCPUs.Size() < jCPUs.Size() {
+				return true
+			}
+			if iCPUs.Size() > jCPUs.Size() {
+				return false
+			}
+			return keys[i].Less(keys[j])
 		})
 }
 
@@ -476,7 +491,7 @@ func (a *cpuAccumulator) sortAvailableSockets() []int {
 // same way as described in the previous paragraph, except that the priority of NUMA nodes and
 // sockets is inverted (e.g. first sort the cores by number of free CPUs in their NUMA nodes, then,
 // for each NUMA node, sort the cores by number of free CPUs in their sockets, etc...).
-func (a *cpuAccumulator) sortAvailableCores() []int {
+func (a *cpuAccumulator) sortAvailableCores() []topology.CoreKey {
 	return a.numaOrSocketsFirst.sortAvailableCores()
 }
 
@@ -506,7 +521,7 @@ func (a *cpuAccumulator) sortAvailableCores() []int {
 func (a *cpuAccumulator) sortAvailableCPUsPacked() []int {
 	var result []int
 	for _, core := range a.sortAvailableCores() {
-		cpus := a.details.CPUsInCores(core).UnsortedList()
+		cpus := a.details.CPUsInCoreKeys(core).UnsortedList()
 		sort.Ints(cpus)
 		result = append(result, cpus...)
 	}
@@ -566,28 +581,16 @@ func (a *cpuAccumulator) takeFullUncore() {
 }
 
 func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
-	// determine the number of cores needed whether SMT/hyperthread is enabled or disabled
-	numCoresNeeded := (a.numCPUsNeeded + a.topo.CPUsPerCore() - 1) / a.topo.CPUsPerCore()
-
 	// determine the N number of free cores (physical cpus) within the UncoreCache, then
 	// determine the M number of free cpus (virtual cpus) that correspond with the free cores
-	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, uncoreID)
-	freeCPUs := a.details.CPUsInCores(freeCores.UnsortedList()...)
+	freeCores := a.details.CoreKeysNeededForCPUsInUncoreCache(a.numCPUsNeeded, uncoreID)
+	freeCPUs := a.details.CPUsInCoreKeys(freeCores...)
 
-	// when SMT/hyperthread is enabled and remaining cpu requirement is an odd integer value:
-	// sort the free CPUs that were determined based on the cores that have available cpus.
-	// if the amount of free cpus is greater than the cpus needed, we can drop the last cpu
-	// since the odd integer request will only require one out of the two free cpus that
-	// correspond to the last core
-	if a.numCPUsNeeded%2 != 0 && a.topo.CPUsPerCore() > 1 {
-		// we sort freeCPUs to ensure we pack virtual cpu allocations, meaning we allocate
-		// whole core's worth of cpus as much as possible to reduce smt-misalignment
+	// We sort and trim CPUs to pack whole cores as much as possible while still
+	// allowing the final core to contribute only the CPUs needed by this request.
+	if freeCPUs.Size() > a.numCPUsNeeded {
 		sortFreeCPUs := freeCPUs.List()
-		if len(sortFreeCPUs) > a.numCPUsNeeded {
-			// if we are in takePartialUncore, the accumulator is not satisfied after
-			// takeFullUncore, so freeCPUs.Size() can't be < 1
-			sortFreeCPUs = sortFreeCPUs[:freeCPUs.Size()-1]
-		}
+		sortFreeCPUs = sortFreeCPUs[:a.numCPUsNeeded]
 		freeCPUs = cpuset.New(sortFreeCPUs...)
 	}
 
@@ -597,7 +600,7 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 		"uncore", uncoreID,
 		"claimed", claimed,
 		"needed", a.numCPUsNeeded,
-		"cores", freeCores.String(),
+		"cores", freeCores,
 		"cpus", freeCPUs.String())
 	if !claimed {
 		return
@@ -608,10 +611,9 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 // First try to take full UncoreCache, if available and need is at least the size of the UncoreCache group.
 // Second try to take the partial UncoreCache if available and the request size can fit w/in the UncoreCache.
 func (a *cpuAccumulator) takeUncoreCache() {
-	numCPUsInUncore := a.topo.CPUsPerUncore()
 	for _, uncore := range a.sortAvailableUncoreCaches() {
 		// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
-		if a.needsAtLeast(numCPUsInUncore) {
+		if a.needsAtLeast(a.topo.CPUDetails.CPUsInUncoreCaches(uncore).Size()) {
 			a.takeFullUncore()
 		}
 
@@ -629,7 +631,7 @@ func (a *cpuAccumulator) takeUncoreCache() {
 
 func (a *cpuAccumulator) takeFullCores() {
 	for _, core := range a.freeCores() {
-		cpusInCore := a.topo.CPUDetails.CPUsInCores(core)
+		cpusInCore := a.topo.CPUDetails.CPUsInCoreKeys(core)
 		if !a.needsAtLeast(cpusInCore.Size()) {
 			continue
 		}

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -381,7 +381,7 @@ func (a *cpuAccumulator) freeUncoreCache() []int {
 	return free
 }
 
-// Returns free core IDs as a slice sorted by sortAvailableCores().
+// Returns free core keys as a slice sorted by sortAvailableCores().
 func (a *cpuAccumulator) freeCores() []topology.CoreKey {
 	free := []topology.CoreKey{}
 	for _, core := range a.sortAvailableCores() {

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -96,7 +96,7 @@ type numaOrSocketsFirstFuncs interface {
 	takeFullSecondLevel()
 	sortAvailableNUMANodes() []int
 	sortAvailableSockets() []int
-	sortAvailableCores() []int
+	sortAvailableCores() []topology.CoreKey
 }
 
 type numaFirst struct{ acc *cpuAccumulator }
@@ -151,11 +151,11 @@ func (n *numaFirst) sortAvailableSockets() []int {
 
 // If NUMA nodes are higher in the memory hierarchy than sockets, then
 // cores sit directly below sockets in the memory hierarchy.
-func (n *numaFirst) sortAvailableCores() []int {
-	var result []int
+func (n *numaFirst) sortAvailableCores() []topology.CoreKey {
+	var result []topology.CoreKey
 	for _, socket := range n.acc.sortAvailableSockets() {
-		cores := n.acc.details.CoresInSockets(socket).UnsortedList()
-		n.acc.sort(cores, n.acc.details.CPUsInCores)
+		cores := n.acc.details.CoreKeysInSockets(socket)
+		n.acc.sortCoreKeys(cores, n.acc.details.CPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -196,11 +196,11 @@ func (s *socketsFirst) sortAvailableSockets() []int {
 
 // If sockets are higher in the memory hierarchy than NUMA nodes, then cores
 // sit directly below NUMA Nodes in the memory hierarchy.
-func (s *socketsFirst) sortAvailableCores() []int {
-	var result []int
+func (s *socketsFirst) sortAvailableCores() []topology.CoreKey {
+	var result []topology.CoreKey
 	for _, numa := range s.acc.sortAvailableNUMANodes() {
-		cores := s.acc.details.CoresInNUMANodes(numa).UnsortedList()
-		s.acc.sort(cores, s.acc.details.CPUsInCores)
+		cores := s.acc.details.CoreKeysInNUMANodes(numa)
+		s.acc.sortCoreKeys(cores, s.acc.details.CPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -333,7 +333,7 @@ func (a *cpuAccumulator) isNUMANodeFree(numaID int) bool {
 // Returns true if the supplied socket is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
 func (a *cpuAccumulator) isSocketFree(socketID int) bool {
-	return a.details.CPUsInSockets(socketID).Size() == a.topo.CPUsPerSocket()
+	return a.details.CPUsInSockets(socketID).Size() == a.topo.CPUDetails.CPUsInSockets(socketID).Size()
 }
 
 // Returns true if the supplied UnCoreCache is fully available,
@@ -344,8 +344,8 @@ func (a *cpuAccumulator) isUncoreCacheFree(uncoreID int) bool {
 
 // Returns true if the supplied core is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
-func (a *cpuAccumulator) isCoreFree(coreID int) bool {
-	return a.details.CPUsInCores(coreID).Size() == a.topo.CPUsPerCore()
+func (a *cpuAccumulator) isCoreFree(core topology.CoreKey) bool {
+	return a.details.CPUsInCoreKeys(core).Size() == a.topo.CPUDetails.CPUsInCoreKeys(core).Size()
 }
 
 // Returns free NUMA Node IDs as a slice sorted by sortAvailableNUMANodes().
@@ -381,9 +381,9 @@ func (a *cpuAccumulator) freeUncoreCache() []int {
 	return free
 }
 
-// Returns free core IDs as a slice sorted by sortAvailableCores().
-func (a *cpuAccumulator) freeCores() []int {
-	free := []int{}
+// Returns free core keys as a slice sorted by sortAvailableCores().
+func (a *cpuAccumulator) freeCores() []topology.CoreKey {
+	free := []topology.CoreKey{}
 	for _, core := range a.sortAvailableCores() {
 		if a.isCoreFree(core) {
 			free = append(free, core)
@@ -415,6 +415,21 @@ func (a *cpuAccumulator) sort(ids []int, getCPUs func(ids ...int) cpuset.CPUSet)
 				return false
 			}
 			return ids[i] < ids[j]
+		})
+}
+
+func (a *cpuAccumulator) sortCoreKeys(keys []topology.CoreKey, getCPUs func(keys ...topology.CoreKey) cpuset.CPUSet) {
+	sort.Slice(keys,
+		func(i, j int) bool {
+			iCPUs := getCPUs(keys[i])
+			jCPUs := getCPUs(keys[j])
+			if iCPUs.Size() < jCPUs.Size() {
+				return true
+			}
+			if iCPUs.Size() > jCPUs.Size() {
+				return false
+			}
+			return keys[i].Less(keys[j])
 		})
 }
 
@@ -476,7 +491,7 @@ func (a *cpuAccumulator) sortAvailableSockets() []int {
 // same way as described in the previous paragraph, except that the priority of NUMA nodes and
 // sockets is inverted (e.g. first sort the cores by number of free CPUs in their NUMA nodes, then,
 // for each NUMA node, sort the cores by number of free CPUs in their sockets, etc...).
-func (a *cpuAccumulator) sortAvailableCores() []int {
+func (a *cpuAccumulator) sortAvailableCores() []topology.CoreKey {
 	return a.numaOrSocketsFirst.sortAvailableCores()
 }
 
@@ -506,7 +521,7 @@ func (a *cpuAccumulator) sortAvailableCores() []int {
 func (a *cpuAccumulator) sortAvailableCPUsPacked() []int {
 	var result []int
 	for _, core := range a.sortAvailableCores() {
-		cpus := a.details.CPUsInCores(core).UnsortedList()
+		cpus := a.details.CPUsInCoreKeys(core).UnsortedList()
 		sort.Ints(cpus)
 		result = append(result, cpus...)
 	}
@@ -566,28 +581,16 @@ func (a *cpuAccumulator) takeFullUncore() {
 }
 
 func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
-	// determine the number of cores needed whether SMT/hyperthread is enabled or disabled
-	numCoresNeeded := (a.numCPUsNeeded + a.topo.CPUsPerCore() - 1) / a.topo.CPUsPerCore()
-
 	// determine the N number of free cores (physical cpus) within the UncoreCache, then
 	// determine the M number of free cpus (virtual cpus) that correspond with the free cores
-	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, uncoreID)
-	freeCPUs := a.details.CPUsInCores(freeCores.UnsortedList()...)
+	freeCores := a.details.CoreKeysNeededForCPUsInUncoreCache(a.numCPUsNeeded, uncoreID)
+	freeCPUs := a.details.CPUsInCoreKeys(freeCores...)
 
-	// when SMT/hyperthread is enabled and remaining cpu requirement is an odd integer value:
-	// sort the free CPUs that were determined based on the cores that have available cpus.
-	// if the amount of free cpus is greater than the cpus needed, we can drop the last cpu
-	// since the odd integer request will only require one out of the two free cpus that
-	// correspond to the last core
-	if a.numCPUsNeeded%2 != 0 && a.topo.CPUsPerCore() > 1 {
-		// we sort freeCPUs to ensure we pack virtual cpu allocations, meaning we allocate
-		// whole core's worth of cpus as much as possible to reduce smt-misalignment
+	// We sort and trim CPUs to pack whole cores as much as possible while still
+	// allowing the final core to contribute only the CPUs needed by this request.
+	if freeCPUs.Size() > a.numCPUsNeeded {
 		sortFreeCPUs := freeCPUs.List()
-		if len(sortFreeCPUs) > a.numCPUsNeeded {
-			// if we are in takePartialUncore, the accumulator is not satisfied after
-			// takeFullUncore, so freeCPUs.Size() can't be < 1
-			sortFreeCPUs = sortFreeCPUs[:freeCPUs.Size()-1]
-		}
+		sortFreeCPUs = sortFreeCPUs[:a.numCPUsNeeded]
 		freeCPUs = cpuset.New(sortFreeCPUs...)
 	}
 
@@ -597,7 +600,7 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 		"uncore", uncoreID,
 		"claimed", claimed,
 		"needed", a.numCPUsNeeded,
-		"cores", freeCores.String(),
+		"cores", freeCores,
 		"cpus", freeCPUs.String())
 	if !claimed {
 		return
@@ -608,10 +611,9 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 // First try to take full UncoreCache, if available and need is at least the size of the UncoreCache group.
 // Second try to take the partial UncoreCache if available and the request size can fit w/in the UncoreCache.
 func (a *cpuAccumulator) takeUncoreCache() {
-	numCPUsInUncore := a.topo.CPUsPerUncore()
 	for _, uncore := range a.sortAvailableUncoreCaches() {
 		// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
-		if a.needsAtLeast(numCPUsInUncore) {
+		if a.needsAtLeast(a.topo.CPUDetails.CPUsInUncoreCaches(uncore).Size()) {
 			a.takeFullUncore()
 		}
 
@@ -629,7 +631,7 @@ func (a *cpuAccumulator) takeUncoreCache() {
 
 func (a *cpuAccumulator) takeFullCores() {
 	for _, core := range a.freeCores() {
-		cpusInCore := a.topo.CPUDetails.CPUsInCores(core)
+		cpusInCore := a.topo.CPUDetails.CPUsInCoreKeys(core)
 		if !a.needsAtLeast(cpusInCore.Size()) {
 			continue
 		}

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -70,6 +70,12 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 			[]int{},
 		},
 		{
+			"asymmetric sockets, larger socket free",
+			topoAsymmetricSockets,
+			cpuset.New(2, 3, 4, 5),
+			[]int{1},
+		},
+		{
 			"dual socket, multi numa per socket, HT, 2 sockets free",
 			topoDualSocketMultiNumaPerSocketHT,
 			mustParseCPUSet(t, "0-79"),
@@ -128,6 +134,15 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
 			}
 		})
+	}
+}
+
+func TestCPUAccumulatorFreeCoresWithRepeatedCoreIDs(t *testing.T) {
+	logger := klog.Background()
+	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1), 2, CPUSortingStrategyPacked)
+
+	if got, want := acc.freeCores(), []topology.CoreKey{{SocketID: 0, ClusterID: 0, CoreID: 0}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("freeCores() = %v, want %v", got, want)
 	}
 }
 
@@ -290,55 +305,86 @@ func TestCPUAccumulatorFreeCores(t *testing.T) {
 		description   string
 		topo          *topology.CPUTopology
 		availableCPUs cpuset.CPUSet
-		expect        []int
+		expect        []topology.CoreKey
 	}{
 		{
 			"single socket HT, 4 cores free",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
-			[]int{0, 1, 2, 3},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 3},
+			},
 		},
 		{
 			"single socket HT, 3 cores free",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 4, 5, 6),
-			[]int{0, 1, 2},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+			},
 		},
 		{
 			"single socket HT, 3 cores free (1 partially consumed)",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6),
-			[]int{0, 1, 2},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+			},
 		},
 		{
 			"single socket HT, 0 cores free",
 			topoSingleSocketHT,
 			cpuset.New(),
-			[]int{},
+			[]topology.CoreKey{},
 		},
 		{
 			"single socket HT, 0 cores free (4 partially consumed)",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3),
-			[]int{},
+			[]topology.CoreKey{},
 		},
 		{
 			"dual socket HT, 6 cores free",
 			topoDualSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-			[]int{0, 2, 4, 1, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 1},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 		{
 			"dual socket HT, 5 cores free (1 consumed from socket 0)",
 			topoDualSocketHT,
 			cpuset.New(2, 1, 3, 4, 5, 7, 8, 9, 10, 11),
-			[]int{2, 4, 1, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 1},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 		{
 			"dual socket HT, 4 cores free (1 consumed from each socket)",
 			topoDualSocketHT,
 			cpuset.New(2, 3, 4, 5, 8, 9, 10, 11),
-			[]int{2, 4, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 	}
 
@@ -766,6 +812,15 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 			10,
 			"",
 			mustParseCPUSet(t, "4-7,12-15,1,9"),
+		},
+		{
+			"take partial uncore from asymmetric SMT uncore",
+			topoAsymmetricUncoreSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "0-5"),
+			3,
+			"",
+			cpuset.New(0, 2, 5),
 		},
 	}...)
 

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -823,6 +823,9 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 			mustParseCPUSet(t, "0-5"),
 			3,
 			"",
+			// This documents the current best-effort heuristic on asymmetric uncore
+			// topology; it is not asserting a stronger "stay within one uncore if
+			// possible" guarantee.
 			cpuset.New(0, 2, 5),
 		},
 	}...)

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -139,9 +139,12 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 
 func TestCPUAccumulatorFreeCoresWithRepeatedCoreIDs(t *testing.T) {
 	logger := klog.Background()
-	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1), 2, CPUSortingStrategyPacked)
+	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1, 2, 3), 2, CPUSortingStrategyPacked)
 
-	if got, want := acc.freeCores(), []topology.CoreKey{{SocketID: 0, ClusterID: 0, CoreID: 0}}; !reflect.DeepEqual(got, want) {
+	if got, want := acc.freeCores(), []topology.CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+	}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("freeCores() = %v, want %v", got, want)
 	}
 }

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -290,55 +290,86 @@ func TestCPUAccumulatorFreeCores(t *testing.T) {
 		description   string
 		topo          *topology.CPUTopology
 		availableCPUs cpuset.CPUSet
-		expect        []int
+		expect        []topology.CoreKey
 	}{
 		{
 			"single socket HT, 4 cores free",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
-			[]int{0, 1, 2, 3},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 3},
+			},
 		},
 		{
 			"single socket HT, 3 cores free",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 4, 5, 6),
-			[]int{0, 1, 2},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+			},
 		},
 		{
 			"single socket HT, 3 cores free (1 partially consumed)",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6),
-			[]int{0, 1, 2},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+			},
 		},
 		{
 			"single socket HT, 0 cores free",
 			topoSingleSocketHT,
 			cpuset.New(),
-			[]int{},
+			[]topology.CoreKey{},
 		},
 		{
 			"single socket HT, 0 cores free (4 partially consumed)",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3),
-			[]int{},
+			[]topology.CoreKey{},
 		},
 		{
 			"dual socket HT, 6 cores free",
 			topoDualSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-			[]int{0, 2, 4, 1, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 1},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 		{
 			"dual socket HT, 5 cores free (1 consumed from socket 0)",
 			topoDualSocketHT,
 			cpuset.New(2, 1, 3, 4, 5, 7, 8, 9, 10, 11),
-			[]int{2, 4, 1, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 1},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 		{
 			"dual socket HT, 4 cores free (1 consumed from each socket)",
 			topoDualSocketHT,
 			cpuset.New(2, 3, 4, 5, 8, 9, 10, 11),
-			[]int{2, 4, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 	}
 

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -70,6 +70,12 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 			[]int{},
 		},
 		{
+			"asymmetric sockets, larger socket free",
+			topoAsymmetricSockets,
+			cpuset.New(2, 3, 4, 5),
+			[]int{1},
+		},
+		{
 			"dual socket, multi numa per socket, HT, 2 sockets free",
 			topoDualSocketMultiNumaPerSocketHT,
 			mustParseCPUSet(t, "0-79"),
@@ -128,6 +134,18 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
 			}
 		})
+	}
+}
+
+func TestCPUAccumulatorFreeCoresWithRepeatedCoreIDs(t *testing.T) {
+	logger := klog.Background()
+	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1, 2, 3), 2, CPUSortingStrategyPacked)
+
+	if got, want := acc.freeCores(), []topology.CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("freeCores() = %v, want %v", got, want)
 	}
 }
 
@@ -797,6 +815,18 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 			10,
 			"",
 			mustParseCPUSet(t, "4-7,12-15,1,9"),
+		},
+		{
+			"take partial uncore from asymmetric SMT uncore",
+			topoAsymmetricUncoreSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "0-5"),
+			3,
+			"",
+			// This documents the current best-effort heuristic on asymmetric uncore
+			// topology; it is not asserting a stronger "stay within one uncore if
+			// possible" guarantee.
+			cpuset.New(0, 2, 5),
 		},
 	}...)
 

--- a/pkg/cpumanager/test_topology.go
+++ b/pkg/cpumanager/test_topology.go
@@ -62,6 +62,49 @@ var (
 		},
 	}
 
+	topoAsymmetricSockets = &topology.CPUTopology{
+		NumCPUs:      6,
+		NumSockets:   2,
+		NumNUMANodes: 2,
+		NumCores:     6,
+		CPUDetails: map[int]topology.CPUInfo{
+			0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			1: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+			2: {CoreID: 0, SocketID: 1, NUMANodeID: 1},
+			3: {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			4: {CoreID: 2, SocketID: 1, NUMANodeID: 1},
+			5: {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+		},
+	}
+
+	topoRepeatedCoreIDs = &topology.CPUTopology{
+		NumCPUs:      4,
+		NumSockets:   2,
+		NumNUMANodes: 2,
+		NumCores:     2,
+		CPUDetails: map[int]topology.CPUInfo{
+			0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			2: {CoreID: 0, SocketID: 1, NUMANodeID: 1},
+			3: {CoreID: 0, SocketID: 1, NUMANodeID: 1},
+		},
+	}
+
+	topoAsymmetricUncoreSMT = &topology.CPUTopology{
+		NumCPUs:        6,
+		NumSockets:     1,
+		NumCores:       3,
+		NumUncoreCache: 2,
+		CPUDetails: map[int]topology.CPUInfo{
+			0: {CoreID: 0, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			1: {CoreID: 1, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			2: {CoreID: 2, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+			3: {CoreID: 0, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			4: {CoreID: 1, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			5: {CoreID: 2, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+		},
+	}
+
 	topoUncoreDualSocketNoSMT = &topology.CPUTopology{
 		NumCPUs:        16,
 		NumSockets:     2,


### PR DESCRIPTION
This is a WIP first step for #35.
﻿
Issue #35 has been open for a while, and I do not think this PR should try to settle the larger allocator/model direction in one shot. The goal here is smaller: keep the current CPUManager-style allocator flow, but replace a few symmetric-topology assumptions with exact `CPUDetails` queries where the data is already available.
﻿
I am marking this as WIP because the broader question is still open: whether we continue to stay close to the kubelet CPUManager allocator code, or eventually split/diverge more intentionally. This PR is meant to make the smallest concrete part reviewable first, then iterate based on feedback.