### PR TITLE
Chore: release and build consistency fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
-        go-version: '1.25'
+        go-version-file: go.mod
     - name: Build
       run: make build
     - name: Test
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - name: Install golangci-lint
         run: make install-golangci-lint
       - name: Run golangci-lint

--- a/.github/workflows/helm-e2e.yaml
+++ b/.github/workflows/helm-e2e.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Build the image
         run: make build-image

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ The automation will:
 
 1. Validate the semantic version format.
 1. Create and push a git tag `vX.Y.Z` at the merged commit.
-1. If it is a minor or major release (e.g. `v0.2.0`), it will automatically branch off `release-vX.Y.Z` and push it to the repository.
+1. If it is a minor or major release (e.g. `v0.2.0`), it will automatically branch off `release-vX.Y` and push it to the repository.
 
 ## 3. Promote the Images
 

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -39,7 +39,7 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f m
 | healthzPath | string | `"/healthz"` | Path for liveness and readiness probes |
 | healthzPort | int | `8080` | Port the HTTP server binds to; used for the container port and probes |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu"` | Container image repository |
+| image.repository | string | `"registry.k8s.io/dra-driver-cpu/dra-driver-cpu"` | Container image repository |
 | image.tag | string | `""` | Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time |
 | imagePullSecrets | list | `[]` | List of image pull secrets |
 | nameOverride | string | `""` | Override the chart name |

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -20,7 +20,7 @@ fullnameOverride: ""
 # @schema additionalProperties:false
 image:
   # -- Container image repository
-  repository: us-central1-docker.pkg.dev/k8s-staging-images/dra-driver-cpu/dra-driver-cpu # @schema required:true
+  repository: registry.k8s.io/dra-driver-cpu/dra-driver-cpu # @schema required:true
   # -- Image tag; defaults to `.Chart.AppVersion` when empty, which is set to the release tag at package time
   tag: ""
   # -- Image pull policy

--- a/test/image/dracputester/affinity_linux.go
+++ b/test/image/dracputester/affinity_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	"golang.org/x/sys/unix"
+	"k8s.io/utils/cpuset"
+)
+
+func getAffinity(logger logr.Logger) (cpuset.CPUSet, error) {
+	var unixCS unix.CPUSet
+	err := unix.SchedGetaffinity(os.Getpid(), &unixCS)
+	if err != nil {
+		return cpuset.New(), err
+	}
+	maxCPUID := 0
+	if topo, err := cpuinfo.NewSystemCPUInfo().GetCPUTopology(logger); err == nil {
+		maxCPUID = affinityScanBoundFromTopology(topo)
+	}
+	return affinityFromMask(&unixCS, maxCPUID), nil
+}

--- a/test/image/dracputester/affinity_linux.go
+++ b/test/image/dracputester/affinity_linux.go
@@ -1,7 +1,7 @@
 //go:build linux
 
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/image/dracputester/affinity_other.go
+++ b/test/image/dracputester/affinity_other.go
@@ -1,0 +1,32 @@
+//go:build !linux
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/go-logr/logr"
+	"k8s.io/utils/cpuset"
+)
+
+func getAffinity(logger logr.Logger) (cpuset.CPUSet, error) {
+	_ = logger
+	return cpuset.New(), fmt.Errorf("CPU affinity detection requires linux, current platform is %s", runtime.GOOS)
+}

--- a/test/image/dracputester/affinity_other.go
+++ b/test/image/dracputester/affinity_other.go
@@ -1,7 +1,7 @@
 //go:build !linux
 
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/image/dracputester/affinity_other_test.go
+++ b/test/image/dracputester/affinity_other_test.go
@@ -1,0 +1,37 @@
+//go:build !linux
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/stdr"
+)
+
+func TestGetAffinityUnsupportedPlatform(t *testing.T) {
+	_, err := getAffinity(stdr.New(log.Default()))
+	if err == nil {
+		t.Fatal("getAffinity() error = nil, want unsupported platform error")
+	}
+	if !strings.Contains(err.Error(), "linux") {
+		t.Fatalf("getAffinity() error = %q, want message mentioning linux", err)
+	}
+}

--- a/test/image/dracputester/affinity_other_test.go
+++ b/test/image/dracputester/affinity_other_test.go
@@ -1,7 +1,7 @@
 //go:build !linux
 
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/image/dracputester/app.go
+++ b/test/image/dracputester/app.go
@@ -25,11 +25,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
-	"golang.org/x/sys/unix"
 	"k8s.io/utils/cpuset"
 )
 
@@ -83,19 +81,6 @@ func affinityScanBoundFromTopology(topo *cpuinfo.CPUTopology) int {
 	}
 	list := cpus.List()
 	return list[len(list)-1] + 1
-}
-
-func getAffinity(logger logr.Logger) (cpuset.CPUSet, error) {
-	var unixCS unix.CPUSet
-	err := unix.SchedGetaffinity(os.Getpid(), &unixCS)
-	if err != nil {
-		return cpuset.New(), err
-	}
-	maxCPUID := 0
-	if topo, err := cpuinfo.NewSystemCPUInfo().GetCPUTopology(logger); err == nil {
-		maxCPUID = affinityScanBoundFromTopology(topo)
-	}
-	return affinityFromMask(&unixCS, maxCPUID), nil
 }
 
 func main() {


### PR DESCRIPTION
## What type of PR is this?
﻿
/kind cleanup
/kind documentation
﻿
## What this PR does / why we need it
﻿
- updates GitHub Actions to read the Go version from `go.mod`
- aligns the Helm chart default image registry with released artifacts
- fixes the release branch naming in `RELEASE.md` so it matches the release automation workflow
- makes `test/image/dracputester` build on non-Linux hosts by splitting Linux-specific affinity logic from shared code
﻿
These changes reduce configuration drift and make local builds work reliably on macOS hosts.
﻿
## Which issue(s) this PR is related to
﻿
N/A
﻿
## Special notes for reviewers
N/A
﻿
## Release note
﻿
```release-note
N/A
```