### PR TITLE
WIP: allocator boundary experiment

### DIFF
--- a/docs/dev/allocator-topology-strawman.md
+++ b/docs/dev/allocator-topology-strawman.md
@@ -14,8 +14,8 @@ The driver currently has three concerns that are coupled more tightly than we
 should rely on for long-term development:
 
 1. CPU topology discovery from Linux sysfs.
-2. CPU allocation policy, currently derived from kubelet CPUManager code.
-3. ResourceSlice/device projection, which is the scheduler-visible API surface.
+1. CPU allocation policy, currently derived from kubelet CPUManager code.
+1. ResourceSlice/device projection, which is the scheduler-visible API surface.
 
 PR #210 is a scoped correctness fix: it keeps the current allocator and
 ResourceSlice shape, but stops using symmetric averages such as
@@ -539,11 +539,11 @@ E2E tests should stay focused on externally visible guarantees:
 
 1. Accept that PR #210 is a correctness fix and should not redesign the
    resource model.
-2. Accept that the allocator has crossed the zero-cost kubelet-resync boundary.
-3. Decide whether to intentionally own a DRA-specific allocator boundary.
-4. Decide whether sysfs-shaped topology data is the preferred internal source
+1. Accept that the allocator has crossed the zero-cost kubelet-resync boundary.
+1. Decide whether to intentionally own a DRA-specific allocator boundary.
+1. Decide whether sysfs-shaped topology data is the preferred internal source
    of truth for now.
-5. Decide how to treat ResourceSlice shape compatibility before GA.
+1. Decide how to treat ResourceSlice shape compatibility before GA.
 
 ## References
 

--- a/docs/dev/allocator-topology-strawman.md
+++ b/docs/dev/allocator-topology-strawman.md
@@ -1,0 +1,568 @@
+# Strawman: CPU Topology Model and Allocator Boundary
+
+This is an input document for discussion, not a final design. It is motivated
+by the asymmetric-topology fix in
+[PR #210](https://github.com/kubernetes-sigs/dra-driver-cpu/pull/210), the
+long-running topology discussion in
+[#35](https://github.com/kubernetes-sigs/dra-driver-cpu/issues/35), and the
+need to consume finer-grained locality data in
+[#173](https://github.com/kubernetes-sigs/dra-driver-cpu/issues/173).
+
+## Summary
+
+The driver currently has three concerns that are coupled more tightly than we
+should rely on for long-term development:
+
+1. CPU topology discovery from Linux sysfs.
+2. CPU allocation policy, currently derived from kubelet CPUManager code.
+3. ResourceSlice/device projection, which is the scheduler-visible API surface.
+
+PR #210 is a scoped correctness fix: it keeps the current allocator and
+ResourceSlice shape, but stops using symmetric averages such as
+`CPUsPerCore`, `CPUsPerSocket`, and `CPUsPerUncore` in places where exact
+`CPUDetails`/`CoreKey` queries are available.
+
+That is the right short-term fix, but it also shows that `cpu_assignment.go`
+has crossed the trivial kubelet-resync boundary. We should make that boundary
+explicit and decide what we want to own.
+
+My strawman recommendation is:
+
+- Do not invent a new generic topology model first.
+- Use Linux sysfs as the canonical discovery source on Linux nodes.
+- Use hwloc as a reference model and possible future backend, not as an
+  immediate hard dependency.
+- Evolve the existing `pkg/cpuinfo` snapshot instead of introducing a parallel
+  topology model.
+- Split topology discovery, allocator queries, allocator policy, and
+  ResourceSlice projection into explicit internal boundaries.
+- Keep the current CPUManager-derived allocator as the baseline policy while
+  adding room for DRA-specific allocation logic where the kernel and DRA API
+  surface actually provide enough locality information.
+- Treat ResourceSlice shape compatibility as a separate API decision, not as
+  an accidental consequence of allocator internals.
+- Keep Node Allocatable Resources and broader CPU accounting as an adjacent but
+  separate design track.
+
+## Background
+
+### What PR #210 fixes
+
+Issue #35 identified that the current `CPUTopology` helpers can infer topology
+properties from global counts. That breaks when topology is not symmetric:
+CPUs may be manually offlined, SMT may be disabled unevenly, core IDs may
+repeat across sockets, or the platform may expose heterogeneous CPU/cache
+structure.
+
+PR #210 takes the smallest useful step:
+
+- `CoreID` is no longer treated as globally unique where core-level precision
+  matters. `CoreKey{SocketID, ClusterID, CoreID}` is used instead.
+- Full socket/core/uncore checks compare against exact CPU sets from
+  `CPUDetails` instead of averages.
+- Partial uncore allocation picks enough exact core keys to satisfy the CPU
+  request, then trims to the requested CPU count.
+- The ResourceSlice model and the grouped/individual device modes are left
+  unchanged.
+
+This preserves the current behavior where possible and fixes the asymmetric
+case without forcing a broader resource model redesign.
+
+### Why this matters beyond PR #210
+
+The current grouped allocator is derived from kubelet CPUManager. That code is
+valuable because it is battle-tested and because we could previously resync it
+with mostly mechanical changes. Once we need local changes in the allocator
+itself, the value of "borrowed code with near-zero review cost" decreases.
+
+This does not mean forking is bad. It means the project should consciously
+decide where the fork starts, which invariants we keep from kubelet, and which
+new invariants are DRA-specific.
+
+Issue #173 makes this practical rather than theoretical. The driver can expose
+PCIe root locality, but grouped allocation currently selects CPUs inside a
+socket/NUMA group without consuming the exact matched PCIe root. Improving this
+requires a clearer allocator/query boundary.
+
+At the same time, the current repository research already shows an important
+limit: Linux exposes generic PCI locality at NUMA-node granularity
+(`numa_node`, `local_cpulist`), but it does not expose a standard mapping from
+PCI devices to die, chiplet, or LLC domains inside a NUMA node. This proposal
+therefore should not promise that sysfs alone can give us generic sub-NUMA or
+LLC-to-I/O locality.
+
+## Existing facts to build on
+
+### Kubernetes CPUManager is a node-local placement policy
+
+Kubernetes CPUManager exists because some workloads need cache affinity,
+scheduling-latency control, and exclusive CPUs. The static policy now has
+multiple placement options, including full physical CPUs, NUMA distribution,
+socket alignment, core spreading, strict reservation, and uncore-cache
+alignment:
+
+- https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/
+
+We should reuse this as a policy baseline and compatibility reference, but not
+assume the kubelet implementation is the right internal boundary for a DRA CPU
+driver forever.
+
+### DRA makes ResourceSlice shape an API surface
+
+DRA drivers create and update ResourceSlices. Kubernetes uses them to find
+nodes and devices that can satisfy ResourceClaims. ResourceSlices are not just
+internal state; they are how the scheduler and users see the driver's resource
+model:
+
+- https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
+
+Recent DRA features make this even more relevant:
+
+- Node Allocatable Resources let DRA devices declare a footprint in standard
+  node resources such as `cpu`.
+- List-type attributes improve modeling of topology cases where a device has
+  adjacency to multiple values, such as multiple PCIe roots.
+- Consumable capacity and partitionable devices are the natural Kubernetes
+  vocabulary for grouped resources, capacity, and hierarchical device shape.
+
+Therefore allocator internals should not accidentally dictate ResourceSlice
+shape. ResourceSlice compatibility should be a deliberate design decision.
+However, Node Allocatable Resources and the broader accounting model should be
+handled as a separate design thread, because they also affect claim sharing,
+QoS/resource accounting, and the KEP-5517 integration path.
+
+### Linux sysfs already exposes the low-level CPU topology
+
+Linux exports CPU topology under
+`/sys/devices/system/cpu/cpuX/topology/`, including package, die, cluster,
+core, sibling/core/cluster/die cpumasks when supported by the architecture.
+The kernel also exposes online/offline/present/possible CPU sets:
+
+- https://docs.kernel.org/admin-guide/cputopology.html
+
+This is already close to the raw data the driver needs. It also matches the
+current implementation direction in `pkg/cpuinfo`, which reads sysfs directly
+and already tracks socket, NUMA node, cluster, core, SMT sibling, uncore cache,
+core type, and online CPUs.
+
+### hwloc is a useful reference and possible backend
+
+hwloc already models hardware locality across packages, NUMA nodes, cores,
+PUs, caches, groups, I/O locality, distances, CPU kinds, and asymmetric
+topologies:
+
+- https://www.open-mpi.org/projects/hwloc/doc/v2.11.2/a00359.php
+
+Two details are especially relevant:
+
+- hwloc explicitly warns that physical OS indexes can be non-contiguous or
+  non-unique, and that core numbers may only be unique within a socket.
+- hwloc supports asymmetric topologies, including missing resources due to
+  cgroups/cpusets and platforms where different packages expose different
+  numbers of cores, SMT threads, or cache levels.
+
+That aligns with PR #210's move from raw `CoreID` to `CoreKey`. It also
+suggests that if we need a richer model, using sysfs/hwloc-shaped concepts is
+safer than inventing a new abstract hierarchy.
+
+## Goals
+
+- Make the allocator ownership boundary explicit after PR #210.
+- Preserve the scoped correctness fix for #35 without expanding PR #210.
+- Avoid a new bespoke topology abstraction unless it solves a concrete problem
+  that sysfs/hwloc-shaped data cannot solve.
+- Provide exact queries for asymmetric topology instead of inferred averages.
+- Allow future allocation logic to consume richer locality inputs such as core
+  keys, uncore domains, CPU kind, and PCIe-root/NUMA locality where the
+  platform exposes them reliably.
+- Keep ResourceSlice shape decisions explicit and reviewable, especially for
+  0.3.0 and GA readiness.
+- Keep the current CPUManager-derived behavior available as the baseline.
+
+## Non-goals
+
+- Do not redesign the ResourceSlice shape in PR #210.
+- Do not require hwloc as an immediate runtime dependency.
+- Do not replace all CPUManager-derived code in one step.
+- Do not solve cluster-level heterogeneous scheduling in this driver. This
+  document focuses on node-local discovery, allocation, and projection.
+- Do not expose every sysfs field as a public DRA attribute by default.
+- Do not treat Node Allocatable Resources, claim sharing, or broader CPU
+  accounting as solved by the allocator-boundary work alone.
+- Do not assume generic Linux sysfs can provide portable sub-NUMA or
+  LLC-to-I/O locality for all platforms.
+
+## Current assumptions we intentionally keep
+
+This proposal is incremental. It does not claim that every current topology
+assumption disappears immediately.
+
+- The existing `pkg/cpuinfo.CPUTopology` / `CPUDetails` model remains the
+  source of truth for CPU topology facts on Linux.
+- In grouped `numanode` mode, the driver currently derives one socket
+  attribute for the device from one CPU in that NUMA node. This matches common
+  topologies, but it is still an assumption and should stay documented until we
+  either enforce it or relax it.
+- PCI locality guarantees remain bounded by the kernel interfaces we actually
+  have today. Under current generic Linux semantics, that means NUMA/root level
+  locality, not a portable sub-NUMA or LLC guarantee.
+- `individual` and `grouped` ResourceSlice modes remain the baseline external
+  API surface unless a future proposal explicitly changes them.
+
+## Proposed internal boundaries
+
+### 1. Discovery model: evolve the existing topology snapshot
+
+Evolve the existing `pkg/cpuinfo` snapshot so it stays close to Linux sysfs and
+explicit about CPU sets.
+
+The snapshot should represent facts, not policy:
+
+- online, present, possible, and offline CPU sets;
+- CPU ID to package/socket, die, cluster, core, NUMA node, SMT sibling, CPU
+  kind, cache/uncore ID;
+- cpumasks for topology domains where available, such as package, die,
+  cluster, and core;
+- PCIe root to local CPU set, when `--expose-pcie-roots` or a future locality
+  feature is enabled;
+- derived indexes for exact queries, built from the same snapshot.
+
+This is not a proposal to introduce a second topology universe next to
+`CPUTopology`. The important change is conceptual: the discovery layer should
+answer "what does the node report?" without encoding allocator assumptions.
+
+### 2. Allocation queries: concrete helpers first
+
+Allocators should not repeatedly scan raw structs or rely on global averages.
+They should consume exact queries over the topology snapshot.
+
+```go
+topo.CPUDetails.CPUsInNUMANodes(...)
+topo.CPUDetails.CPUsInSockets(...)
+topo.CPUDetails.CPUsInCoreKeys(...)
+topo.CPUDetails.CPUsInUncoreCaches(...)
+topo.CPUDetails.CoreKeysInNUMANodes(...)
+topo.CPUDetails.CoreKeysInSockets(...)
+```
+
+If this starts to sprawl, the first step should be a concrete adapter or
+package-local helper around existing `CPUDetails` queries. We should not rush
+to introduce an exported cross-package interface until we have at least two
+substantially different consumers or implementations that justify it.
+
+The key principle is that allocators ask exact questions and get CPU sets or
+stable keys back. They do not divide global counts to infer local shape.
+
+Implementation can remain simple:
+
+- keep `CPUDetails` as the source of CPU facts for now;
+- add precomputed indexes only when a hot path or code clarity justifies it;
+- keep index construction deterministic and test it with asymmetric fixtures.
+
+This avoids over-engineering while still providing a clear boundary for future
+allocators.
+
+### 3. Allocator boundary: package-local before public interface
+
+The current grouped allocation path should become an explicit boundary, but it
+does not need to start as a public or cross-package interface.
+
+```go
+type AllocationRequest struct {
+    AvailableCPUs cpuset.CPUSet
+    Count         int
+    Constraints   AllocationConstraints
+    Topology      *cpuinfo.CPUTopology
+}
+
+type AllocationConstraints struct {
+    PreferFullCores       bool
+    PreferUncoreAlignment bool
+    PreferNUMAPacked      bool
+    PreferNUMADistributed bool
+    RequiredPCIeRoot      string
+}
+```
+
+This is not a proposal to add all options at once. It is a way to make policy
+inputs explicit inside the grouped allocation path, so future work can add one
+constraint at a time without rewiring ResourceSlice publication.
+
+Candidate implementations:
+
+- current CPUManager-derived grouped allocator, maintained as the compatibility
+  baseline;
+- future DRA-specific grouped allocation logic that consumes richer topology
+  queries where the platform exposes them reliably;
+- `ExplicitCPUSetAllocator`: existing machine-group behavior where an external
+  scheduler or opaque config supplies the cpuset.
+
+Only after the project has a real second allocator path should we decide
+whether a formal `Allocator` interface adds value or just indirection.
+
+### 4. ResourceSlice projection
+
+ResourceSlice projection should be a separate layer:
+
+```text
+topology snapshot -> projection policy -> ResourceSlice devices/attributes/capacity
+```
+
+This layer decides what users and the scheduler see:
+
+- individual CPU devices;
+- grouped capacity devices by NUMA node, socket, machine, or future locality
+  domain;
+- attributes such as socket ID, NUMA node ID, core ID, core type, SMT enabled,
+  cache ID, PCIe root, and compatibility attributes;
+- future topology projections only when the scheduler-visible semantics are
+  clear and testable.
+
+The allocator may use richer internal data than the ResourceSlice exposes, but
+it must not violate what the ResourceSlice promised. For example, if a
+ResourceClaim is matched on a PCIe root, a future allocator should either
+allocate CPUs local to that root or the ResourceSlice shape should avoid
+implying that guarantee.
+
+Node Allocatable Resource mappings are intentionally excluded from this layer in
+this proposal. They belong to a broader resource-accounting and KEP-5517
+integration discussion.
+
+## Design alternatives
+
+### Option A: Keep patching the CPUManager-derived allocator
+
+Keep the current code layout and patch it as new topology needs appear.
+
+Pros:
+
+- lowest immediate cost;
+- preserves current behavior;
+- no new abstraction to review.
+
+Cons:
+
+- drift from kubelet becomes harder to reason about;
+- each new locality feature adds another local patch;
+- ResourceSlice shape and allocator needs remain implicitly coupled;
+- finer-grained locality-aware allocation will likely force larger changes
+  anyway.
+
+This is acceptable for PR #210 but probably not enough for 0.3.0 and GA.
+
+### Option B: Fork the allocator intentionally, keep current model
+
+Declare `pkg/cpumanager/cpu_assignment.go` as intentionally forked and continue
+evolving it around `pkg/cpuinfo`.
+
+Pros:
+
+- honest about the current state after PR #210;
+- minimal package churn;
+- lets us fix #35 and some #173 follow-ups incrementally.
+
+Cons:
+
+- still ties allocator shape to today's `pkg/cpuinfo`;
+- may duplicate topology/query code as features grow;
+- does not force a clean ResourceSlice projection boundary.
+
+This is a reasonable near-term transition, but it should be paired with
+decision records and tests that make the forked behavior clear.
+
+### Option C: Add explicit topology, query, allocator, and projection boundaries
+
+Keep the current CPUManager-derived allocator as one implementation, but add
+internal boundaries that separate discovery facts, exact queries, allocation
+policy, and ResourceSlice projection.
+
+Pros:
+
+- avoids inventing a new topology universe;
+- lets sysfs/hwloc-shaped data flow into allocators;
+- makes future NUMA/root-aware allocation possible under current kernel
+  semantics;
+- keeps ResourceSlice compatibility as a deliberate API decision;
+- allows incremental migration and comparison against existing behavior.
+
+Cons:
+
+- requires careful scoping to avoid abstraction churn;
+- needs tests for both current behavior and asymmetric cases;
+- still leaves open how to handle accounting and API changes outside allocator
+  internals.
+
+This is my recommended direction.
+
+### Option D: Adopt hwloc directly as the internal model
+
+Use hwloc as the primary topology discovery and representation layer.
+
+Pros:
+
+- avoids reimplementing a mature topology model;
+- handles asymmetric topology, object hierarchy, distances, CPU kinds, and I/O
+  locality concepts;
+- widely understood in HPC/performance-sensitive environments.
+
+Cons:
+
+- likely adds cgo and runtime/library packaging concerns;
+- may be more model than this driver needs today;
+- Kubernetes/node-agent environments often prefer minimal dependencies;
+- still needs a DRA-specific projection and allocator policy layer.
+
+This should remain an evaluation path, not the first step.
+
+## Recommended phased plan
+
+### Phase 0: Merge the scoped correctness fix
+
+Keep PR #210 narrow:
+
+- exact `CPUDetails`/`CoreKey` queries;
+- no ResourceSlice shape change;
+- no allocator interface change;
+- tests for repeated core IDs, asymmetric sockets, and asymmetric uncore/SMT.
+
+### Phase 1: Document allocator ownership
+
+Add a short developer note that explains:
+
+- which files are still intended to track kubelet CPUManager closely;
+- which files are intentionally diverged;
+- how to evaluate future kubelet resyncs;
+- what invariants this driver preserves from CPUManager behavior.
+
+This prevents accidental drift from being mistaken for mechanical vendoring.
+
+### Phase 2: Consolidate exact topology queries without changing behavior
+
+Start by consolidating exact query helpers around the existing
+`CPUTopology`/`CPUDetails` model. If a dedicated helper type is needed, keep it
+package-local or concrete at first.
+
+Tests should prove:
+
+- asymmetric socket sizes;
+- repeated core IDs across sockets;
+- asymmetric SMT/offlined CPUs;
+- uncore/cache domains with non-uniform CPU counts;
+- no behavior change for existing symmetric fixtures.
+
+### Phase 3: Make grouped allocation policy inputs explicit
+
+Move the current grouped allocation path behind an explicit request/constraint
+boundary while keeping the current implementation and default behavior.
+
+Only add a formal `Allocator` interface if the code now has at least one real
+alternative implementation that makes the interface earn its keep. This phase
+should not change ResourceSlice output.
+
+### Phase 4: Prototype a locality-aware allocator
+
+Prototype one concrete improvement that the current allocator cannot express
+cleanly. The strongest candidate is #173, but scoped to what the kernel and the
+driver can actually guarantee today:
+
+- input: a matched PCIe root or locality domain;
+- allocator behavior: intersect available CPUs with CPUs local to that
+  root/NUMA domain before applying CPU/core/uncore packing;
+- output: CPUSet that satisfies both quantity and the locality guarantee the
+  platform can actually expose.
+
+This should be feature-gated or opt-in until ResourceSlice semantics are
+reviewed.
+
+### Phase 5: Decide ResourceSlice compatibility policy
+
+Before GA, decide which ResourceSlice shapes are stable:
+
+- Is `individual` mode stable as per-CPU devices?
+- Is `grouped` by NUMA node/socket/machine stable?
+- Can future grouped devices represent LLC, PCIe root, die, cluster, or other
+  domains?
+- Which attributes are compatibility attributes, which are informational, and
+  which imply allocator guarantees?
+
+This is the real GA-facing decision. It should not be hidden inside allocator
+code changes.
+
+### Parallel track: accounting and Node Allocatable Resources
+
+The project should discuss Node Allocatable Resource mappings and broader CPU
+accounting separately from allocator boundaries. That work touches:
+
+- claim sharing constraints;
+- kubelet/QoS/accounting interactions;
+- KEP-5517 integration and migration strategy.
+
+## Testing strategy
+
+Unit tests should use synthetic topology fixtures that intentionally break
+symmetric assumptions:
+
+- sockets with different numbers of CPUs;
+- cores with different SMT widths;
+- core IDs repeated across sockets;
+- clusters present on one architecture and absent on another;
+- offlined CPUs that make one package partially available;
+- uncore/cache domains with different CPU counts;
+- PCIe root locality at the granularity the kernel actually reports today.
+
+E2E tests should stay focused on externally visible guarantees:
+
+- ResourceSlices are published with expected devices/attributes/capacity;
+- claims in grouped mode get exclusive CPU sets of the requested size;
+- allocations do not use reserved CPUs;
+- when a future locality-aware mode is enabled, allocated CPUs satisfy the
+  selected locality constraint at the documented guarantee level.
+
+## Open questions
+
+- Should the first formal proposal target only allocator boundaries, or also
+  ResourceSlice compatibility policy?
+- Should the driver keep one default grouped allocator selected by
+  configuration, or dynamically vary grouped allocation behavior based on
+  request constraints?
+- Should sysfs remain the only supported backend for now, with hwloc used only
+  as a reference model?
+- Which ResourceSlice attributes imply hard allocation guarantees, and which
+  are only descriptive?
+- Should future locality domains be represented as grouped devices, as
+  attributes on existing devices, or both?
+- What is the minimum ResourceSlice shape we are willing to call GA-stable?
+- When, if ever, should Node Allocatable Resources move from adjacent context
+  into a dedicated design proposal for this driver?
+
+## Proposed decision points for maintainers
+
+1. Accept that PR #210 is a correctness fix and should not redesign the
+   resource model.
+2. Accept that the allocator has crossed the zero-cost kubelet-resync boundary.
+3. Decide whether to intentionally own a DRA-specific allocator boundary.
+4. Decide whether sysfs-shaped topology data is the preferred internal source
+   of truth for now.
+5. Decide how to treat ResourceSlice shape compatibility before GA.
+
+## References
+
+- PR #210: https://github.com/kubernetes-sigs/dra-driver-cpu/pull/210
+- Issue #35: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/35
+- Issue #173: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/173
+- Repository sysfs/PCIe locality research:
+  https://github.com/kubernetes-sigs/dra-driver-cpu/blob/main/docs/dev/topology-linux-sysfs.md
+- Kubernetes CPU Manager policy docs:
+  https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/
+- Kubernetes Dynamic Resource Allocation docs:
+  https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
+- DRA consumable capacity KEP:
+  https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5075-dra-consumable-capacity/README.md
+- DRA partitionable devices KEP:
+  https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4815-dra-partitionable-devices/README.md
+- Native Resource Management for DRA:
+  https://github.com/kubernetes/enhancements/issues/5517
+- Linux CPU topology sysfs docs:
+  https://docs.kernel.org/admin-guide/cputopology.html
+- hwloc documentation:
+  https://www.open-mpi.org/projects/hwloc/doc/v2.11.2/a00359.php

--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -163,12 +163,7 @@ func (s *SystemCPUInfo) GetCPUTopology(logger logr.Logger) (*CPUTopology, error)
 	cpuDetails := make(CPUDetails)
 	sockets := sets.NewInt()
 	numaNodes := sets.NewInt()
-	type coreIdent struct {
-		SocketID  int
-		ClusterID int
-		CoreID    int
-	}
-	cores := sets.New[coreIdent]()
+	cores := sets.New[CoreKey]()
 	uncoreCaches := sets.NewInt()
 
 	for i := range cpuInfos {
@@ -176,9 +171,7 @@ func (s *SystemCPUInfo) GetCPUTopology(logger logr.Logger) (*CPUTopology, error)
 		cpuDetails[info.CpuID] = info
 		sockets.Insert(info.SocketID)
 		numaNodes.Insert(info.NUMANodeID)
-		// A core is unique by socket, cluster, and core id
-		coreKey := coreIdent{SocketID: info.SocketID, ClusterID: info.ClusterID, CoreID: info.CoreID}
-		cores.Insert(coreKey)
+		cores.Insert(info.CoreKey())
 		if info.UncoreCacheID != -1 {
 			uncoreCaches.Insert(info.UncoreCacheID)
 		}
@@ -431,17 +424,10 @@ func populateTopologyInfo(cpuInfo *CPUInfo, logger logr.Logger) error {
 
 // TODO: Handle more complex sibling relationships (e.g. 4-way SMT) if needed in the future. For now we only handle 2-way hyperthreading which is the most common case.
 func populateCpuSiblings(cpuInfos []CPUInfo) {
-	// Define a key struct to identify a unique physical core.
-	type coreLocation struct {
-		socket  int
-		cluster int
-		core    int
-	}
-
 	// Map each physical core to the list of logical CPUs (siblings) on it.
-	coreToCPU := make(map[coreLocation][]int)
+	coreToCPU := make(map[CoreKey][]int)
 	for _, info := range cpuInfos {
-		key := coreLocation{socket: info.SocketID, cluster: info.ClusterID, core: info.CoreID}
+		key := info.CoreKey()
 		coreToCPU[key] = append(coreToCPU[key], info.CpuID)
 	}
 
@@ -518,9 +504,9 @@ func combinePath(value string, combineWith ...string) string {
 	}
 }
 
-// TODO: Refactor topology representation to handle asymmetric CPU distributions.
-// The current funcs CPUsPerCore, CPUsPerSocket, CPUsPerUncore assume symmetry
-// and would be inaccurate if CPUs are offlined asymmetrically or on heterogeneous systems.
+// These helpers assume symmetric CPU distributions. Allocation code should
+// prefer exact CPUDetails queries because CPUs can be offlined asymmetrically
+// or grouped unevenly on heterogeneous systems.
 // See https://github.com/kubernetes-sigs/dra-driver-cpu/pull/16#discussion_r2588301122
 func (t *CPUTopology) CPUsPerCore() int {
 	if t.NumCores == 0 {

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -40,6 +40,9 @@ type CoreKey struct {
 	CoreID    int
 }
 
+// Less keeps CoreID as the primary key because cpumanager sorts core keys only
+// after it has already partitioned them by higher-level topology (socket or
+// NUMA). Changing this order changes packed-allocation decisions.
 func (k CoreKey) Less(other CoreKey) bool {
 	if k.CoreID != other.CoreID {
 		return k.CoreID < other.CoreID
@@ -281,10 +284,30 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 // CoreKeysNeededForCPUsInUncoreCache returns the smallest ordered set of core
 // keys from the given UncoreCache IDs whose CPUs can satisfy numCPUsNeeded.
 func (d CPUDetails) CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded int, ids ...int) []CoreKey {
+	counts := map[CoreKey]int{}
+	for _, info := range d {
+		for _, id := range ids {
+			if info.UncoreCacheID == id {
+				counts[info.CoreKey()]++
+				break
+			}
+		}
+	}
+
+	coreKeys := make([]CoreKey, 0, len(counts))
+	for key := range counts {
+		coreKeys = append(coreKeys, key)
+	}
+	sort.Slice(coreKeys, func(i, j int) bool {
+		return coreKeys[i].Less(coreKeys[j])
+	})
+
 	var result []CoreKey
-	for _, key := range d.coreKeysInUncoreCache(ids...) {
+	cpuCount := 0
+	for _, key := range coreKeys {
 		result = append(result, key)
-		if d.CPUsInCoreKeys(result...).Size() >= numCPUsNeeded {
+		cpuCount += counts[key]
+		if cpuCount >= numCPUsNeeded {
 			return result
 		}
 	}

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -327,17 +327,6 @@ func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
 	return cpuset.New(coreIDs...)
 }
 
-func (d CPUDetails) coreKeysInUncoreCache(ids ...int) []CoreKey {
-	return d.coreKeysFor(func(info CPUInfo) bool {
-		for _, id := range ids {
-			if info.UncoreCacheID == id {
-				return true
-			}
-		}
-		return false
-	})
-}
-
 func (d CPUDetails) coreKeysFor(include func(CPUInfo) bool) []CoreKey {
 	seen := map[CoreKey]struct{}{}
 	for _, info := range d {

--- a/pkg/cpuinfo/cpuinfo_utils.go
+++ b/pkg/cpuinfo/cpuinfo_utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cpuinfo
 
 import (
+	"sort"
+
 	"k8s.io/utils/cpuset"
 )
 
@@ -28,6 +30,33 @@ import (
 
 // CPUDetails is a map from CPU ID to Core ID, Socket ID, and NUMA ID.
 type CPUDetails map[int]CPUInfo
+
+// CoreKey identifies a physical core within the topology. CoreID alone is not
+// globally unique on all systems, so callers that need core-level precision
+// should use this key instead of the raw CoreID.
+type CoreKey struct {
+	SocketID  int
+	ClusterID int
+	CoreID    int
+}
+
+func (k CoreKey) Less(other CoreKey) bool {
+	if k.CoreID != other.CoreID {
+		return k.CoreID < other.CoreID
+	}
+	if k.SocketID != other.SocketID {
+		return k.SocketID < other.SocketID
+	}
+	return k.ClusterID < other.ClusterID
+}
+
+func (i CPUInfo) CoreKey() CoreKey {
+	return CoreKey{
+		SocketID:  i.SocketID,
+		ClusterID: i.ClusterID,
+		CoreID:    i.CoreID,
+	}
+}
 
 func (d CPUDetails) KeepOnly(cpus cpuset.CPUSet) CPUDetails {
 	result := CPUDetails{}
@@ -66,13 +95,27 @@ func (d CPUDetails) CPUsInNUMANodes(ids ...int) cpuset.CPUSet {
 // core IDs in this CPUDetails.
 // TODO: CoreID is only unique within a socket. On multi-socket systems where CoreIDs repeat
 // across sockets, this method may return CPUs from multiple sockets for the same CoreID.
-// Consider refactoring core-level methods to use CoreKey{SocketID, CoreID} for correct
+// Consider refactoring core-level methods to use CoreKey{SocketID, ClusterID, CoreID} for correct
 // disambiguation, similar to CPUTopology.CPUsByCore.
 func (d CPUDetails) CPUsInCores(ids ...int) cpuset.CPUSet {
 	var cpuIDs []int
 	for _, id := range ids {
 		for cpu, info := range d {
 			if info.CoreID == id {
+				cpuIDs = append(cpuIDs, cpu)
+			}
+		}
+	}
+	return cpuset.New(cpuIDs...)
+}
+
+// CPUsInCoreKeys returns all logical CPUs associated with the given physical
+// core keys.
+func (d CPUDetails) CPUsInCoreKeys(keys ...CoreKey) cpuset.CPUSet {
+	var cpuIDs []int
+	for _, key := range keys {
+		for cpu, info := range d {
+			if info.CoreKey() == key {
 				cpuIDs = append(cpuIDs, cpu)
 			}
 		}
@@ -170,6 +213,19 @@ func (d CPUDetails) CoresInSockets(ids ...int) cpuset.CPUSet {
 	return cpuset.New(coreIDs...)
 }
 
+// CoreKeysInSockets returns all physical core keys associated with the given
+// socket IDs.
+func (d CPUDetails) CoreKeysInSockets(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		for _, id := range ids {
+			if info.SocketID == id {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 // NUMANodesInSockets returns all of the logical NUMANode IDs associated with
 // the given socket IDs in this CPUDetails.
 func (d CPUDetails) NUMANodesInSockets(ids ...int) cpuset.CPUSet {
@@ -198,6 +254,19 @@ func (d CPUDetails) CoresInNUMANodes(ids ...int) cpuset.CPUSet {
 	return cpuset.New(coreIDs...)
 }
 
+// CoreKeysInNUMANodes returns all physical core keys associated with the given
+// NUMA node IDs.
+func (d CPUDetails) CoreKeysInNUMANodes(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		for _, id := range ids {
+			if info.NUMANodeID == id {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 // CoresNeededInUncoreCache returns either the full list of all available unique core IDs associated with the given
 // UnCoreCache IDs in this CPUDetails or subset that matches the ask.
 func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpuset.CPUSet {
@@ -207,6 +276,19 @@ func (d CPUDetails) CoresNeededInUncoreCache(numCoresNeeded int, ids ...int) cpu
 	}
 	tmpCoreIDs := coreIDs.List()
 	return cpuset.New(tmpCoreIDs[:numCoresNeeded]...)
+}
+
+// CoreKeysNeededForCPUsInUncoreCache returns the smallest ordered set of core
+// keys from the given UncoreCache IDs whose CPUs can satisfy numCPUsNeeded.
+func (d CPUDetails) CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded int, ids ...int) []CoreKey {
+	var result []CoreKey
+	for _, key := range d.coreKeysInUncoreCache(ids...) {
+		result = append(result, key)
+		if d.CPUsInCoreKeys(result...).Size() >= numCPUsNeeded {
+			return result
+		}
+	}
+	return result
 }
 
 // Helper function that just gets the cores
@@ -220,4 +302,33 @@ func (d CPUDetails) coresInUncoreCache(ids ...int) cpuset.CPUSet {
 		}
 	}
 	return cpuset.New(coreIDs...)
+}
+
+func (d CPUDetails) coreKeysInUncoreCache(ids ...int) []CoreKey {
+	return d.coreKeysFor(func(info CPUInfo) bool {
+		for _, id := range ids {
+			if info.UncoreCacheID == id {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (d CPUDetails) coreKeysFor(include func(CPUInfo) bool) []CoreKey {
+	seen := map[CoreKey]struct{}{}
+	for _, info := range d {
+		if include(info) {
+			seen[info.CoreKey()] = struct{}{}
+		}
+	}
+
+	coreKeys := make([]CoreKey, 0, len(seen))
+	for key := range seen {
+		coreKeys = append(coreKeys, key)
+	}
+	sort.Slice(coreKeys, func(i, j int) bool {
+		return coreKeys[i].Less(coreKeys[j])
+	})
+	return coreKeys
 }

--- a/pkg/cpuinfo/cpuinfo_utils_test.go
+++ b/pkg/cpuinfo/cpuinfo_utils_test.go
@@ -18,6 +18,7 @@ package cpuinfo
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,6 +110,26 @@ func TestCPUsInCoreKeys(t *testing.T) {
 	assert.True(t, cpuset.New(4).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 1, CoreID: 0})))
 }
 
+func TestCoreKeyLessOrdersByCoreThenSocketThenCluster(t *testing.T) {
+	keys := []CoreKey{
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+		{SocketID: 0, ClusterID: 1, CoreID: 0},
+		{SocketID: 0, ClusterID: 0, CoreID: 1},
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].Less(keys[j])
+	})
+
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 0, ClusterID: 1, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+		{SocketID: 0, ClusterID: 0, CoreID: 1},
+	}, keys)
+}
+
 func TestCPUsInSockets(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1, 2, 3).Equals(testCPUDetails.CPUsInSockets(0)))
 	assert.True(t, cpuset.New(4, 5, 6, 7).Equals(testCPUDetails.CPUsInSockets(1)))
@@ -183,6 +204,18 @@ func TestCoreKeysNeededForCPUsInUncoreCache(t *testing.T) {
 	}, details.CoreKeysNeededForCPUsInUncoreCache(1, 0))
 	assert.Equal(t, []CoreKey{
 		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(3, 0))
+
+	details = CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 1, UncoreCacheID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 1, UncoreCacheID: 0},
+		2: {CpuID: 2, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		3: {CpuID: 3, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		4: {CpuID: 4, SocketID: 0, ClusterID: 1, CoreID: 0, UncoreCacheID: 0},
+	}
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 1, CoreID: 0},
 		{SocketID: 1, ClusterID: 0, CoreID: 0},
 	}, details.CoreKeysNeededForCPUsInUncoreCache(3, 0))
 }

--- a/pkg/cpuinfo/cpuinfo_utils_test.go
+++ b/pkg/cpuinfo/cpuinfo_utils_test.go
@@ -95,6 +95,20 @@ func TestCPUsInCores(t *testing.T) {
 	assert.True(t, cpuset.New().Equals(testCPUDetails.CPUsInCores(10)))
 }
 
+func TestCPUsInCoreKeys(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 0},
+		2: {CpuID: 2, SocketID: 1, ClusterID: 0, CoreID: 0},
+		3: {CpuID: 3, SocketID: 1, ClusterID: 0, CoreID: 0},
+		4: {CpuID: 4, SocketID: 1, ClusterID: 1, CoreID: 0},
+	}
+
+	assert.True(t, cpuset.New(0, 1).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 0, ClusterID: 0, CoreID: 0})))
+	assert.True(t, cpuset.New(2, 3).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 0, CoreID: 0})))
+	assert.True(t, cpuset.New(4).Equals(details.CPUsInCoreKeys(CoreKey{SocketID: 1, ClusterID: 1, CoreID: 0})))
+}
+
 func TestCPUsInSockets(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1, 2, 3).Equals(testCPUDetails.CPUsInSockets(0)))
 	assert.True(t, cpuset.New(4, 5, 6, 7).Equals(testCPUDetails.CPUsInSockets(1)))
@@ -154,4 +168,21 @@ func TestCoresInUncoreCache(t *testing.T) {
 	assert.True(t, cpuset.New(0, 1).Equals(testCPUDetails.coresInUncoreCache(0)))
 	assert.True(t, cpuset.New(2, 3).Equals(testCPUDetails.coresInUncoreCache(1)))
 	assert.True(t, cpuset.New().Equals(testCPUDetails.coresInUncoreCache(2)))
+}
+
+func TestCoreKeysNeededForCPUsInUncoreCache(t *testing.T) {
+	details := CPUDetails{
+		0: {CpuID: 0, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		1: {CpuID: 1, SocketID: 0, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		2: {CpuID: 2, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+		3: {CpuID: 3, SocketID: 1, ClusterID: 0, CoreID: 0, UncoreCacheID: 0},
+	}
+
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(1, 0))
+	assert.Equal(t, []CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+	}, details.CoreKeysNeededForCPUsInUncoreCache(3, 0))
 }

--- a/pkg/cpumanager/allocation_request.go
+++ b/pkg/cpumanager/allocation_request.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	topology "github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	"k8s.io/utils/cpuset"
+)
+
+// allocationRequest keeps grouped-allocation inputs explicit without
+// committing to a public cross-package allocator interface yet.
+type allocationRequest struct {
+	topology           *topology.CPUTopology
+	availableCPUs      cpuset.CPUSet
+	numCPUs            int
+	cpuSortingStrategy CPUSortingStrategy
+	constraints        allocationConstraints
+}
+
+type allocationConstraints struct {
+	preferAlignByUncoreCache bool
+}
+
+func newPackedAllocationRequest(topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuSortingStrategy CPUSortingStrategy, preferAlignByUncoreCache bool) allocationRequest {
+	return allocationRequest{
+		topology:           topo,
+		availableCPUs:      availableCPUs,
+		numCPUs:            numCPUs,
+		cpuSortingStrategy: cpuSortingStrategy,
+		constraints: allocationConstraints{
+			preferAlignByUncoreCache: preferAlignByUncoreCache,
+		},
+	}
+}

--- a/pkg/cpumanager/allocation_request.go
+++ b/pkg/cpumanager/allocation_request.go
@@ -33,6 +33,7 @@ type allocationRequest struct {
 
 type allocationConstraints struct {
 	preferAlignByUncoreCache bool
+	cpuGroupSize             int
 }
 
 func newPackedAllocationRequest(topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuSortingStrategy CPUSortingStrategy, preferAlignByUncoreCache bool) allocationRequest {
@@ -43,6 +44,18 @@ func newPackedAllocationRequest(topo *topology.CPUTopology, availableCPUs cpuset
 		cpuSortingStrategy: cpuSortingStrategy,
 		constraints: allocationConstraints{
 			preferAlignByUncoreCache: preferAlignByUncoreCache,
+		},
+	}
+}
+
+func newDistributedAllocationRequest(topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy) allocationRequest {
+	return allocationRequest{
+		topology:           topo,
+		availableCPUs:      availableCPUs,
+		numCPUs:            numCPUs,
+		cpuSortingStrategy: cpuSortingStrategy,
+		constraints: allocationConstraints{
+			cpuGroupSize: cpuGroupSize,
 		},
 	}
 }

--- a/pkg/cpumanager/allocation_request.go
+++ b/pkg/cpumanager/allocation_request.go
@@ -21,6 +21,13 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
+type allocationPolicy int
+
+const (
+	allocationPolicyPacked allocationPolicy = iota
+	allocationPolicyDistributed
+)
+
 // allocationRequest keeps grouped-allocation inputs explicit without
 // committing to a public cross-package allocator interface yet.
 type allocationRequest struct {
@@ -28,6 +35,7 @@ type allocationRequest struct {
 	availableCPUs      cpuset.CPUSet
 	numCPUs            int
 	cpuSortingStrategy CPUSortingStrategy
+	policy             allocationPolicy
 	constraints        allocationConstraints
 }
 
@@ -42,6 +50,7 @@ func newPackedAllocationRequest(topo *topology.CPUTopology, availableCPUs cpuset
 		availableCPUs:      availableCPUs,
 		numCPUs:            numCPUs,
 		cpuSortingStrategy: cpuSortingStrategy,
+		policy:             allocationPolicyPacked,
 		constraints: allocationConstraints{
 			preferAlignByUncoreCache: preferAlignByUncoreCache,
 		},
@@ -54,6 +63,7 @@ func newDistributedAllocationRequest(topo *topology.CPUTopology, availableCPUs c
 		availableCPUs:      availableCPUs,
 		numCPUs:            numCPUs,
 		cpuSortingStrategy: cpuSortingStrategy,
+		policy:             allocationPolicyDistributed,
 		constraints: allocationConstraints{
 			cpuGroupSize: cpuGroupSize,
 		},

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -121,8 +121,8 @@ func (n *numaFirst) takeFullSecondLevel() {
 func (a *cpuAccumulator) sortAvailableUncoreCaches() []int {
 	var result []int
 	for _, numa := range a.sortAvailableNUMANodes() {
-		uncore := a.details.UncoreInNUMANodes(numa).UnsortedList()
-		a.sort(uncore, a.details.CPUsInUncoreCaches)
+		uncore := a.queries.availableUncoreInNUMANodes(numa).UnsortedList()
+		a.sort(uncore, a.queries.availableCPUsInUncoreCaches)
 		result = append(result, uncore...)
 	}
 	return result
@@ -131,8 +131,8 @@ func (a *cpuAccumulator) sortAvailableUncoreCaches() []int {
 // If NUMA nodes are higher in the memory hierarchy than sockets, then just
 // sort the NUMA nodes directly, and return them.
 func (n *numaFirst) sortAvailableNUMANodes() []int {
-	numas := n.acc.details.NUMANodes().UnsortedList()
-	n.acc.sort(numas, n.acc.details.CPUsInNUMANodes)
+	numas := n.acc.queries.availableNUMANodes().UnsortedList()
+	n.acc.sort(numas, n.acc.queries.availableCPUsInNUMANodes)
 	return numas
 }
 
@@ -142,8 +142,8 @@ func (n *numaFirst) sortAvailableNUMANodes() []int {
 func (n *numaFirst) sortAvailableSockets() []int {
 	var result []int
 	for _, numa := range n.sortAvailableNUMANodes() {
-		sockets := n.acc.details.SocketsInNUMANodes(numa).UnsortedList()
-		n.acc.sort(sockets, n.acc.details.CPUsInSockets)
+		sockets := n.acc.queries.availableSocketsInNUMANodes(numa).UnsortedList()
+		n.acc.sort(sockets, n.acc.queries.availableCPUsInSockets)
 		result = append(result, sockets...)
 	}
 	return result
@@ -154,8 +154,8 @@ func (n *numaFirst) sortAvailableSockets() []int {
 func (n *numaFirst) sortAvailableCores() []topology.CoreKey {
 	var result []topology.CoreKey
 	for _, socket := range n.acc.sortAvailableSockets() {
-		cores := n.acc.details.CoreKeysInSockets(socket)
-		n.acc.sortCoreKeys(cores, n.acc.details.CPUsInCoreKeys)
+		cores := n.acc.queries.availableCoreKeysInSockets(socket)
+		n.acc.sortCoreKeys(cores, n.acc.queries.availableCPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -179,8 +179,8 @@ func (s *socketsFirst) takeFullSecondLevel() {
 func (s *socketsFirst) sortAvailableNUMANodes() []int {
 	var result []int
 	for _, socket := range s.sortAvailableSockets() {
-		numas := s.acc.details.NUMANodesInSockets(socket).UnsortedList()
-		s.acc.sort(numas, s.acc.details.CPUsInNUMANodes)
+		numas := s.acc.queries.availableNUMANodesInSockets(socket).UnsortedList()
+		s.acc.sort(numas, s.acc.queries.availableCPUsInNUMANodes)
 		result = append(result, numas...)
 	}
 	return result
@@ -189,8 +189,8 @@ func (s *socketsFirst) sortAvailableNUMANodes() []int {
 // If sockets are higher in the memory hierarchy than NUMA nodes, then just
 // sort the sockets directly, and return them.
 func (s *socketsFirst) sortAvailableSockets() []int {
-	sockets := s.acc.details.Sockets().UnsortedList()
-	s.acc.sort(sockets, s.acc.details.CPUsInSockets)
+	sockets := s.acc.queries.availableSockets().UnsortedList()
+	s.acc.sort(sockets, s.acc.queries.availableCPUsInSockets)
 	return sockets
 }
 
@@ -199,8 +199,8 @@ func (s *socketsFirst) sortAvailableSockets() []int {
 func (s *socketsFirst) sortAvailableCores() []topology.CoreKey {
 	var result []topology.CoreKey
 	for _, numa := range s.acc.sortAvailableNUMANodes() {
-		cores := s.acc.details.CoreKeysInNUMANodes(numa)
-		s.acc.sortCoreKeys(cores, s.acc.details.CPUsInCoreKeys)
+		cores := s.acc.queries.availableCoreKeysInNUMANodes(numa)
+		s.acc.sortCoreKeys(cores, s.acc.queries.availableCPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -278,6 +278,10 @@ type cpuAccumulator struct {
 	// number of CPUS. When a CPU is claimed, it's removed from `details`.
 	details topology.CPUDetails
 
+	// `queries` keeps exact topology lookups in one place while preserving the
+	// distinction between the full topology and the currently available CPUs.
+	queries topologyQueries
+
 	// `numCPUsNeeded` is the number of CPUs that the accumulator still needs to accumulate to reach
 	// the desired number of CPUs. When the cpuAccumulator is created, `numCPUsNeeded` is set to the
 	// total number of CPUs to accumulate. Every time a CPU is claimed, `numCPUsNeeded` is decreased
@@ -312,6 +316,7 @@ func newCPUAccumulatorForRequest(logger logr.Logger, request allocationRequest) 
 		numCPUsNeeded: request.numCPUs,
 		result:        cpuset.New(),
 	}
+	acc.queries = newTopologyQueries(request.topology, &acc.details)
 
 	if request.topology.NumSockets >= request.topology.NumNUMANodes {
 		acc.numaOrSocketsFirst = &numaFirst{acc}
@@ -331,25 +336,25 @@ func newCPUAccumulatorForRequest(logger logr.Logger, request allocationRequest) 
 // Returns true if the supplied NUMANode is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
 func (a *cpuAccumulator) isNUMANodeFree(numaID int) bool {
-	return a.details.CPUsInNUMANodes(numaID).Size() == a.topo.CPUDetails.CPUsInNUMANodes(numaID).Size()
+	return a.queries.availableCPUsInNUMANodes(numaID).Size() == a.queries.allCPUsInNUMANodes(numaID).Size()
 }
 
 // Returns true if the supplied socket is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
 func (a *cpuAccumulator) isSocketFree(socketID int) bool {
-	return a.details.CPUsInSockets(socketID).Size() == a.topo.CPUDetails.CPUsInSockets(socketID).Size()
+	return a.queries.availableCPUsInSockets(socketID).Size() == a.queries.allCPUsInSockets(socketID).Size()
 }
 
 // Returns true if the supplied UnCoreCache is fully available,
 // "fully available" means that all the CPUs in it are free.
 func (a *cpuAccumulator) isUncoreCacheFree(uncoreID int) bool {
-	return a.details.CPUsInUncoreCaches(uncoreID).Size() == a.topo.CPUDetails.CPUsInUncoreCaches(uncoreID).Size()
+	return a.queries.availableCPUsInUncoreCaches(uncoreID).Size() == a.queries.allCPUsInUncoreCaches(uncoreID).Size()
 }
 
 // Returns true if the supplied core is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
 func (a *cpuAccumulator) isCoreFree(core topology.CoreKey) bool {
-	return a.details.CPUsInCoreKeys(core).Size() == a.topo.CPUDetails.CPUsInCoreKeys(core).Size()
+	return a.queries.availableCPUsInCoreKeys(core).Size() == a.queries.allCPUsInCoreKeys(core).Size()
 }
 
 // Returns free NUMA Node IDs as a slice sorted by sortAvailableNUMANodes().
@@ -525,7 +530,7 @@ func (a *cpuAccumulator) sortAvailableCores() []topology.CoreKey {
 func (a *cpuAccumulator) sortAvailableCPUsPacked() []int {
 	var result []int
 	for _, core := range a.sortAvailableCores() {
-		cpus := a.details.CPUsInCoreKeys(core).UnsortedList()
+		cpus := a.queries.availableCPUsInCoreKeys(core).UnsortedList()
 		sort.Ints(cpus)
 		result = append(result, cpus...)
 	}
@@ -538,7 +543,7 @@ func (a *cpuAccumulator) sortAvailableCPUsPacked() []int {
 func (a *cpuAccumulator) sortAvailableCPUsSpread() []int {
 	var result []int
 	for _, socket := range a.sortAvailableSockets() {
-		cpus := a.details.CPUsInSockets(socket).UnsortedList()
+		cpus := a.queries.availableCPUsInSockets(socket).UnsortedList()
 		sort.Ints(cpus)
 		result = append(result, cpus...)
 	}
@@ -547,13 +552,13 @@ func (a *cpuAccumulator) sortAvailableCPUsSpread() []int {
 
 func (a *cpuAccumulator) take(cpus cpuset.CPUSet) {
 	a.result = a.result.Union(cpus)
-	a.details = a.details.KeepOnly(a.details.CPUs().Difference(a.result))
+	a.details = a.details.KeepOnly(a.queries.availableCPUsSet().Difference(a.result))
 	a.numCPUsNeeded -= cpus.Size()
 }
 
 func (a *cpuAccumulator) takeFullNUMANodes() {
 	for _, numa := range a.freeNUMANodes() {
-		cpusInNUMANode := a.topo.CPUDetails.CPUsInNUMANodes(numa)
+		cpusInNUMANode := a.queries.allCPUsInNUMANodes(numa)
 		if !a.needsAtLeast(cpusInNUMANode.Size()) {
 			continue
 		}
@@ -564,7 +569,7 @@ func (a *cpuAccumulator) takeFullNUMANodes() {
 
 func (a *cpuAccumulator) takeFullSockets() {
 	for _, socket := range a.freeSockets() {
-		cpusInSocket := a.topo.CPUDetails.CPUsInSockets(socket)
+		cpusInSocket := a.queries.allCPUsInSockets(socket)
 		if !a.needsAtLeast(cpusInSocket.Size()) {
 			continue
 		}
@@ -575,7 +580,7 @@ func (a *cpuAccumulator) takeFullSockets() {
 
 func (a *cpuAccumulator) takeFullUncore() {
 	for _, uncore := range a.freeUncoreCache() {
-		cpusInUncore := a.topo.CPUDetails.CPUsInUncoreCaches(uncore)
+		cpusInUncore := a.queries.allCPUsInUncoreCaches(uncore)
 		if !a.needsAtLeast(cpusInUncore.Size()) {
 			continue
 		}
@@ -587,8 +592,8 @@ func (a *cpuAccumulator) takeFullUncore() {
 func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 	// determine the N number of free cores (physical cpus) within the UncoreCache, then
 	// determine the M number of free cpus (virtual cpus) that correspond with the free cores
-	freeCores := a.details.CoreKeysNeededForCPUsInUncoreCache(a.numCPUsNeeded, uncoreID)
-	freeCPUs := a.details.CPUsInCoreKeys(freeCores...)
+	freeCores := a.queries.availableCoreKeysNeededForCPUsInUncoreCache(a.numCPUsNeeded, uncoreID)
+	freeCPUs := a.queries.availableCPUsInCoreKeys(freeCores...)
 
 	// We sort and trim CPUs to pack whole cores as much as possible while still
 	// allowing the final core to contribute only the CPUs needed by this request.
@@ -617,7 +622,7 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 func (a *cpuAccumulator) takeUncoreCache() {
 	for _, uncore := range a.sortAvailableUncoreCaches() {
 		// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
-		if a.needsAtLeast(a.topo.CPUDetails.CPUsInUncoreCaches(uncore).Size()) {
+		if a.needsAtLeast(a.queries.allCPUsInUncoreCaches(uncore).Size()) {
 			a.takeFullUncore()
 		}
 
@@ -635,7 +640,7 @@ func (a *cpuAccumulator) takeUncoreCache() {
 
 func (a *cpuAccumulator) takeFullCores() {
 	for _, core := range a.freeCores() {
-		cpusInCore := a.topo.CPUDetails.CPUsInCoreKeys(core)
+		cpusInCore := a.queries.allCPUsInCoreKeys(core)
 		if !a.needsAtLeast(cpusInCore.Size()) {
 			continue
 		}
@@ -659,13 +664,13 @@ func (a *cpuAccumulator) takeRemainingCPUs() {
 // CPU groups have size given by the `cpuGroupSize` argument.
 func (a *cpuAccumulator) rangeNUMANodesNeededToSatisfy(cpuGroupSize int) (minNumNUMAs, maxNumNUMAs int) {
 	// Get the total number of NUMA nodes in the system.
-	numNUMANodes := a.topo.CPUDetails.NUMANodes().Size()
+	numNUMANodes := a.queries.allNUMANodes().Size()
 
 	// Get the total number of NUMA nodes that have CPUs available on them.
-	numNUMANodesAvailable := a.details.NUMANodes().Size()
+	numNUMANodesAvailable := a.queries.availableNUMANodes().Size()
 
 	// Get the total number of CPUs in the system.
-	numCPUs := a.topo.CPUDetails.CPUs().Size()
+	numCPUs := a.queries.allCPUs().Size()
 
 	// Get the total number of 'cpuGroups' in the system.
 	numCPUGroups := (numCPUs-1)/cpuGroupSize + 1
@@ -701,7 +706,7 @@ func (a *cpuAccumulator) isSatisfied() bool {
 // isFailed returns true if and only if there aren't enough available CPUs in the system.
 // (e.g. the accumulator needs 4 CPUs but only 3 are available).
 func (a *cpuAccumulator) isFailed() bool {
-	return a.numCPUsNeeded > a.details.CPUs().Size()
+	return a.numCPUsNeeded > a.queries.availableCPUsSet().Size()
 }
 
 // iterateCombinations walks through all n-choose-k subsets of size k in n and
@@ -949,7 +954,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 
 			// Check that this combination of NUMA nodes has enough CPUs to
 			// satisfy the allocation overall.
-			cpus := acc.details.CPUsInNUMANodes(combo...)
+			cpus := acc.queries.availableCPUsInNUMANodes(combo...)
 			if cpus.Size() < numCPUs {
 				return Continue
 			}
@@ -958,7 +963,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 			// 'cpuGroupSize' across the NUMA nodes in this combo.
 			numCPUGroups := 0
 			for _, numa := range combo {
-				numCPUGroups += (acc.details.CPUsInNUMANodes(numa).Size() / cpuGroupSize)
+				numCPUGroups += (acc.queries.availableCPUsInNUMANodes(numa).Size() / cpuGroupSize)
 			}
 			if (numCPUGroups * cpuGroupSize) < numCPUs {
 				return Continue
@@ -969,7 +974,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 			// modulo some remainder.
 			distribution := (numCPUs / len(combo) / cpuGroupSize) * cpuGroupSize
 			for _, numa := range combo {
-				cpus := acc.details.CPUsInNUMANodes(numa)
+				cpus := acc.queries.availableCPUsInNUMANodes(numa)
 				if cpus.Size() < distribution {
 					return Continue
 				}
@@ -982,7 +987,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 			// this combo should ultimately be chosen.
 			availableAfterAllocation := make(mapIntInt, len(numas))
 			for _, numa := range numas {
-				availableAfterAllocation[numa] = acc.details.CPUsInNUMANodes(numa).Size()
+				availableAfterAllocation[numa] = acc.queries.availableCPUsInNUMANodes(numa).Size()
 			}
 			for _, numa := range combo {
 				availableAfterAllocation[numa] -= distribution
@@ -1092,7 +1097,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 		// size 'cpuGroupSize' from 'bestCombo'.
 		distribution := (numCPUs / len(bestCombo) / cpuGroupSize) * cpuGroupSize
 		for _, numa := range bestCombo {
-			cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.details.CPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false)
+			cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.queries.availableCPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false)
 			acc.take(cpus)
 		}
 
@@ -1104,10 +1109,10 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 				if remainder == 0 {
 					break
 				}
-				if acc.details.CPUsInNUMANodes(numa).Size() < cpuGroupSize {
+				if acc.queries.availableCPUsInNUMANodes(numa).Size() < cpuGroupSize {
 					continue
 				}
-				cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.details.CPUsInNUMANodes(numa), cpuGroupSize, cpuSortingStrategy, false)
+				cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.queries.availableCPUsInNUMANodes(numa), cpuGroupSize, cpuSortingStrategy, false)
 				acc.take(cpus)
 				remainder -= cpuGroupSize
 			}

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -316,6 +316,8 @@ func newCPUAccumulatorForRequest(logger logr.Logger, request allocationRequest) 
 		numCPUsNeeded: request.numCPUs,
 		result:        cpuset.New(),
 	}
+	// Keep topology queries attached to the accumulator field itself so take()
+	// can replace acc.details and queries still see the latest available CPUs.
 	acc.queries = newTopologyQueries(request.topology, &acc.details)
 
 	if request.topology.NumSockets >= request.topology.NumNUMANodes {

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -301,21 +301,25 @@ type cpuAccumulator struct {
 }
 
 func newCPUAccumulator(logger logr.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuSortingStrategy CPUSortingStrategy) *cpuAccumulator {
+	return newCPUAccumulatorForRequest(logger, newPackedAllocationRequest(topo, availableCPUs, numCPUs, cpuSortingStrategy, false))
+}
+
+func newCPUAccumulatorForRequest(logger logr.Logger, request allocationRequest) *cpuAccumulator {
 	acc := &cpuAccumulator{
 		logger:        logger,
-		topo:          topo,
-		details:       topo.CPUDetails.KeepOnly(availableCPUs),
-		numCPUsNeeded: numCPUs,
+		topo:          request.topology,
+		details:       request.topology.CPUDetails.KeepOnly(request.availableCPUs),
+		numCPUsNeeded: request.numCPUs,
 		result:        cpuset.New(),
 	}
 
-	if topo.NumSockets >= topo.NumNUMANodes {
+	if request.topology.NumSockets >= request.topology.NumNUMANodes {
 		acc.numaOrSocketsFirst = &numaFirst{acc}
 	} else {
 		acc.numaOrSocketsFirst = &socketsFirst{acc}
 	}
 
-	if cpuSortingStrategy == CPUSortingStrategyPacked {
+	if request.cpuSortingStrategy == CPUSortingStrategyPacked {
 		acc.availableCPUSorter = &sortCPUsPacked{acc}
 	} else {
 		acc.availableCPUSorter = &sortCPUsSpread{acc}
@@ -777,12 +781,16 @@ func (a *cpuAccumulator) iterateCombinations(n []int, k int, f func([]int) LoopC
 // order of free CPUs). For any NUMA node, the cores are selected from the ones in the socket with
 // the least amount of free CPUs to the one with the highest amount of free CPUs.
 func TakeByTopologyNUMAPacked(logger logr.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuSortingStrategy CPUSortingStrategy, preferAlignByUncoreCache bool) (cpuset.CPUSet, error) {
-	acc := newCPUAccumulator(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy)
+	return takeByTopologyNUMAPackedRequest(logger, newPackedAllocationRequest(topo, availableCPUs, numCPUs, cpuSortingStrategy, preferAlignByUncoreCache))
+}
+
+func takeByTopologyNUMAPackedRequest(logger logr.Logger, request allocationRequest) (cpuset.CPUSet, error) {
+	acc := newCPUAccumulatorForRequest(logger, request)
 	if acc.isSatisfied() {
 		return acc.result, nil
 	}
 	if acc.isFailed() {
-		return cpuset.New(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", numCPUs, availableCPUs.Size())
+		return cpuset.New(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", request.numCPUs, request.availableCPUs.Size())
 	}
 
 	// Algorithm: topology-aware best-fit
@@ -802,7 +810,7 @@ func TakeByTopologyNUMAPacked(logger logr.Logger, topo *topology.CPUTopology, av
 	// 2. If PreferAlignByUncoreCache is enabled, acquire whole UncoreCaches
 	//    if available and the container requires at least a UncoreCache's-worth
 	//    of CPUs. Otherwise, acquire CPUs from the least amount of UncoreCaches.
-	if preferAlignByUncoreCache {
+	if request.constraints.preferAlignByUncoreCache {
 		acc.takeUncoreCache()
 		if acc.isSatisfied() {
 			return acc.result, nil
@@ -812,7 +820,7 @@ func TakeByTopologyNUMAPacked(logger logr.Logger, topo *topology.CPUTopology, av
 	// 3. Acquire whole cores, if available and the container requires at least
 	//    a core's-worth of CPUs.
 	//    If `CPUSortingStrategySpread` is specified, skip taking the whole core.
-	if cpuSortingStrategy != CPUSortingStrategySpread {
+	if request.cpuSortingStrategy != CPUSortingStrategySpread {
 		acc.takeFullCores()
 		if acc.isSatisfied() {
 			return acc.result, nil
@@ -899,17 +907,18 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 	// can't distribute CPUs in this chunk size.
 	// PreferAlignByUncoreCache feature not implemented here yet and set to false.
 	// Support for PreferAlignByUncoreCache to be done at beta release.
+	request := newPackedAllocationRequest(topo, availableCPUs, numCPUs, cpuSortingStrategy, false)
 	if (numCPUs % cpuGroupSize) != 0 {
-		return TakeByTopologyNUMAPacked(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy, false)
+		return takeByTopologyNUMAPackedRequest(logger, request)
 	}
 
 	// Otherwise build an accumulator to start allocating CPUs from.
-	acc := newCPUAccumulator(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy)
+	acc := newCPUAccumulatorForRequest(logger, request)
 	if acc.isSatisfied() {
 		return acc.result, nil
 	}
 	if acc.isFailed() {
-		return cpuset.New(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", numCPUs, availableCPUs.Size())
+		return cpuset.New(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", request.numCPUs, request.availableCPUs.Size())
 	}
 
 	// Get the list of NUMA nodes represented by the set of CPUs in 'availableCPUs'.
@@ -1122,5 +1131,5 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 
 	// If we never found a combination of NUMA nodes that we could properly
 	// distribute CPUs across, fall back to the packing algorithm.
-	return TakeByTopologyNUMAPacked(logger, topo, availableCPUs, numCPUs, cpuSortingStrategy, false)
+	return takeByTopologyNUMAPackedRequest(logger, request)
 }

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -96,7 +96,7 @@ type numaOrSocketsFirstFuncs interface {
 	takeFullSecondLevel()
 	sortAvailableNUMANodes() []int
 	sortAvailableSockets() []int
-	sortAvailableCores() []int
+	sortAvailableCores() []topology.CoreKey
 }
 
 type numaFirst struct{ acc *cpuAccumulator }
@@ -151,11 +151,11 @@ func (n *numaFirst) sortAvailableSockets() []int {
 
 // If NUMA nodes are higher in the memory hierarchy than sockets, then
 // cores sit directly below sockets in the memory hierarchy.
-func (n *numaFirst) sortAvailableCores() []int {
-	var result []int
+func (n *numaFirst) sortAvailableCores() []topology.CoreKey {
+	var result []topology.CoreKey
 	for _, socket := range n.acc.sortAvailableSockets() {
-		cores := n.acc.details.CoresInSockets(socket).UnsortedList()
-		n.acc.sort(cores, n.acc.details.CPUsInCores)
+		cores := n.acc.details.CoreKeysInSockets(socket)
+		n.acc.sortCoreKeys(cores, n.acc.details.CPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -196,11 +196,11 @@ func (s *socketsFirst) sortAvailableSockets() []int {
 
 // If sockets are higher in the memory hierarchy than NUMA nodes, then cores
 // sit directly below NUMA Nodes in the memory hierarchy.
-func (s *socketsFirst) sortAvailableCores() []int {
-	var result []int
+func (s *socketsFirst) sortAvailableCores() []topology.CoreKey {
+	var result []topology.CoreKey
 	for _, numa := range s.acc.sortAvailableNUMANodes() {
-		cores := s.acc.details.CoresInNUMANodes(numa).UnsortedList()
-		s.acc.sort(cores, s.acc.details.CPUsInCores)
+		cores := s.acc.details.CoreKeysInNUMANodes(numa)
+		s.acc.sortCoreKeys(cores, s.acc.details.CPUsInCoreKeys)
 		result = append(result, cores...)
 	}
 	return result
@@ -333,7 +333,7 @@ func (a *cpuAccumulator) isNUMANodeFree(numaID int) bool {
 // Returns true if the supplied socket is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
 func (a *cpuAccumulator) isSocketFree(socketID int) bool {
-	return a.details.CPUsInSockets(socketID).Size() == a.topo.CPUsPerSocket()
+	return a.details.CPUsInSockets(socketID).Size() == a.topo.CPUDetails.CPUsInSockets(socketID).Size()
 }
 
 // Returns true if the supplied UnCoreCache is fully available,
@@ -344,8 +344,8 @@ func (a *cpuAccumulator) isUncoreCacheFree(uncoreID int) bool {
 
 // Returns true if the supplied core is fully available in `a.details`.
 // "fully available" means that all the CPUs in it are free.
-func (a *cpuAccumulator) isCoreFree(coreID int) bool {
-	return a.details.CPUsInCores(coreID).Size() == a.topo.CPUsPerCore()
+func (a *cpuAccumulator) isCoreFree(core topology.CoreKey) bool {
+	return a.details.CPUsInCoreKeys(core).Size() == a.topo.CPUDetails.CPUsInCoreKeys(core).Size()
 }
 
 // Returns free NUMA Node IDs as a slice sorted by sortAvailableNUMANodes().
@@ -382,8 +382,8 @@ func (a *cpuAccumulator) freeUncoreCache() []int {
 }
 
 // Returns free core IDs as a slice sorted by sortAvailableCores().
-func (a *cpuAccumulator) freeCores() []int {
-	free := []int{}
+func (a *cpuAccumulator) freeCores() []topology.CoreKey {
+	free := []topology.CoreKey{}
 	for _, core := range a.sortAvailableCores() {
 		if a.isCoreFree(core) {
 			free = append(free, core)
@@ -415,6 +415,21 @@ func (a *cpuAccumulator) sort(ids []int, getCPUs func(ids ...int) cpuset.CPUSet)
 				return false
 			}
 			return ids[i] < ids[j]
+		})
+}
+
+func (a *cpuAccumulator) sortCoreKeys(keys []topology.CoreKey, getCPUs func(keys ...topology.CoreKey) cpuset.CPUSet) {
+	sort.Slice(keys,
+		func(i, j int) bool {
+			iCPUs := getCPUs(keys[i])
+			jCPUs := getCPUs(keys[j])
+			if iCPUs.Size() < jCPUs.Size() {
+				return true
+			}
+			if iCPUs.Size() > jCPUs.Size() {
+				return false
+			}
+			return keys[i].Less(keys[j])
 		})
 }
 
@@ -476,7 +491,7 @@ func (a *cpuAccumulator) sortAvailableSockets() []int {
 // same way as described in the previous paragraph, except that the priority of NUMA nodes and
 // sockets is inverted (e.g. first sort the cores by number of free CPUs in their NUMA nodes, then,
 // for each NUMA node, sort the cores by number of free CPUs in their sockets, etc...).
-func (a *cpuAccumulator) sortAvailableCores() []int {
+func (a *cpuAccumulator) sortAvailableCores() []topology.CoreKey {
 	return a.numaOrSocketsFirst.sortAvailableCores()
 }
 
@@ -506,7 +521,7 @@ func (a *cpuAccumulator) sortAvailableCores() []int {
 func (a *cpuAccumulator) sortAvailableCPUsPacked() []int {
 	var result []int
 	for _, core := range a.sortAvailableCores() {
-		cpus := a.details.CPUsInCores(core).UnsortedList()
+		cpus := a.details.CPUsInCoreKeys(core).UnsortedList()
 		sort.Ints(cpus)
 		result = append(result, cpus...)
 	}
@@ -566,28 +581,16 @@ func (a *cpuAccumulator) takeFullUncore() {
 }
 
 func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
-	// determine the number of cores needed whether SMT/hyperthread is enabled or disabled
-	numCoresNeeded := (a.numCPUsNeeded + a.topo.CPUsPerCore() - 1) / a.topo.CPUsPerCore()
-
 	// determine the N number of free cores (physical cpus) within the UncoreCache, then
 	// determine the M number of free cpus (virtual cpus) that correspond with the free cores
-	freeCores := a.details.CoresNeededInUncoreCache(numCoresNeeded, uncoreID)
-	freeCPUs := a.details.CPUsInCores(freeCores.UnsortedList()...)
+	freeCores := a.details.CoreKeysNeededForCPUsInUncoreCache(a.numCPUsNeeded, uncoreID)
+	freeCPUs := a.details.CPUsInCoreKeys(freeCores...)
 
-	// when SMT/hyperthread is enabled and remaining cpu requirement is an odd integer value:
-	// sort the free CPUs that were determined based on the cores that have available cpus.
-	// if the amount of free cpus is greater than the cpus needed, we can drop the last cpu
-	// since the odd integer request will only require one out of the two free cpus that
-	// correspond to the last core
-	if a.numCPUsNeeded%2 != 0 && a.topo.CPUsPerCore() > 1 {
-		// we sort freeCPUs to ensure we pack virtual cpu allocations, meaning we allocate
-		// whole core's worth of cpus as much as possible to reduce smt-misalignment
+	// We sort and trim CPUs to pack whole cores as much as possible while still
+	// allowing the final core to contribute only the CPUs needed by this request.
+	if freeCPUs.Size() > a.numCPUsNeeded {
 		sortFreeCPUs := freeCPUs.List()
-		if len(sortFreeCPUs) > a.numCPUsNeeded {
-			// if we are in takePartialUncore, the accumulator is not satisfied after
-			// takeFullUncore, so freeCPUs.Size() can't be < 1
-			sortFreeCPUs = sortFreeCPUs[:freeCPUs.Size()-1]
-		}
+		sortFreeCPUs = sortFreeCPUs[:a.numCPUsNeeded]
 		freeCPUs = cpuset.New(sortFreeCPUs...)
 	}
 
@@ -597,7 +600,7 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 		"uncore", uncoreID,
 		"claimed", claimed,
 		"needed", a.numCPUsNeeded,
-		"cores", freeCores.String(),
+		"cores", freeCores,
 		"cpus", freeCPUs.String())
 	if !claimed {
 		return
@@ -608,10 +611,9 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 // First try to take full UncoreCache, if available and need is at least the size of the UncoreCache group.
 // Second try to take the partial UncoreCache if available and the request size can fit w/in the UncoreCache.
 func (a *cpuAccumulator) takeUncoreCache() {
-	numCPUsInUncore := a.topo.CPUsPerUncore()
 	for _, uncore := range a.sortAvailableUncoreCaches() {
 		// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
-		if a.needsAtLeast(numCPUsInUncore) {
+		if a.needsAtLeast(a.topo.CPUDetails.CPUsInUncoreCaches(uncore).Size()) {
 			a.takeFullUncore()
 		}
 
@@ -629,7 +631,7 @@ func (a *cpuAccumulator) takeUncoreCache() {
 
 func (a *cpuAccumulator) takeFullCores() {
 	for _, core := range a.freeCores() {
-		cpusInCore := a.topo.CPUDetails.CPUsInCores(core)
+		cpusInCore := a.topo.CPUDetails.CPUsInCoreKeys(core)
 		if !a.needsAtLeast(cpusInCore.Size()) {
 			continue
 		}

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -381,7 +381,7 @@ func (a *cpuAccumulator) freeUncoreCache() []int {
 	return free
 }
 
-// Returns free core IDs as a slice sorted by sortAvailableCores().
+// Returns free core keys as a slice sorted by sortAvailableCores().
 func (a *cpuAccumulator) freeCores() []topology.CoreKey {
 	free := []topology.CoreKey{}
 	for _, core := range a.sortAvailableCores() {

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -907,14 +907,26 @@ func takeByTopologyNUMAPackedRequest(logger logr.Logger, request allocationReque
 // important, for example, to ensure that all CPUs (i.e. all hyperthreads) from
 // a single core are allocated together.
 func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy) (cpuset.CPUSet, error) {
+	return takeByTopologyNUMADistributedRequest(logger, newDistributedAllocationRequest(topo, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy))
+}
+
+func takeByTopologyNUMADistributedRequest(logger logr.Logger, request allocationRequest) (cpuset.CPUSet, error) {
+	cpuGroupSize := request.constraints.cpuGroupSize
+
 	// If the number of CPUs requested cannot be handed out in chunks of
 	// 'cpuGroupSize', then we just call out the packing algorithm since we
 	// can't distribute CPUs in this chunk size.
 	// PreferAlignByUncoreCache feature not implemented here yet and set to false.
 	// Support for PreferAlignByUncoreCache to be done at beta release.
-	request := newPackedAllocationRequest(topo, availableCPUs, numCPUs, cpuSortingStrategy, false)
-	if (numCPUs % cpuGroupSize) != 0 {
-		return takeByTopologyNUMAPackedRequest(logger, request)
+	packedRequest := newPackedAllocationRequest(
+		request.topology,
+		request.availableCPUs,
+		request.numCPUs,
+		request.cpuSortingStrategy,
+		false,
+	)
+	if (request.numCPUs % cpuGroupSize) != 0 {
+		return takeByTopologyNUMAPackedRequest(logger, packedRequest)
 	}
 
 	// Otherwise build an accumulator to start allocating CPUs from.
@@ -955,7 +967,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 			// Check that this combination of NUMA nodes has enough CPUs to
 			// satisfy the allocation overall.
 			cpus := acc.queries.availableCPUsInNUMANodes(combo...)
-			if cpus.Size() < numCPUs {
+			if cpus.Size() < request.numCPUs {
 				return Continue
 			}
 
@@ -965,14 +977,14 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 			for _, numa := range combo {
 				numCPUGroups += (acc.queries.availableCPUsInNUMANodes(numa).Size() / cpuGroupSize)
 			}
-			if (numCPUGroups * cpuGroupSize) < numCPUs {
+			if (numCPUGroups * cpuGroupSize) < request.numCPUs {
 				return Continue
 			}
 
 			// Check that each NUMA node in this combination can allocate an
 			// even distribution of CPUs in groups of size 'cpuGroupSize',
 			// modulo some remainder.
-			distribution := (numCPUs / len(combo) / cpuGroupSize) * cpuGroupSize
+			distribution := (request.numCPUs / len(combo) / cpuGroupSize) * cpuGroupSize
 			for _, numa := range combo {
 				cpus := acc.queries.availableCPUsInNUMANodes(numa)
 				if cpus.Size() < distribution {
@@ -996,7 +1008,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 			// Check if there are any remaining CPUs to distribute across the
 			// NUMA nodes once CPUs have been evenly distributed in groups of
 			// size 'cpuGroupSize'.
-			remainder := numCPUs - (distribution * len(combo))
+			remainder := request.numCPUs - (distribution * len(combo))
 
 			// Get a list of NUMA nodes to consider pulling the remainder CPUs
 			// from. This list excludes NUMA nodes that don't have at least
@@ -1095,15 +1107,15 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 		// Otherwise, start allocating CPUs from the NUMA node combination
 		// chosen. First allocate an even distribution of CPUs in groups of
 		// size 'cpuGroupSize' from 'bestCombo'.
-		distribution := (numCPUs / len(bestCombo) / cpuGroupSize) * cpuGroupSize
+		distribution := (request.numCPUs / len(bestCombo) / cpuGroupSize) * cpuGroupSize
 		for _, numa := range bestCombo {
-			cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.queries.availableCPUsInNUMANodes(numa), distribution, cpuSortingStrategy, false)
+			cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.queries.availableCPUsInNUMANodes(numa), distribution, request.cpuSortingStrategy, false)
 			acc.take(cpus)
 		}
 
 		// Then allocate any remaining CPUs in groups of size 'cpuGroupSize'
 		// from each NUMA node in the remainder set.
-		remainder := numCPUs - (distribution * len(bestCombo))
+		remainder := request.numCPUs - (distribution * len(bestCombo))
 		for remainder > 0 {
 			for _, numa := range bestRemainder {
 				if remainder == 0 {
@@ -1112,7 +1124,7 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 				if acc.queries.availableCPUsInNUMANodes(numa).Size() < cpuGroupSize {
 					continue
 				}
-				cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.queries.availableCPUsInNUMANodes(numa), cpuGroupSize, cpuSortingStrategy, false)
+				cpus, _ := TakeByTopologyNUMAPacked(logger, acc.topo, acc.queries.availableCPUsInNUMANodes(numa), cpuGroupSize, request.cpuSortingStrategy, false)
 				acc.take(cpus)
 				remainder -= cpuGroupSize
 			}
@@ -1136,5 +1148,5 @@ func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopolog
 
 	// If we never found a combination of NUMA nodes that we could properly
 	// distribute CPUs across, fall back to the packing algorithm.
-	return takeByTopologyNUMAPackedRequest(logger, request)
+	return takeByTopologyNUMAPackedRequest(logger, packedRequest)
 }

--- a/pkg/cpumanager/cpu_assignment.go
+++ b/pkg/cpumanager/cpu_assignment.go
@@ -786,7 +786,18 @@ func (a *cpuAccumulator) iterateCombinations(n []int, k int, f func([]int) LoopC
 // order of free CPUs). For any NUMA node, the cores are selected from the ones in the socket with
 // the least amount of free CPUs to the one with the highest amount of free CPUs.
 func TakeByTopologyNUMAPacked(logger logr.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuSortingStrategy CPUSortingStrategy, preferAlignByUncoreCache bool) (cpuset.CPUSet, error) {
-	return takeByTopologyNUMAPackedRequest(logger, newPackedAllocationRequest(topo, availableCPUs, numCPUs, cpuSortingStrategy, preferAlignByUncoreCache))
+	return takeByTopologyRequest(logger, newPackedAllocationRequest(topo, availableCPUs, numCPUs, cpuSortingStrategy, preferAlignByUncoreCache))
+}
+
+func takeByTopologyRequest(logger logr.Logger, request allocationRequest) (cpuset.CPUSet, error) {
+	switch request.policy {
+	case allocationPolicyPacked:
+		return takeByTopologyNUMAPackedRequest(logger, request)
+	case allocationPolicyDistributed:
+		return takeByTopologyNUMADistributedRequest(logger, request)
+	default:
+		return cpuset.New(), fmt.Errorf("unknown allocation policy: %d", request.policy)
+	}
 }
 
 func takeByTopologyNUMAPackedRequest(logger logr.Logger, request allocationRequest) (cpuset.CPUSet, error) {
@@ -907,7 +918,7 @@ func takeByTopologyNUMAPackedRequest(logger logr.Logger, request allocationReque
 // important, for example, to ensure that all CPUs (i.e. all hyperthreads) from
 // a single core are allocated together.
 func takeByTopologyNUMADistributed(logger logr.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy) (cpuset.CPUSet, error) {
-	return takeByTopologyNUMADistributedRequest(logger, newDistributedAllocationRequest(topo, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy))
+	return takeByTopologyRequest(logger, newDistributedAllocationRequest(topo, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy))
 }
 
 func takeByTopologyNUMADistributedRequest(logger logr.Logger, request allocationRequest) (cpuset.CPUSet, error) {

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -149,6 +149,24 @@ func TestCPUAccumulatorFreeCoresWithRepeatedCoreIDs(t *testing.T) {
 	}
 }
 
+func TestTopologyQueriesTrackAllAndAvailableCoreCPUs(t *testing.T) {
+	logger := klog.Background()
+	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1), 0, CPUSortingStrategyPacked)
+
+	socket0Core0 := topology.CoreKey{SocketID: 0, ClusterID: 0, CoreID: 0}
+	socket1Core0 := topology.CoreKey{SocketID: 1, ClusterID: 0, CoreID: 0}
+
+	if got, want := acc.queries.allCPUsInCoreKeys(socket0Core0), cpuset.New(0, 1); !got.Equals(want) {
+		t.Fatalf("allCPUsInCoreKeys(socket0Core0) = %s, want %s", got.String(), want.String())
+	}
+	if got, want := acc.queries.allCPUsInCoreKeys(socket1Core0), cpuset.New(2, 3); !got.Equals(want) {
+		t.Fatalf("allCPUsInCoreKeys(socket1Core0) = %s, want %s", got.String(), want.String())
+	}
+	if got := acc.queries.availableCPUsInCoreKeys(socket1Core0); !got.Equals(cpuset.New()) {
+		t.Fatalf("availableCPUsInCoreKeys(socket1Core0) = %s, want empty set", got.String())
+	}
+}
+
 func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
 	logger := klog.Background()
 	testCases := []struct {

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -70,6 +70,12 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 			[]int{},
 		},
 		{
+			"asymmetric sockets, larger socket free",
+			topoAsymmetricSockets,
+			cpuset.New(2, 3, 4, 5),
+			[]int{1},
+		},
+		{
 			"dual socket, multi numa per socket, HT, 2 sockets free",
 			topoDualSocketMultiNumaPerSocketHT,
 			mustParseCPUSet(t, "0-79"),
@@ -128,6 +134,15 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
 			}
 		})
+	}
+}
+
+func TestCPUAccumulatorFreeCoresWithRepeatedCoreIDs(t *testing.T) {
+	logger := klog.Background()
+	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1), 2, CPUSortingStrategyPacked)
+
+	if got, want := acc.freeCores(), []topology.CoreKey{{SocketID: 0, ClusterID: 0, CoreID: 0}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("freeCores() = %v, want %v", got, want)
 	}
 }
 
@@ -290,55 +305,86 @@ func TestCPUAccumulatorFreeCores(t *testing.T) {
 		description   string
 		topo          *topology.CPUTopology
 		availableCPUs cpuset.CPUSet
-		expect        []int
+		expect        []topology.CoreKey
 	}{
 		{
 			"single socket HT, 4 cores free",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
-			[]int{0, 1, 2, 3},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 3},
+			},
 		},
 		{
 			"single socket HT, 3 cores free",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 4, 5, 6),
-			[]int{0, 1, 2},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+			},
 		},
 		{
 			"single socket HT, 3 cores free (1 partially consumed)",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6),
-			[]int{0, 1, 2},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 1},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+			},
 		},
 		{
 			"single socket HT, 0 cores free",
 			topoSingleSocketHT,
 			cpuset.New(),
-			[]int{},
+			[]topology.CoreKey{},
 		},
 		{
 			"single socket HT, 0 cores free (4 partially consumed)",
 			topoSingleSocketHT,
 			cpuset.New(0, 1, 2, 3),
-			[]int{},
+			[]topology.CoreKey{},
 		},
 		{
 			"dual socket HT, 6 cores free",
 			topoDualSocketHT,
 			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-			[]int{0, 2, 4, 1, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 0},
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 1},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 		{
 			"dual socket HT, 5 cores free (1 consumed from socket 0)",
 			topoDualSocketHT,
 			cpuset.New(2, 1, 3, 4, 5, 7, 8, 9, 10, 11),
-			[]int{2, 4, 1, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 1},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 		{
 			"dual socket HT, 4 cores free (1 consumed from each socket)",
 			topoDualSocketHT,
 			cpuset.New(2, 3, 4, 5, 8, 9, 10, 11),
-			[]int{2, 4, 3, 5},
+			[]topology.CoreKey{
+				{SocketID: 0, ClusterID: 0, CoreID: 2},
+				{SocketID: 0, ClusterID: 0, CoreID: 4},
+				{SocketID: 1, ClusterID: 0, CoreID: 3},
+				{SocketID: 1, ClusterID: 0, CoreID: 5},
+			},
 		},
 	}
 
@@ -766,6 +812,15 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 			10,
 			"",
 			mustParseCPUSet(t, "4-7,12-15,1,9"),
+		},
+		{
+			"take partial uncore from asymmetric SMT uncore",
+			topoAsymmetricUncoreSMT,
+			StaticPolicyOptions{PreferAlignByUncoreCacheOption: true},
+			mustParseCPUSet(t, "0-5"),
+			3,
+			"",
+			cpuset.New(0, 2, 5),
 		},
 	}...)
 

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -167,6 +167,23 @@ func TestTopologyQueriesTrackAllAndAvailableCoreCPUs(t *testing.T) {
 	}
 }
 
+func TestTopologyQueriesTrackAvailableCPUsAfterTake(t *testing.T) {
+	logger := klog.Background()
+	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1, 2, 3), 0, CPUSortingStrategyPacked)
+
+	socket1Core0 := topology.CoreKey{SocketID: 1, ClusterID: 0, CoreID: 0}
+
+	if got, want := acc.queries.availableCPUsInCoreKeys(socket1Core0), cpuset.New(2, 3); !got.Equals(want) {
+		t.Fatalf("availableCPUsInCoreKeys(socket1Core0) before take = %s, want %s", got.String(), want.String())
+	}
+
+	acc.take(cpuset.New(2, 3))
+
+	if got := acc.queries.availableCPUsInCoreKeys(socket1Core0); !got.Equals(cpuset.New()) {
+		t.Fatalf("availableCPUsInCoreKeys(socket1Core0) after take = %s, want empty set", got.String())
+	}
+}
+
 func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
 	logger := klog.Background()
 	testCases := []struct {

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -845,6 +845,21 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 	}
 }
 
+func TestTakeByTopologyNUMAPackedRequest(t *testing.T) {
+	logger := klog.Background()
+	request := newPackedAllocationRequest(topoAsymmetricUncoreSMT, mustParseCPUSet(t, "0-5"), 3, CPUSortingStrategyPacked, true)
+
+	got, err := takeByTopologyNUMAPackedRequest(logger, request)
+	if err != nil {
+		t.Fatalf("takeByTopologyNUMAPackedRequest() failed: %v", err)
+	}
+
+	want := cpuset.New(0, 2, 5)
+	if !got.Equals(want) {
+		t.Fatalf("takeByTopologyNUMAPackedRequest() = %s, want %s", got.String(), want.String())
+	}
+}
+
 func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
 	logger := klog.Background()
 	testCases := []struct {

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -878,6 +878,27 @@ func TestTakeByTopologyNUMAPackedRequest(t *testing.T) {
 	}
 }
 
+func TestTakeByTopologyNUMADistributedRequest(t *testing.T) {
+	logger := klog.Background()
+	request := newDistributedAllocationRequest(
+		topoDualSocketHT,
+		cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+		1,
+		2,
+		CPUSortingStrategyPacked,
+	)
+
+	got, err := takeByTopologyNUMADistributedRequest(logger, request)
+	if err != nil {
+		t.Fatalf("takeByTopologyNUMADistributedRequest() failed: %v", err)
+	}
+
+	want := cpuset.New(2)
+	if !got.Equals(want) {
+		t.Fatalf("takeByTopologyNUMADistributedRequest() = %s, want %s", got.String(), want.String())
+	}
+}
+
 func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
 	logger := klog.Background()
 	testCases := []struct {

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -139,9 +139,12 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 
 func TestCPUAccumulatorFreeCoresWithRepeatedCoreIDs(t *testing.T) {
 	logger := klog.Background()
-	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1), 2, CPUSortingStrategyPacked)
+	acc := newCPUAccumulator(logger, topoRepeatedCoreIDs, cpuset.New(0, 1, 2, 3), 2, CPUSortingStrategyPacked)
 
-	if got, want := acc.freeCores(), []topology.CoreKey{{SocketID: 0, ClusterID: 0, CoreID: 0}}; !reflect.DeepEqual(got, want) {
+	if got, want := acc.freeCores(), []topology.CoreKey{
+		{SocketID: 0, ClusterID: 0, CoreID: 0},
+		{SocketID: 1, ClusterID: 0, CoreID: 0},
+	}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("freeCores() = %v, want %v", got, want)
 	}
 }

--- a/pkg/cpumanager/cpu_assignment_test.go
+++ b/pkg/cpumanager/cpu_assignment_test.go
@@ -899,6 +899,42 @@ func TestTakeByTopologyNUMADistributedRequest(t *testing.T) {
 	}
 }
 
+func TestTakeByTopologyRequestUsesPackedPolicy(t *testing.T) {
+	logger := klog.Background()
+	request := newPackedAllocationRequest(topoAsymmetricUncoreSMT, mustParseCPUSet(t, "0-5"), 3, CPUSortingStrategyPacked, true)
+
+	got, err := takeByTopologyRequest(logger, request)
+	if err != nil {
+		t.Fatalf("takeByTopologyRequest() failed: %v", err)
+	}
+
+	want := cpuset.New(0, 2, 5)
+	if !got.Equals(want) {
+		t.Fatalf("takeByTopologyRequest() = %s, want %s", got.String(), want.String())
+	}
+}
+
+func TestTakeByTopologyRequestUsesDistributedPolicy(t *testing.T) {
+	logger := klog.Background()
+	request := newDistributedAllocationRequest(
+		topoDualSocketHT,
+		cpuset.New(1, 2, 3, 4, 5, 7, 8, 9, 10, 11),
+		1,
+		2,
+		CPUSortingStrategyPacked,
+	)
+
+	got, err := takeByTopologyRequest(logger, request)
+	if err != nil {
+		t.Fatalf("takeByTopologyRequest() failed: %v", err)
+	}
+
+	want := cpuset.New(2)
+	if !got.Equals(want) {
+		t.Fatalf("takeByTopologyRequest() = %s, want %s", got.String(), want.String())
+	}
+}
+
 func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
 	logger := klog.Background()
 	testCases := []struct {

--- a/pkg/cpumanager/test_topology.go
+++ b/pkg/cpumanager/test_topology.go
@@ -62,6 +62,49 @@ var (
 		},
 	}
 
+	topoAsymmetricSockets = &topology.CPUTopology{
+		NumCPUs:      6,
+		NumSockets:   2,
+		NumNUMANodes: 2,
+		NumCores:     6,
+		CPUDetails: map[int]topology.CPUInfo{
+			0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			1: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+			2: {CoreID: 0, SocketID: 1, NUMANodeID: 1},
+			3: {CoreID: 1, SocketID: 1, NUMANodeID: 1},
+			4: {CoreID: 2, SocketID: 1, NUMANodeID: 1},
+			5: {CoreID: 3, SocketID: 1, NUMANodeID: 1},
+		},
+	}
+
+	topoRepeatedCoreIDs = &topology.CPUTopology{
+		NumCPUs:      4,
+		NumSockets:   2,
+		NumNUMANodes: 2,
+		NumCores:     2,
+		CPUDetails: map[int]topology.CPUInfo{
+			0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+			2: {CoreID: 0, SocketID: 1, NUMANodeID: 1},
+			3: {CoreID: 0, SocketID: 1, NUMANodeID: 1},
+		},
+	}
+
+	topoAsymmetricUncoreSMT = &topology.CPUTopology{
+		NumCPUs:        6,
+		NumSockets:     1,
+		NumCores:       3,
+		NumUncoreCache: 2,
+		CPUDetails: map[int]topology.CPUInfo{
+			0: {CoreID: 0, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			1: {CoreID: 1, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			2: {CoreID: 2, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+			3: {CoreID: 0, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			4: {CoreID: 1, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 0},
+			5: {CoreID: 2, SocketID: 0, NUMANodeID: 0, UncoreCacheID: 1},
+		},
+	}
+
 	topoUncoreDualSocketNoSMT = &topology.CPUTopology{
 		NumCPUs:        16,
 		NumSockets:     2,

--- a/pkg/cpumanager/topology_queries.go
+++ b/pkg/cpumanager/topology_queries.go
@@ -23,7 +23,9 @@ import (
 
 // topologyQueries keeps exact topology queries in one place while preserving
 // the distinction between the full topology and the accumulator's currently
-// available CPUs.
+// available CPUs. availableCPUs points at cpuAccumulator.details itself, not a
+// copied map, so queries continue to observe take() replacing that field with a
+// freshly filtered CPUDetails.
 type topologyQueries struct {
 	topology      *topology.CPUTopology
 	availableCPUs *topology.CPUDetails

--- a/pkg/cpumanager/topology_queries.go
+++ b/pkg/cpumanager/topology_queries.go
@@ -41,7 +41,7 @@ func (q topologyQueries) allCPUs() cpuset.CPUSet {
 }
 
 func (q topologyQueries) availableCPUsSet() cpuset.CPUSet {
-	return (*q.availableCPUs).CPUs()
+	return q.availableCPUs.CPUs()
 }
 
 func (q topologyQueries) allNUMANodes() cpuset.CPUSet {
@@ -49,11 +49,11 @@ func (q topologyQueries) allNUMANodes() cpuset.CPUSet {
 }
 
 func (q topologyQueries) availableNUMANodes() cpuset.CPUSet {
-	return (*q.availableCPUs).NUMANodes()
+	return q.availableCPUs.NUMANodes()
 }
 
 func (q topologyQueries) availableSockets() cpuset.CPUSet {
-	return (*q.availableCPUs).Sockets()
+	return q.availableCPUs.Sockets()
 }
 
 func (q topologyQueries) allCPUsInNUMANodes(ids ...int) cpuset.CPUSet {
@@ -61,7 +61,7 @@ func (q topologyQueries) allCPUsInNUMANodes(ids ...int) cpuset.CPUSet {
 }
 
 func (q topologyQueries) availableCPUsInNUMANodes(ids ...int) cpuset.CPUSet {
-	return (*q.availableCPUs).CPUsInNUMANodes(ids...)
+	return q.availableCPUs.CPUsInNUMANodes(ids...)
 }
 
 func (q topologyQueries) allCPUsInSockets(ids ...int) cpuset.CPUSet {
@@ -69,7 +69,7 @@ func (q topologyQueries) allCPUsInSockets(ids ...int) cpuset.CPUSet {
 }
 
 func (q topologyQueries) availableCPUsInSockets(ids ...int) cpuset.CPUSet {
-	return (*q.availableCPUs).CPUsInSockets(ids...)
+	return q.availableCPUs.CPUsInSockets(ids...)
 }
 
 func (q topologyQueries) allCPUsInUncoreCaches(ids ...int) cpuset.CPUSet {
@@ -77,7 +77,7 @@ func (q topologyQueries) allCPUsInUncoreCaches(ids ...int) cpuset.CPUSet {
 }
 
 func (q topologyQueries) availableCPUsInUncoreCaches(ids ...int) cpuset.CPUSet {
-	return (*q.availableCPUs).CPUsInUncoreCaches(ids...)
+	return q.availableCPUs.CPUsInUncoreCaches(ids...)
 }
 
 func (q topologyQueries) allCPUsInCoreKeys(keys ...topology.CoreKey) cpuset.CPUSet {
@@ -85,29 +85,29 @@ func (q topologyQueries) allCPUsInCoreKeys(keys ...topology.CoreKey) cpuset.CPUS
 }
 
 func (q topologyQueries) availableCPUsInCoreKeys(keys ...topology.CoreKey) cpuset.CPUSet {
-	return (*q.availableCPUs).CPUsInCoreKeys(keys...)
+	return q.availableCPUs.CPUsInCoreKeys(keys...)
 }
 
 func (q topologyQueries) availableUncoreInNUMANodes(ids ...int) cpuset.CPUSet {
-	return (*q.availableCPUs).UncoreInNUMANodes(ids...)
+	return q.availableCPUs.UncoreInNUMANodes(ids...)
 }
 
 func (q topologyQueries) availableSocketsInNUMANodes(ids ...int) cpuset.CPUSet {
-	return (*q.availableCPUs).SocketsInNUMANodes(ids...)
+	return q.availableCPUs.SocketsInNUMANodes(ids...)
 }
 
 func (q topologyQueries) availableNUMANodesInSockets(ids ...int) cpuset.CPUSet {
-	return (*q.availableCPUs).NUMANodesInSockets(ids...)
+	return q.availableCPUs.NUMANodesInSockets(ids...)
 }
 
 func (q topologyQueries) availableCoreKeysInSockets(ids ...int) []topology.CoreKey {
-	return (*q.availableCPUs).CoreKeysInSockets(ids...)
+	return q.availableCPUs.CoreKeysInSockets(ids...)
 }
 
 func (q topologyQueries) availableCoreKeysInNUMANodes(ids ...int) []topology.CoreKey {
-	return (*q.availableCPUs).CoreKeysInNUMANodes(ids...)
+	return q.availableCPUs.CoreKeysInNUMANodes(ids...)
 }
 
 func (q topologyQueries) availableCoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded int, ids ...int) []topology.CoreKey {
-	return (*q.availableCPUs).CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded, ids...)
+	return q.availableCPUs.CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded, ids...)
 }

--- a/pkg/cpumanager/topology_queries.go
+++ b/pkg/cpumanager/topology_queries.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	topology "github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	"k8s.io/utils/cpuset"
+)
+
+// topologyQueries keeps exact topology queries in one place while preserving
+// the distinction between the full topology and the accumulator's currently
+// available CPUs.
+type topologyQueries struct {
+	topology      *topology.CPUTopology
+	availableCPUs *topology.CPUDetails
+}
+
+func newTopologyQueries(topo *topology.CPUTopology, availableCPUs *topology.CPUDetails) topologyQueries {
+	return topologyQueries{
+		topology:      topo,
+		availableCPUs: availableCPUs,
+	}
+}
+
+func (q topologyQueries) allCPUs() cpuset.CPUSet {
+	return q.topology.CPUDetails.CPUs()
+}
+
+func (q topologyQueries) availableCPUsSet() cpuset.CPUSet {
+	return (*q.availableCPUs).CPUs()
+}
+
+func (q topologyQueries) allNUMANodes() cpuset.CPUSet {
+	return q.topology.CPUDetails.NUMANodes()
+}
+
+func (q topologyQueries) availableNUMANodes() cpuset.CPUSet {
+	return (*q.availableCPUs).NUMANodes()
+}
+
+func (q topologyQueries) availableSockets() cpuset.CPUSet {
+	return (*q.availableCPUs).Sockets()
+}
+
+func (q topologyQueries) allCPUsInNUMANodes(ids ...int) cpuset.CPUSet {
+	return q.topology.CPUDetails.CPUsInNUMANodes(ids...)
+}
+
+func (q topologyQueries) availableCPUsInNUMANodes(ids ...int) cpuset.CPUSet {
+	return (*q.availableCPUs).CPUsInNUMANodes(ids...)
+}
+
+func (q topologyQueries) allCPUsInSockets(ids ...int) cpuset.CPUSet {
+	return q.topology.CPUDetails.CPUsInSockets(ids...)
+}
+
+func (q topologyQueries) availableCPUsInSockets(ids ...int) cpuset.CPUSet {
+	return (*q.availableCPUs).CPUsInSockets(ids...)
+}
+
+func (q topologyQueries) allCPUsInUncoreCaches(ids ...int) cpuset.CPUSet {
+	return q.topology.CPUDetails.CPUsInUncoreCaches(ids...)
+}
+
+func (q topologyQueries) availableCPUsInUncoreCaches(ids ...int) cpuset.CPUSet {
+	return (*q.availableCPUs).CPUsInUncoreCaches(ids...)
+}
+
+func (q topologyQueries) allCPUsInCoreKeys(keys ...topology.CoreKey) cpuset.CPUSet {
+	return q.topology.CPUDetails.CPUsInCoreKeys(keys...)
+}
+
+func (q topologyQueries) availableCPUsInCoreKeys(keys ...topology.CoreKey) cpuset.CPUSet {
+	return (*q.availableCPUs).CPUsInCoreKeys(keys...)
+}
+
+func (q topologyQueries) availableUncoreInNUMANodes(ids ...int) cpuset.CPUSet {
+	return (*q.availableCPUs).UncoreInNUMANodes(ids...)
+}
+
+func (q topologyQueries) availableSocketsInNUMANodes(ids ...int) cpuset.CPUSet {
+	return (*q.availableCPUs).SocketsInNUMANodes(ids...)
+}
+
+func (q topologyQueries) availableNUMANodesInSockets(ids ...int) cpuset.CPUSet {
+	return (*q.availableCPUs).NUMANodesInSockets(ids...)
+}
+
+func (q topologyQueries) availableCoreKeysInSockets(ids ...int) []topology.CoreKey {
+	return (*q.availableCPUs).CoreKeysInSockets(ids...)
+}
+
+func (q topologyQueries) availableCoreKeysInNUMANodes(ids ...int) []topology.CoreKey {
+	return (*q.availableCPUs).CoreKeysInNUMANodes(ids...)
+}
+
+func (q topologyQueries) availableCoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded int, ids ...int) []topology.CoreKey {
+	return (*q.availableCPUs).CoreKeysNeededForCPUsInUncoreCache(numCPUsNeeded, ids...)
+}


### PR DESCRIPTION
## Summary

This is a WIP experiment for the allocator-boundary direction discussed in #35, #173, and #210.

This branch is intentionally stacked on top of #210 (`AutuSnow/fix-asymmetric-topology`), so before #210 merges the diff also includes that prerequisite work.

This draft PR currently contains two focused pieces:

- a strawman / input document for the allocator-boundary direction;
- a first package-local experiment in `pkg/cpumanager` that makes grouped-allocation inputs explicit without introducing a public allocator interface yet.

## Why

The immediate goal is to test whether we can make the allocator/query boundary more explicit while preserving the current behavior and without prematurely redesigning the ResourceSlice shape or the accounting model.

The experiment is intentionally scoped:

- no ResourceSlice API changes;
- no Node Allocatable Resources / KEP-5517 accounting changes;
- no generic sub-NUMA or LLC-to-I/O locality claims beyond what the current kernel interfaces can actually guarantee.


## Notes for Review

- treat this as a design-and-experiment PR, not as a ready-to-merge feature PR;
- the design note was tightened to keep allocator boundary, ResourceSlice compatibility, and broader accounting as separate discussion tracks;
- the code change is only meant to validate the first internal boundary, not to finalize the allocator architecture.
