### PR TITLE
feat: add configuration file support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,8 @@ helm-schema: ## regenerate values.schema.json from values.yaml @schema annotatio
 		-f ${HELM_CHART}/values.yaml \
 		-o ${HELM_CHART}/values.schema.json \
 		--use-helm-docs \
+		--bundle \
+		--bundle-root ${HELM_CHART} \
 		--indent 2
 
 .PHONY: helm-schema-check

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You need to disable the CPUManager on the nodes you wish to run this DRA driver.
 
 ## Driver configuration
 
+### Command-line flags
+
 The driver can be configured with the following command-line flags:
 
 - `--cpu-device-mode`: Sets the mode for exposing CPU devices.
@@ -38,13 +40,40 @@ When deploying with Helm, set `driverConfig` in your values file. The chart seri
 map to YAML, stores it in a ConfigMap, mounts it as `/etc/dracpu/config.yaml` inside the
 driver container, and passes `--config` automatically.
 
+#### Schema
+
+The config file is a **flat** YAML map - there are no nested groups. All fields are optional
+except where noted. Unknown fields are rejected at startup to catch typos early.
+
+| Field              | Type   | Default     | Description                                                                              |
+| ------------------ | ------ | ----------- | ---------------------------------------------------------------------------------------- |
+| `apiVersion`       | string | *(omitted)* | When present, must be `v1alpha1`. Rejected otherwise.                                    |
+| `cpuDeviceMode`    | string | `grouped`   | CPU exposure mode: `individual` or `grouped`.                                            |
+| `groupBy`          | string | `numanode`  | Grouping strategy when `cpuDeviceMode` is `grouped`: `numanode`, `socket`, or `machine`. |
+| `reservedCPUs`     | string | *(none)*    | CPUs excluded from allocation, e.g. `"0-1"`.                                             |
+| `hostnameOverride` | string | *(none)*    | Override the node hostname the driver registers under.                                   |
+| `exposePCIeRoots`  | bool   | `false`     | Add PCIe root attributes to CPU devices (requires `DRAListTypeAttributes` feature gate). |
+| `kubeconfig`       | string | *(none)*    | Path to a kubeconfig file (for out-of-cluster use).                                      |
+
+#### Versioning and backward compatibility
+
+The schema is versioned via the optional `apiVersion` field (currently `v1alpha1`). The layout
+is intentionally flat for now. If a nested hierarchy is introduced in the future, the
+`apiVersion` field will be bumped so that older config files continue to be accepted or produce a
+an error.
+
+#### Example
+
 ```yaml
 # values.yaml
 driverConfig:
+  apiVersion: v1alpha1
   cpuDeviceMode: grouped
   groupBy: numanode
   reservedCPUs: "0-3"
 ```
+
+The `apiVersion` field is optional. When present it must equal `v1alpha1` (the current version); any other value is rejected at startup.
 
 `driverConfig` is a single map covering all driver settings — there is no separate Helm value
 per field. `args.*` on the other hand exposes individual fields as explicit Helm values and

--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ The driver can be configured with the following command-line flags:
 - `--reserved-cpus`: Specifies a set of CPUs to be reserved for system and kubelet processes. These CPUs will not be allocatable by the DRA driver and would be excluded from the `ResourceSlice`. The value is a cpuset, e.g., `0-1`. This semantic is the same as the one the kubelet applies with its `static` CPU Manager policy and enabling [`strict-cpu-reservation`](https://kubernetes.io/blog/2024/12/16/cpumanager-strict-cpu-reservation/) flag and specifying the CPUs with the [`reservedSystemCPUs`](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list) to be reserved for system daemons. For correct CPU accounting, the number of CPUs reserved with this flag should match the sum of the kubelet's `kubeReserved` and `systemReserved` settings. This ensures the kubelet subtracts the correct number of CPUs from `Node.Status.Allocatable`.
 - `--expose-pcie-roots`: If enabled, adds the "resource.kubernetes.io/pcieRoot" standard value to CPU devices, to report the PCIe roots close to each device. Since it always reports values as list, this option requires the cluster Feature Gate `DRAListTypeAttributes` (see KEP 5491) to be enabled. The driver has no way to introspect the cluster Feature Gate, so care must be taken to enable first the Feature Gate then this option.
 
+### Configuration file
+
+When deploying with Helm, set `driverConfig` in your values file. The chart serializes the
+map to YAML, stores it in a ConfigMap, mounts it as `/etc/dracpu/config.yaml` inside the
+driver container, and passes `--config` automatically.
+
+```yaml
+# values.yaml
+driverConfig:
+  cpuDeviceMode: grouped
+  groupBy: numanode
+  reservedCPUs: "0-3"
+```
+
+`driverConfig` is a single map covering all driver settings — there is no separate Helm value
+per field. `args.*` on the other hand exposes individual fields as explicit Helm values and
+translates them to CLI flags. Both reach the same driver settings; `args.*` takes priority when
+both are set for the same field.
+
+Both `args.*` and `driverConfig` exist during a transition period. The intent is to eventually
+deprecate `args.*` in favour of `driverConfig` as the single configuration mechanism. The driver
+logs the effective configuration at startup so you can verify which values are active.
+
 ## How it Works
 
 The driver is deployed as a DaemonSet which contains two core components:

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -53,10 +53,18 @@ const (
 
 var (
 	driverFlags = driverconfig.Default()
-	ready       atomic.Bool
+	configFile  string
+
+	ready atomic.Bool
 )
 
 func init() {
+	// --config is kept outside Config to avoid a self-referential loop,
+	// following the convention used by kubeadm and similar tools.
+	flag.StringVar(&configFile, "config", "",
+		"Path to a YAML driver configuration file. Values in the file "+
+			"are applied for any flag not explicitly provided on the command line. "+
+			"If empty, only CLI flags and built-in defaults are used.")
 	driverFlags.AddFlags(flag.CommandLine)
 }
 
@@ -85,26 +93,32 @@ func main() {
 
 	logger := ctxlog.Setup()
 
-	if err := runDriver(logger); err != nil {
+	cfg, err := driverconfig.Load(driverFlags, configFile, flag.CommandLine)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dracpu: failed to load configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := runDriver(logger, cfg); err != nil {
 		os.Exit(1)
 	}
 }
 
-func runDriver(logger logr.Logger) error {
-	if err := run(logger); err != nil {
+func runDriver(logger logr.Logger, cfg driverconfig.Config) error {
+	if err := run(logger, cfg); err != nil {
 		logger.Error(err, "failed to run")
 		return err
 	}
 	return nil
 }
 
-func run(logger logr.Logger) error {
+func run(logger logr.Logger, cfg driverconfig.Config) error {
 	printVersion(logger)
-	flag.VisitAll(func(f *flag.Flag) {
-		logger.Info("FLAG", "name", f.Name, "value", f.Value.String())
-	})
+	logger.Info("CONFIG", "bindAddress", cfg.BindAddress, "cpuDeviceMode", cfg.CPUDeviceMode,
+		"groupBy", cfg.GroupBy, "reservedCPUs", cfg.ReservedCPUs,
+		"hostnameOverride", cfg.HostnameOverride, "exposePCIeRoots", cfg.ExposePCIeRoots)
 
-	reservedCPUSet, err := cpuset.Parse(driverFlags.ReservedCPUs)
+	reservedCPUSet, err := cpuset.Parse(cfg.ReservedCPUs)
 	if err != nil {
 		return fmt.Errorf("failed to parse reserved CPUs: %w", err)
 	}
@@ -126,7 +140,7 @@ func run(logger logr.Logger) error {
 	// Add metrics handler
 	mux.Handle("/metrics", promhttp.Handler())
 	server := &http.Server{
-		Addr:              driverFlags.BindAddress,
+		Addr:              cfg.BindAddress,
 		Handler:           mux,
 		IdleTimeout:       120 * time.Second,
 		ReadTimeout:       10 * time.Second,
@@ -141,8 +155,8 @@ func run(logger logr.Logger) error {
 	}()
 
 	var restConfig *rest.Config
-	if driverFlags.Kubeconfig != "" {
-		restConfig, err = clientcmd.BuildConfigFromFlags("", driverFlags.Kubeconfig)
+	if cfg.Kubeconfig != "" {
+		restConfig, err = clientcmd.BuildConfigFromFlags("", cfg.Kubeconfig)
 	} else {
 		// creates the in-cluster config
 		restConfig, err = rest.InClusterConfig()
@@ -162,7 +176,7 @@ func run(logger logr.Logger) error {
 		return fmt.Errorf("can not create client-go client: %w", err)
 	}
 
-	nodeName, err := nodeutil.GetHostname(driverFlags.HostnameOverride)
+	nodeName, err := nodeutil.GetHostname(cfg.HostnameOverride)
 	if err != nil {
 		return fmt.Errorf("can not obtain the node name, use the hostname-override flag if you want to set it to a specific value: %w", err)
 	}
@@ -183,9 +197,9 @@ func run(logger logr.Logger) error {
 		DriverName:       driverName,
 		NodeName:         nodeName,
 		ReservedCPUs:     reservedCPUSet,
-		CPUDeviceMode:    driverFlags.CPUDeviceMode,
-		CPUDeviceGroupBy: driverFlags.GroupBy,
-		ExposePCIeRoots:  driverFlags.ExposePCIeRoots,
+		CPUDeviceMode:    cfg.CPUDeviceMode,
+		CPUDeviceGroupBy: cfg.GroupBy,
+		ExposePCIeRoots:  cfg.ExposePCIeRoots,
 		Metrics:          cpumetrics.New(prometheus.DefaultRegisterer),
 	}
 	driverProviders := driver.Providers{

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -62,8 +62,9 @@ func init() {
 	// --config is kept outside Config to avoid a self-referential loop,
 	// following the convention used by kubeadm and similar tools.
 	flag.StringVar(&configFile, "config", "",
-		"Path to a YAML driver configuration file. Values in the file "+
-			"are applied for any flag not explicitly provided on the command line. "+
+		"Path to a YAML driver configuration file. Configuration values are applied in order: "+
+			"built-in defaults, then file values, then explicit CLI flags. "+
+			"Only values explicitly set on the command line override earlier layers. "+
 			"If empty, only CLI flags and built-in defaults are used.")
 	driverFlags.AddFlags(flag.CommandLine)
 }
@@ -93,9 +94,9 @@ func main() {
 
 	logger := ctxlog.Setup()
 
-	cfg, err := driverconfig.Load(driverFlags, configFile, flag.CommandLine)
+	cfg, err := driverconfig.Load(driverFlags, configFile, flag.CommandLine, logger)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "dracpu: failed to load configuration: %v\n", err)
+		logger.Error(err, "failed to load configuration")
 		os.Exit(1)
 	}
 
@@ -114,16 +115,14 @@ func runDriver(logger logr.Logger, cfg driverconfig.Config) error {
 
 func run(logger logr.Logger, cfg driverconfig.Config) error {
 	printVersion(logger)
-	logger.Info("CONFIG", "bindAddress", cfg.BindAddress, "cpuDeviceMode", cfg.CPUDeviceMode,
-		"groupBy", cfg.GroupBy, "reservedCPUs", cfg.ReservedCPUs,
-		"hostnameOverride", cfg.HostnameOverride, "exposePCIeRoots", cfg.ExposePCIeRoots)
+	logger.Info("CONFIG", cfg.LogValues()...)
 
 	reservedCPUSet, err := cpuset.Parse(cfg.ReservedCPUs)
 	if err != nil {
 		return fmt.Errorf("failed to parse reserved CPUs: %w", err)
 	}
 
-	sfs, err := newSysFS(logger, driverFlags.SysFSOverlay)
+	sfs, err := newSysFS(logger, cfg.SysFSOverlay)
 	if err != nil {
 		return err
 	}

--- a/cmd/dracpu/app_test.go
+++ b/cmd/dracpu/app_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/driverconfig"
+)
+
+// TestRunUsesConfigSysFSOverlay: run() must build the sysfs overlay from cfg, not the pre-merge driverFlags.
+func TestRunUsesConfigSysFSOverlay(t *testing.T) {
+	cfg := driverconfig.Default()
+	cfg.SysFSOverlay = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	err := run(testr.New(t), cfg)
+	if err == nil {
+		t.Fatal("run() succeeded, want error reading missing sysfs overlay")
+	}
+	if !strings.Contains(err.Error(), "read sysfs overlay") {
+		t.Fatalf("run() error = %v, want sysfs overlay read error (cfg.SysFSOverlay was ignored)", err)
+	}
+}

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -35,13 +35,13 @@ helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driv
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for scheduling the DaemonSet pods |
-| args.cpuDeviceMode | string | `"grouped"` | CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device) |
+| args.cpuDeviceMode | string | `""` | CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); when empty, defers to `driverConfig.cpuDeviceMode` or the built-in default (`grouped`) |
 | args.exposePCIeRoots | bool | `false` | Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster |
-| args.groupBy | string | `"numanode"` | Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine` |
+| args.groupBy | string | `""` | Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; when empty, defers to `driverConfig.groupBy` or the built-in default (`numanode`) |
 | args.hostnameOverride | string | `""` | Override the node name the driver registers under; omitted when empty |
 | args.logLevel | int | `4` | Log verbosity level passed as `--v` |
 | args.reservedCPUs | string | `""` | CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty |
-| driverConfig | object | `{}` | Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. CLI flags (args.*) always take priority over values set here. Example:   driverConfig:     cpuDeviceMode: grouped     groupBy: numanode     reservedCPUs: "0-3" |
+| driverConfig | object | `{}` | Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. Fields in `args.*` that are non-empty always take priority over values set here. Example:   driverConfig:     cpuDeviceMode: individual     groupBy: socket     reservedCPUs: "0-3" |
 | extraArgs | list | `[]` | Extra command-line arguments appended to the driver arguments |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for the driver container |
 | extraVolumes | list | `[]` | Extra volumes for the DaemonSet pod |

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -36,7 +36,7 @@ helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driv
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for scheduling the DaemonSet pods |
 | args.cpuDeviceMode | string | `""` | CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); when empty, defers to `driverConfig.cpuDeviceMode` or the built-in default (`grouped`) |
-| args.exposePCIeRoots | bool | `false` | Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster |
+| args.exposePCIeRoots | bool | `false` | Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster. Not configurable via `driverConfig`; use this flag instead |
 | args.groupBy | string | `""` | Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; when empty, defers to `driverConfig.groupBy` or the built-in default (`numanode`) |
 | args.hostnameOverride | string | `""` | Override the node name the driver registers under; omitted when empty |
 | args.logLevel | int | `4` | Log verbosity level passed as `--v` |

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -41,6 +41,7 @@ helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driv
 | args.hostnameOverride | string | `""` | Override the node name the driver registers under; omitted when empty |
 | args.logLevel | int | `4` | Log verbosity level passed as `--v` |
 | args.reservedCPUs | string | `""` | CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty |
+| driverConfig | object | `{}` | Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. CLI flags (args.*) always take priority over values set here. Example:   driverConfig:     cpuDeviceMode: grouped     groupBy: numanode     reservedCPUs: "0-3" |
 | extraArgs | list | `[]` | Extra command-line arguments appended to the driver arguments |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for the driver container |
 | extraVolumes | list | `[]` | Extra volumes for the DaemonSet pod |

--- a/deployment/helm/dra-driver-cpu/driverconfig.schema.json
+++ b/deployment/helm/dra-driver-cpu/driverconfig.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "driverconfig.schema.json",
+  "$comment": "Schema for driverConfig values. Mirrors internal/driverconfig/config.go Config struct, except bindAddress which is intentionally excluded — use the healthzPort Helm value instead. Update this file when fields are added or removed from Config.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "enum": ["v1alpha1"]
+    },
+    "kubeconfig": {
+      "type": "string"
+    },
+    "hostnameOverride": {
+      "type": "string"
+    },
+    "reservedCPUs": {
+      "type": "string"
+    },
+    "cpuDeviceMode": {
+      "type": "string",
+      "enum": ["grouped", "individual"]
+    },
+    "groupBy": {
+      "type": "string",
+      "enum": ["numanode", "socket", "machine"]
+    },
+    "exposePCIeRoots": {
+      "type": "boolean"
+    }
+  }
+}

--- a/deployment/helm/dra-driver-cpu/driverconfig.schema.json
+++ b/deployment/helm/dra-driver-cpu/driverconfig.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "driverconfig.schema.json",
-  "$comment": "Schema for driverConfig values. Mirrors internal/driverconfig/config.go Config struct, except bindAddress which is intentionally excluded — use the healthzPort Helm value instead. Update this file when fields are added or removed from Config.",
+  "$comment": "Schema for driverConfig values. Mirrors internal/driverconfig/config.go Config struct, except bindAddress, exposePCIeRoots, and showMetrics, whose config-file values are ignored — use healthzPort, args.exposePCIeRoots, and --show-metrics instead. Update this file when fields are added or removed from Config.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -26,8 +26,8 @@
       "type": "string",
       "enum": ["numanode", "socket", "machine"]
     },
-    "exposePCIeRoots": {
-      "type": "boolean"
+    "sysfsOverlay": {
+      "type": "string"
     }
   }
 }

--- a/deployment/helm/dra-driver-cpu/templates/configmap.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.driverConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dra-driver-cpu.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dra-driver-cpu.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- .Values.driverConfig | toYaml | nindent 4 }}
+{{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -64,8 +64,12 @@ spec:
         args:
           - /dracpu
           - --v={{ .Values.args.logLevel }}
+          {{- if .Values.args.cpuDeviceMode }}
           - --cpu-device-mode={{ .Values.args.cpuDeviceMode }}
+          {{- end }}
+          {{- if .Values.args.groupBy }}
           - --group-by={{ .Values.args.groupBy }}
+          {{- end }}
           {{- if .Values.healthzPort }}
           - --bind-address=:{{ .Values.healthzPort }}
           {{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -79,9 +79,7 @@ spec:
           {{- if .Values.args.hostnameOverride }}
           - --hostname-override={{ .Values.args.hostnameOverride }}
           {{- end }}
-          {{- if .Values.args.exposePCIeRoots }}
-          - --expose-pcie-roots
-          {{- end }}
+          - --expose-pcie-roots={{ .Values.args.exposePCIeRoots }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -34,10 +34,13 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- if .Values.driverConfig }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical
@@ -78,6 +81,9 @@ spec:
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- if .Values.driverConfig }}
+          - --config=/etc/dracpu/config.yaml
+          {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
@@ -115,6 +121,11 @@ spec:
         {{- with .Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.driverConfig }}
+        - name: driver-config
+          mountPath: /etc/dracpu
+          readOnly: true
+        {{- end }}
       volumes:
       - name: device-plugin
         hostPath:
@@ -131,4 +142,9 @@ spec:
           type: DirectoryOrCreate
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.driverConfig }}
+      - name: driver-config
+        configMap:
+          name: {{ include "dra-driver-cpu.fullname" . }}-config
       {{- end }}

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -53,8 +53,8 @@
     },
     "driverConfig": {
       "description": "Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. CLI flags (args.*) always take priority over values set here. Example: driverConfig: cpuDeviceMode: grouped groupBy: numanode reservedCPUs: \"0-3\"",
-      "type": "object",
-      "additionalProperties": true
+      "$ref": "driverconfig.schema.json",
+      "type": "object"
     },
     "extraArgs": {
       "description": "Extra command-line arguments appended to the driver arguments",
@@ -207,6 +207,50 @@
           }
         }
       }
+    }
+  },
+  "$defs": {
+    "driverconfig.schema.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "driverconfig.schema.json",
+      "$comment": "Schema for driverConfig values. Mirrors internal/driverconfig/config.go Config struct, except bindAddress which is intentionally excluded — use the healthzPort Helm value instead. Update this file when fields are added or removed from Config.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "enum": [
+            "v1alpha1"
+          ]
+        },
+        "cpuDeviceMode": {
+          "type": "string",
+          "enum": [
+            "grouped",
+            "individual"
+          ]
+        },
+        "exposePCIeRoots": {
+          "type": "boolean"
+        },
+        "groupBy": {
+          "type": "string",
+          "enum": [
+            "numanode",
+            "socket",
+            "machine"
+          ]
+        },
+        "hostnameOverride": {
+          "type": "string"
+        },
+        "kubeconfig": {
+          "type": "string"
+        },
+        "reservedCPUs": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -15,9 +15,10 @@
       ],
       "properties": {
         "cpuDeviceMode": {
-          "description": "CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device)",
+          "description": "CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); when empty, defers to `driverConfig.cpuDeviceMode` or the built-in default (`grouped`)",
           "type": "string",
           "enum": [
+            "",
             "grouped",
             "individual"
           ]
@@ -27,9 +28,10 @@
           "type": "boolean"
         },
         "groupBy": {
-          "description": "Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`",
+          "description": "Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; when empty, defers to `driverConfig.groupBy` or the built-in default (`numanode`)",
           "type": "string",
           "enum": [
+            "",
             "numanode",
             "socket",
             "machine"
@@ -52,7 +54,7 @@
       "additionalProperties": false
     },
     "driverConfig": {
-      "description": "Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. CLI flags (args.*) always take priority over values set here. Example: driverConfig: cpuDeviceMode: grouped groupBy: numanode reservedCPUs: \"0-3\"",
+      "description": "Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. Fields in `args.*` that are non-empty always take priority over values set here. Example: driverConfig: cpuDeviceMode: individual groupBy: socket reservedCPUs: \"0-3\"",
       "$ref": "driverconfig.schema.json",
       "type": "object"
     },

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -51,6 +51,11 @@
       },
       "additionalProperties": false
     },
+    "driverConfig": {
+      "description": "Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. CLI flags (args.*) always take priority over values set here. Example: driverConfig: cpuDeviceMode: grouped groupBy: numanode reservedCPUs: \"0-3\"",
+      "type": "object",
+      "additionalProperties": true
+    },
     "extraArgs": {
       "description": "Extra command-line arguments appended to the driver arguments",
       "type": "array",

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -24,7 +24,7 @@
           ]
         },
         "exposePCIeRoots": {
-          "description": "Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster",
+          "description": "Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster. Not configurable via `driverConfig`; use this flag instead",
           "type": "boolean"
         },
         "groupBy": {
@@ -215,7 +215,7 @@
     "driverconfig.schema.json": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "driverconfig.schema.json",
-      "$comment": "Schema for driverConfig values. Mirrors internal/driverconfig/config.go Config struct, except bindAddress which is intentionally excluded — use the healthzPort Helm value instead. Update this file when fields are added or removed from Config.",
+      "$comment": "Schema for driverConfig values. Mirrors internal/driverconfig/config.go Config struct, except bindAddress, exposePCIeRoots, and showMetrics, whose config-file values are ignored — use healthzPort, args.exposePCIeRoots, and --show-metrics instead. Update this file when fields are added or removed from Config.",
       "type": "object",
       "properties": {
         "apiVersion": {
@@ -230,9 +230,6 @@
             "grouped",
             "individual"
           ]
-        },
-        "exposePCIeRoots": {
-          "type": "boolean"
         },
         "groupBy": {
           "type": "string",
@@ -249,6 +246,9 @@
           "type": "string"
         },
         "reservedCPUs": {
+          "type": "string"
+        },
+        "sysfsOverlay": {
           "type": "string"
         }
       },

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -86,7 +86,7 @@ args:
   reservedCPUs: ""
   # -- Override the node name the driver registers under; omitted when empty
   hostnameOverride: ""
-  # -- Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster
+  # -- Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster. Not configurable via `driverConfig`; use this flag instead
   exposePCIeRoots: false # @schema type:boolean
 
 # -- Path for liveness and readiness probes

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -102,4 +102,4 @@ healthzPort: 8080 # @schema type:integer;minimum:1;maximum:65535
 #     cpuDeviceMode: grouped
 #     groupBy: numanode
 #     reservedCPUs: "0-3"
-driverConfig: {} # @schema type:object;additionalProperties:true
+driverConfig: {} # @schema $ref: ./driverconfig.schema.json

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -93,3 +93,13 @@ args:
 healthzPath: /healthz
 # -- Port the HTTP server binds to; used for the container port and probes
 healthzPort: 8080 # @schema type:integer;minimum:1;maximum:65535
+
+# -- Driver config file contents. When non-empty, a ConfigMap is created and
+# mounted into the driver container as /etc/dracpu/config.yaml. CLI flags
+# (args.*) always take priority over values set here.
+# Example:
+#   driverConfig:
+#     cpuDeviceMode: grouped
+#     groupBy: numanode
+#     reservedCPUs: "0-3"
+driverConfig: {} # @schema type:object;additionalProperties:true

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -78,10 +78,10 @@ affinity: {}
 args:
   # -- Log verbosity level passed as `--v`
   logLevel: 4 # @schema type:integer;minimum:0;required:true
-  # -- CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device)
-  cpuDeviceMode: "grouped" # @schema enum:[grouped, individual];required:true
-  # -- Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`
-  groupBy: "numanode" # @schema enum:[numanode, socket, machine];required:true
+  # -- CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); when empty, defers to `driverConfig.cpuDeviceMode` or the built-in default (`grouped`)
+  cpuDeviceMode: "" # @schema enum:["",grouped,individual];required:true
+  # -- Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; when empty, defers to `driverConfig.groupBy` or the built-in default (`numanode`)
+  groupBy: "" # @schema enum:["",numanode,socket,machine];required:true
   # -- CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty
   reservedCPUs: ""
   # -- Override the node name the driver registers under; omitted when empty
@@ -95,11 +95,11 @@ healthzPath: /healthz
 healthzPort: 8080 # @schema type:integer;minimum:1;maximum:65535
 
 # -- Driver config file contents. When non-empty, a ConfigMap is created and
-# mounted into the driver container as /etc/dracpu/config.yaml. CLI flags
-# (args.*) always take priority over values set here.
+# mounted into the driver container as /etc/dracpu/config.yaml. Fields in
+# `args.*` that are non-empty always take priority over values set here.
 # Example:
 #   driverConfig:
-#     cpuDeviceMode: grouped
-#     groupBy: numanode
+#     cpuDeviceMode: individual
+#     groupBy: socket
 #     reservedCPUs: "0-3"
 driverConfig: {} # @schema $ref: ./driverconfig.schema.json

--- a/internal/driverconfig/cfgfile.go
+++ b/internal/driverconfig/cfgfile.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driverconfig
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -74,13 +75,16 @@ func mergeMap(dst, src map[string]any) {
 }
 
 // applyMap applies only the keys present in m to cfg; absent keys are
-// untouched (encoding/json.Unmarshal semantics).
+// untouched (encoding/json.Unmarshal semantics). Unknown keys are rejected
+// to catch typos early rather than silently ignoring them.
 func applyMap(cfg *Config, m map[string]any) error {
 	data, err := json.Marshal(m)
 	if err != nil {
 		return fmt.Errorf("marshaling config map: %w", err)
 	}
-	if err := json.Unmarshal(data, cfg); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(cfg); err != nil {
 		return fmt.Errorf("applying config map: %w", err)
 	}
 	return nil

--- a/internal/driverconfig/cfgfile.go
+++ b/internal/driverconfig/cfgfile.go
@@ -1,0 +1,88 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driverconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+// buildConfMap loads the config file at filePath into confMap.
+// It validates and strips "apiVersion" before returning.
+func buildConfMap(confMap map[string]interface{}, filePath string) error {
+	if err := loadAndMerge(confMap, filePath); err != nil {
+		return err
+	}
+
+	if err := validateAPIVersion(confMap); err != nil {
+		return err
+	}
+	delete(confMap, "apiVersion")
+
+	return nil
+}
+
+// loadAndMerge reads the YAML file at path and merges it into dst.
+func loadAndMerge(dst map[string]interface{}, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	src := map[string]interface{}{}
+	if err := yaml.Unmarshal(data, &src); err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	mergeMap(dst, src)
+	return nil
+}
+
+// validateAPIVersion checks confMap["apiVersion"] when present.
+func validateAPIVersion(confMap map[string]interface{}) error {
+	raw, ok := confMap["apiVersion"]
+	if !ok {
+		return nil
+	}
+	apiVer, _ := raw.(string)
+	if apiVer != ConfigAPIVersion {
+		return fmt.Errorf("unsupported apiVersion %q, want %q", apiVer, ConfigAPIVersion)
+	}
+	return nil
+}
+
+func mergeMap(dst, src map[string]interface{}) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+// applyMap applies only the keys present in m to cfg; absent keys are
+// untouched (encoding/json.Unmarshal semantics).
+func applyMap(cfg *Config, m map[string]interface{}) error {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling config map: %w", err)
+	}
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return fmt.Errorf("applying config map: %w", err)
+	}
+	return nil
+}

--- a/internal/driverconfig/cfgfile.go
+++ b/internal/driverconfig/cfgfile.go
@@ -19,6 +19,7 @@ package driverconfig
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 
 	"sigs.k8s.io/yaml"
@@ -26,7 +27,7 @@ import (
 
 // buildConfMap loads the config file at filePath into confMap.
 // It validates and strips "apiVersion" before returning.
-func buildConfMap(confMap map[string]interface{}, filePath string) error {
+func buildConfMap(confMap map[string]any, filePath string) error {
 	if err := loadAndMerge(confMap, filePath); err != nil {
 		return err
 	}
@@ -40,13 +41,13 @@ func buildConfMap(confMap map[string]interface{}, filePath string) error {
 }
 
 // loadAndMerge reads the YAML file at path and merges it into dst.
-func loadAndMerge(dst map[string]interface{}, path string) error {
+func loadAndMerge(dst map[string]any, path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	src := map[string]interface{}{}
+	src := map[string]any{}
 	if err := yaml.Unmarshal(data, &src); err != nil {
 		return fmt.Errorf("parsing %s: %w", path, err)
 	}
@@ -56,7 +57,7 @@ func loadAndMerge(dst map[string]interface{}, path string) error {
 }
 
 // validateAPIVersion checks confMap["apiVersion"] when present.
-func validateAPIVersion(confMap map[string]interface{}) error {
+func validateAPIVersion(confMap map[string]any) error {
 	raw, ok := confMap["apiVersion"]
 	if !ok {
 		return nil
@@ -68,15 +69,13 @@ func validateAPIVersion(confMap map[string]interface{}) error {
 	return nil
 }
 
-func mergeMap(dst, src map[string]interface{}) {
-	for k, v := range src {
-		dst[k] = v
-	}
+func mergeMap(dst, src map[string]any) {
+	maps.Copy(dst, src)
 }
 
 // applyMap applies only the keys present in m to cfg; absent keys are
 // untouched (encoding/json.Unmarshal semantics).
-func applyMap(cfg *Config, m map[string]interface{}) error {
+func applyMap(cfg *Config, m map[string]any) error {
 	data, err := json.Marshal(m)
 	if err != nil {
 		return fmt.Errorf("marshaling config map: %w", err)

--- a/internal/driverconfig/cfgfile.go
+++ b/internal/driverconfig/cfgfile.go
@@ -20,41 +20,40 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"os"
 
 	"sigs.k8s.io/yaml"
 )
 
-// buildConfMap loads the config file at filePath into confMap.
-// It validates and strips "apiVersion" before returning.
-func buildConfMap(confMap map[string]any, filePath string) error {
-	if err := loadAndMerge(confMap, filePath); err != nil {
-		return err
+// buildConfMap loads the config file at filePath, validates and strips
+// "apiVersion", and returns the resulting map.
+func buildConfMap(filePath string) (map[string]any, error) {
+	confMap, err := loadFile(filePath)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := validateAPIVersion(confMap); err != nil {
-		return err
+		return nil, err
 	}
 	delete(confMap, "apiVersion")
 
-	return nil
+	return confMap, nil
 }
 
-// loadAndMerge reads the YAML file at path and merges it into dst.
-func loadAndMerge(dst map[string]any, path string) error {
+// loadFile reads and parses the YAML file at path into a map.
+func loadFile(path string) (map[string]any, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("reading %s: %w", path, err)
+		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	src := map[string]any{}
-	if err := yaml.Unmarshal(data, &src); err != nil {
-		return fmt.Errorf("parsing %s: %w", path, err)
+	confMap := map[string]any{}
+	if err := yaml.Unmarshal(data, &confMap); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 
-	mergeMap(dst, src)
-	return nil
+	return confMap, nil
 }
 
 // validateAPIVersion checks confMap["apiVersion"] when present.
@@ -68,10 +67,6 @@ func validateAPIVersion(confMap map[string]any) error {
 		return fmt.Errorf("unsupported apiVersion %q, want %q", apiVer, ConfigAPIVersion)
 	}
 	return nil
-}
-
-func mergeMap(dst, src map[string]any) {
-	maps.Copy(dst, src)
 }
 
 // applyMap applies only the keys present in m to cfg; absent keys are

--- a/internal/driverconfig/config.go
+++ b/internal/driverconfig/config.go
@@ -31,3 +31,18 @@ type Config struct {
 	ShowMetrics      bool   `json:"showMetrics,omitempty"`
 	SysFSOverlay     string `json:"sysfsOverlay,omitempty"`
 }
+
+// LogValues returns key-value pairs for structured logging of the config.
+func (c Config) LogValues() []any {
+	return []any{
+		"kubeconfig", c.Kubeconfig,
+		"bindAddress", c.BindAddress,
+		"cpuDeviceMode", c.CPUDeviceMode,
+		"groupBy", c.GroupBy,
+		"reservedCPUs", c.ReservedCPUs,
+		"hostnameOverride", c.HostnameOverride,
+		"exposePCIeRoots", c.ExposePCIeRoots,
+		"showMetrics", c.ShowMetrics,
+		"sysfsOverlay", c.SysFSOverlay,
+	}
+}

--- a/internal/driverconfig/config.go
+++ b/internal/driverconfig/config.go
@@ -16,13 +16,10 @@ limitations under the License.
 
 package driverconfig
 
-import (
-	"flag"
-	"fmt"
+// ConfigAPIVersion is the version validated in config files.
+const ConfigAPIVersion = "v1alpha1"
 
-	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
-)
-
+// Config holds the driver runtime configuration.
 type Config struct {
 	Kubeconfig       string `json:"kubeconfig,omitempty"`
 	HostnameOverride string `json:"hostnameOverride,omitempty"`
@@ -33,87 +30,4 @@ type Config struct {
 	ExposePCIeRoots  bool   `json:"exposePCIeRoots,omitempty"`
 	ShowMetrics      bool   `json:"showMetrics,omitempty"`
 	SysFSOverlay     string `json:"sysfsOverlay,omitempty"`
-}
-
-func Default() Config {
-	return Config{
-		BindAddress:   ":8080",
-		CPUDeviceMode: device.CPU_DEVICE_MODE_GROUPED,
-		GroupBy:       device.GROUP_BY_NUMA_NODE,
-	}
-}
-
-func (c *Config) AddFlags(fs *flag.FlagSet) {
-	c.applyDefaults()
-
-	fs.StringVar(&c.Kubeconfig, "kubeconfig", c.Kubeconfig, "absolute path to the kubeconfig file")
-	fs.StringVar(&c.HostnameOverride, "hostname-override", c.HostnameOverride, "If non-empty, will be used as the name of the Node that kube-network-policies is running on. If unset, the node name is assumed to be the same as the node's hostname.")
-	fs.StringVar(&c.BindAddress, "bind-address", c.BindAddress, "The address to bind the HTTP server for /healthz and /metrics endpoints")
-	fs.StringVar(&c.ReservedCPUs, "reserved-cpus", c.ReservedCPUs, "cpuset of CPUs to be excluded from ResourceSlice.")
-	fs.Var(newCPUDeviceModeValue(&c.CPUDeviceMode, c.CPUDeviceMode), "cpu-device-mode", "Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device.")
-	fs.Var(newGroupByValue(&c.GroupBy, c.GroupBy), "group-by", "When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket', 'numanode', or 'machine' (machine mode requires an external scheduler to include cpuset configuration in claim allocation results).")
-	fs.BoolVar(&c.ExposePCIeRoots, "expose-pcie-roots", c.ExposePCIeRoots, "Discover and expose PCIe roots as device attributes. Requires the DRAListTypeAttributes=true Feature Gate in the cluster.")
-	fs.BoolVar(&c.ShowMetrics, "show-metrics", c.ShowMetrics, "Print custom driver metrics metadata as JSON and exit.")
-	fs.StringVar(&c.SysFSOverlay, "sysfs-overlay", c.SysFSOverlay, "Path to a YAML file containing sysfs file overlays.")
-}
-
-func (c *Config) applyDefaults() {
-	defaults := Default()
-	if c.BindAddress == "" {
-		c.BindAddress = defaults.BindAddress
-	}
-	if c.CPUDeviceMode == "" {
-		c.CPUDeviceMode = defaults.CPUDeviceMode
-	}
-	if c.GroupBy == "" {
-		c.GroupBy = defaults.GroupBy
-	}
-}
-
-type cpuDeviceModeValue struct {
-	value *string
-}
-
-func newCPUDeviceModeValue(val *string, def string) *cpuDeviceModeValue {
-	*val = def
-	return &cpuDeviceModeValue{value: val}
-}
-
-func (v *cpuDeviceModeValue) String() string {
-	if v == nil || v.value == nil {
-		return ""
-	}
-	return *v.value
-}
-
-func (v *cpuDeviceModeValue) Set(s string) error {
-	if s != device.CPU_DEVICE_MODE_GROUPED && s != device.CPU_DEVICE_MODE_INDIVIDUAL {
-		return fmt.Errorf("invalid value: %q, must be %s or %s", s, device.CPU_DEVICE_MODE_GROUPED, device.CPU_DEVICE_MODE_INDIVIDUAL)
-	}
-	*v.value = s
-	return nil
-}
-
-type groupByValue struct {
-	value *string
-}
-
-func newGroupByValue(val *string, def string) *groupByValue {
-	*val = def
-	return &groupByValue{value: val}
-}
-
-func (v *groupByValue) String() string {
-	if v == nil || v.value == nil {
-		return ""
-	}
-	return *v.value
-}
-
-func (v *groupByValue) Set(s string) error {
-	if s != device.GROUP_BY_SOCKET && s != device.GROUP_BY_NUMA_NODE && s != device.GROUP_BY_MACHINE {
-		return fmt.Errorf("invalid value: %q, must be %s, %s or %s", s, device.GROUP_BY_SOCKET, device.GROUP_BY_NUMA_NODE, device.GROUP_BY_MACHINE)
-	}
-	*v.value = s
-	return nil
 }

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The test file lives in package driverconfig_test (external test package) to
+// verify the exported API without access to internal helpers.
+package driverconfig_test
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/driverconfig"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFlagSet creates a FlagSet with cfg registered and args parsed.
+func newFlagSet(t *testing.T, cfg *driverconfig.Config, args []string) *flag.FlagSet {
+	t.Helper()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.AddFlags(fs)
+	require.NoError(t, fs.Parse(args))
+	return fs
+}
+
+// writeFile creates name with content inside dir and returns the full path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+// TestLoad_NoFile: empty filePath returns base unchanged.
+func TestLoad_NoFile(t *testing.T) {
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	result, err := driverconfig.Load(cfg, "", fs)
+
+	require.NoError(t, err)
+	assert.Equal(t, cfg, result)
+}
+
+// TestLoad_FileOverridesDefaults: file values are applied when no CLI flags are set.
+func TestLoad_FileOverridesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+bindAddress: ":9090"
+cpuDeviceMode: individual
+groupBy: socket
+reservedCPUs: "0-3"
+exposePCIeRoots: true
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil) // no CLI flags
+
+	result, err := driverconfig.Load(cfg, cfgFile, fs)
+
+	require.NoError(t, err)
+	assert.Equal(t, ":9090", result.BindAddress)
+	assert.Equal(t, device.CPU_DEVICE_MODE_INDIVIDUAL, result.CPUDeviceMode)
+	assert.Equal(t, device.GROUP_BY_SOCKET, result.GroupBy)
+	assert.Equal(t, "0-3", result.ReservedCPUs)
+	assert.True(t, result.ExposePCIeRoots)
+}
+
+// TestLoad_CLIFlagWinsOverFile: an explicitly-passed CLI flag beats the file value.
+func TestLoad_CLIFlagWinsOverFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+bindAddress: ":9090"
+cpuDeviceMode: individual
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, []string{
+		"--bind-address=:7070",
+		"--cpu-device-mode=grouped",
+	})
+
+	result, err := driverconfig.Load(cfg, cfgFile, fs)
+
+	require.NoError(t, err)
+	assert.Equal(t, ":7070", result.BindAddress)
+	assert.Equal(t, device.CPU_DEVICE_MODE_GROUPED, result.CPUDeviceMode)
+}
+
+// TestLoad_PartialFile: fields absent from the file retain their default values.
+func TestLoad_PartialFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+reservedCPUs: "4-7"
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	result, err := driverconfig.Load(cfg, cfgFile, fs)
+
+	require.NoError(t, err)
+	assert.Equal(t, "4-7", result.ReservedCPUs)
+	assert.Equal(t, ":8080", result.BindAddress)
+	assert.Equal(t, device.CPU_DEVICE_MODE_GROUPED, result.CPUDeviceMode)
+	assert.Equal(t, device.GROUP_BY_NUMA_NODE, result.GroupBy)
+}
+
+// TestLoad_FileWithoutAPIVersion: omitting apiVersion is accepted.
+func TestLoad_FileWithoutAPIVersion(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+bindAddress: ":9191"
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	result, err := driverconfig.Load(cfg, cfgFile, fs)
+
+	require.NoError(t, err)
+	assert.Equal(t, ":9191", result.BindAddress)
+}
+
+// TestLoad_UnknownAPIVersionIsError: an unrecognised apiVersion is rejected.
+func TestLoad_UnknownAPIVersionIsError(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v99
+bindAddress: ":9090"
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	_, err := driverconfig.Load(cfg, cfgFile, fs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported apiVersion")
+	assert.Contains(t, err.Error(), "v99")
+}
+
+// TestLoad_MissingFileIsError: a non-existent file path returns an error.
+func TestLoad_MissingFileIsError(t *testing.T) {
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	_, err := driverconfig.Load(cfg, "/does/not/exist/config.yaml", fs)
+
+	require.Error(t, err)
+}
+
+// TestDefault pins the built-in default values.
+func TestDefault(t *testing.T) {
+	d := driverconfig.Default()
+
+	assert.Equal(t, ":8080", d.BindAddress)
+	assert.Equal(t, device.CPU_DEVICE_MODE_GROUPED, d.CPUDeviceMode)
+	assert.Equal(t, device.GROUP_BY_NUMA_NODE, d.GroupBy)
+	// Fields with no built-in default must be zero/empty.
+	assert.Empty(t, d.Kubeconfig)
+	assert.Empty(t, d.HostnameOverride)
+	assert.Empty(t, d.ReservedCPUs)
+	assert.False(t, d.ExposePCIeRoots)
+}
+
+// TestLoad_InvalidCPUDeviceModeIsError: an invalid cpuDeviceMode in the file is rejected.
+func TestLoad_InvalidCPUDeviceModeIsError(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+cpuDeviceMode: garbage
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	_, err := driverconfig.Load(cfg, cfgFile, fs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid cpuDeviceMode")
+	assert.Contains(t, err.Error(), "garbage")
+}
+
+// TestLoad_InvalidGroupByIsError: an invalid groupBy in the file is rejected.
+func TestLoad_InvalidGroupByIsError(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+groupBy: garbage
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	_, err := driverconfig.Load(cfg, cfgFile, fs)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid groupBy")
+	assert.Contains(t, err.Error(), "garbage")
+}

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -22,8 +22,11 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
+	"github.com/go-logr/logr/testr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/internal/driverconfig"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
 	"github.com/stretchr/testify/assert"
@@ -52,7 +55,7 @@ func TestLoad_NoFile(t *testing.T) {
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil)
 
-	result, err := driverconfig.Load(cfg, "", fs)
+	result, err := driverconfig.Load(cfg, "", fs, testr.New(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, cfg, result)
@@ -73,7 +76,7 @@ exposePCIeRoots: true
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil) // no CLI flags
 
-	result, err := driverconfig.Load(cfg, cfgFile, fs)
+	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, ":9090", result.BindAddress)
@@ -98,7 +101,7 @@ cpuDeviceMode: individual
 		"--cpu-device-mode=grouped",
 	})
 
-	result, err := driverconfig.Load(cfg, cfgFile, fs)
+	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, ":7070", result.BindAddress)
@@ -116,7 +119,7 @@ reservedCPUs: "4-7"
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil)
 
-	result, err := driverconfig.Load(cfg, cfgFile, fs)
+	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, "4-7", result.ReservedCPUs)
@@ -135,7 +138,7 @@ bindAddress: ":9191"
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil)
 
-	result, err := driverconfig.Load(cfg, cfgFile, fs)
+	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, ":9191", result.BindAddress)
@@ -152,7 +155,7 @@ bindAddress: ":9090"
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil)
 
-	_, err := driverconfig.Load(cfg, cfgFile, fs)
+	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported apiVersion")
@@ -164,9 +167,35 @@ func TestLoad_MissingFileIsError(t *testing.T) {
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil)
 
-	_, err := driverconfig.Load(cfg, "/does/not/exist/config.yaml", fs)
+	_, err := driverconfig.Load(cfg, "/does/not/exist/config.yaml", fs, testr.New(t))
 
 	require.Error(t, err)
+}
+
+// TestLoad_UnmappedFlagLogsError: a flag missing from flagToJSONKey logs an error.
+func TestLoad_UnmappedFlagLogsError(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+bindAddress: ":9090"
+`)
+
+	cfg := driverconfig.Default()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.AddFlags(fs)
+	// Simulate a flag that AddFlags registers but flagToJSONKey forgot to map.
+	fs.String("unmapped-flag", "", "a flag missing from flagToJSONKey")
+	require.NoError(t, fs.Parse([]string{"--unmapped-flag=value"}))
+
+	var logs strings.Builder
+	logger := funcr.New(func(prefix, args string) {
+		logs.WriteString(prefix + " " + args + "\n")
+	}, funcr.Options{})
+
+	_, err := driverconfig.Load(cfg, cfgFile, fs, logger)
+
+	require.NoError(t, err)
+	assert.Contains(t, logs.String(), "unmapped-flag")
 }
 
 // TestDefault pins the built-in default values.
@@ -194,7 +223,7 @@ cpuDeviceMode: garbage
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil)
 
-	_, err := driverconfig.Load(cfg, cfgFile, fs)
+	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid cpuDeviceMode")
@@ -212,7 +241,7 @@ groupBy: garbage
 	cfg := driverconfig.Default()
 	fs := newFlagSet(t, &cfg, nil)
 
-	_, err := driverconfig.Load(cfg, cfgFile, fs)
+	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid groupBy")

--- a/internal/driverconfig/defaults.go
+++ b/internal/driverconfig/defaults.go
@@ -1,0 +1,28 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driverconfig
+
+import "github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+
+// Default returns a Config with built-in default values.
+func Default() Config {
+	return Config{
+		BindAddress:   ":8080",
+		CPUDeviceMode: device.CPU_DEVICE_MODE_GROUPED,
+		GroupBy:       device.GROUP_BY_NUMA_NODE,
+	}
+}

--- a/internal/driverconfig/flagmap_internal_test.go
+++ b/internal/driverconfig/flagmap_internal_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Internal package test: has direct access to the unexported flagToJSONKey map.
+package driverconfig
+
+import (
+	"flag"
+	"testing"
+)
+
+// TestFlagToJSONKey_CoversAllFlags: every AddFlags flag has a flagToJSONKey entry.
+func TestFlagToJSONKey_CoversAllFlags(t *testing.T) {
+	cfg := Config{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	fs.VisitAll(func(f *flag.Flag) {
+		if _, ok := flagToJSONKey[f.Name]; !ok {
+			t.Errorf("flag %q is registered via AddFlags but missing from flagToJSONKey", f.Name)
+		}
+	})
+}
+
+// TestFlagToJSONKey_NoStaleEntries: every flagToJSONKey entry maps to a real flag.
+func TestFlagToJSONKey_NoStaleEntries(t *testing.T) {
+	cfg := Config{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	for flagName := range flagToJSONKey {
+		if fs.Lookup(flagName) == nil {
+			t.Errorf("flagToJSONKey has entry %q but AddFlags does not register this flag", flagName)
+		}
+	}
+}

--- a/internal/driverconfig/flags.go
+++ b/internal/driverconfig/flags.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driverconfig
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+)
+
+// AddFlags registers every Config field as a CLI flag on fs.
+func (c *Config) AddFlags(fs *flag.FlagSet) {
+	c.applyDefaults()
+
+	fs.StringVar(&c.Kubeconfig, "kubeconfig", c.Kubeconfig, "absolute path to the kubeconfig file")
+	fs.StringVar(&c.HostnameOverride, "hostname-override", c.HostnameOverride, "If non-empty, will be used as the name of the Node that kube-network-policies is running on. If unset, the node name is assumed to be the same as the node's hostname.")
+	fs.StringVar(&c.BindAddress, "bind-address", c.BindAddress, "The address to bind the HTTP server for /healthz and /metrics endpoints")
+	fs.StringVar(&c.ReservedCPUs, "reserved-cpus", c.ReservedCPUs, "cpuset of CPUs to be excluded from ResourceSlice.")
+	fs.Var(newCPUDeviceModeValue(&c.CPUDeviceMode, c.CPUDeviceMode), "cpu-device-mode", "Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device.")
+	fs.Var(newGroupByValue(&c.GroupBy, c.GroupBy), "group-by", "When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket', 'numanode', or 'machine' (machine mode requires an external scheduler to include cpuset configuration in claim allocation results).")
+	fs.BoolVar(&c.ExposePCIeRoots, "expose-pcie-roots", c.ExposePCIeRoots, "Discover and expose PCIe roots as device attributes. Requires the DRAListTypeAttributes=true Feature Gate in the cluster.")
+	fs.BoolVar(&c.ShowMetrics, "show-metrics", c.ShowMetrics, "Print custom driver metrics metadata as JSON and exit.")
+	fs.StringVar(&c.SysFSOverlay, "sysfs-overlay", c.SysFSOverlay, "Path to a YAML file containing sysfs file overlays.")
+}
+
+func (c *Config) applyDefaults() {
+	defaults := Default()
+	if c.BindAddress == "" {
+		c.BindAddress = defaults.BindAddress
+	}
+	if c.CPUDeviceMode == "" {
+		c.CPUDeviceMode = defaults.CPUDeviceMode
+	}
+	if c.GroupBy == "" {
+		c.GroupBy = defaults.GroupBy
+	}
+}
+
+// Validate checks that enum fields hold recognised values.
+// Config files bypass the flag.Value validators, so Load calls this after merging.
+func (c Config) Validate() error {
+	if c.CPUDeviceMode != device.CPU_DEVICE_MODE_GROUPED && c.CPUDeviceMode != device.CPU_DEVICE_MODE_INDIVIDUAL {
+		return fmt.Errorf("invalid cpuDeviceMode %q: must be %q or %q",
+			c.CPUDeviceMode, device.CPU_DEVICE_MODE_GROUPED, device.CPU_DEVICE_MODE_INDIVIDUAL)
+	}
+	if c.CPUDeviceMode == device.CPU_DEVICE_MODE_GROUPED {
+		if c.GroupBy != device.GROUP_BY_SOCKET && c.GroupBy != device.GROUP_BY_NUMA_NODE && c.GroupBy != device.GROUP_BY_MACHINE {
+			return fmt.Errorf("invalid groupBy %q: must be %q, %q, or %q",
+				c.GroupBy, device.GROUP_BY_SOCKET, device.GROUP_BY_NUMA_NODE, device.GROUP_BY_MACHINE)
+		}
+	}
+	return nil
+}
+
+// cpuDeviceModeValue is a flag.Value that validates the --cpu-device-mode flag.
+type cpuDeviceModeValue struct {
+	value *string
+}
+
+func newCPUDeviceModeValue(val *string, def string) *cpuDeviceModeValue {
+	*val = def
+	return &cpuDeviceModeValue{value: val}
+}
+
+func (v *cpuDeviceModeValue) String() string {
+	if v == nil || v.value == nil {
+		return ""
+	}
+	return *v.value
+}
+
+func (v *cpuDeviceModeValue) Set(s string) error {
+	if s != device.CPU_DEVICE_MODE_GROUPED && s != device.CPU_DEVICE_MODE_INDIVIDUAL {
+		return fmt.Errorf("invalid value: %q, must be %s or %s", s, device.CPU_DEVICE_MODE_GROUPED, device.CPU_DEVICE_MODE_INDIVIDUAL)
+	}
+	*v.value = s
+	return nil
+}
+
+// groupByValue is a flag.Value that validates the --group-by flag.
+type groupByValue struct {
+	value *string
+}
+
+func newGroupByValue(val *string, def string) *groupByValue {
+	*val = def
+	return &groupByValue{value: val}
+}
+
+func (v *groupByValue) String() string {
+	if v == nil || v.value == nil {
+		return ""
+	}
+	return *v.value
+}
+
+func (v *groupByValue) Set(s string) error {
+	if s != device.GROUP_BY_SOCKET && s != device.GROUP_BY_NUMA_NODE && s != device.GROUP_BY_MACHINE {
+		return fmt.Errorf("invalid value: %q, must be %s, %s or %s", s, device.GROUP_BY_SOCKET, device.GROUP_BY_NUMA_NODE, device.GROUP_BY_MACHINE)
+	}
+	*v.value = s
+	return nil
+}

--- a/internal/driverconfig/load.go
+++ b/internal/driverconfig/load.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driverconfig
+
+import (
+	"flag"
+	"fmt"
+)
+
+// flagToJSONKey maps CLI flag names to their Config JSON keys.
+// Add an entry here whenever a new field is added to Config and AddFlags.
+var flagToJSONKey = map[string]string{
+	"kubeconfig":        "kubeconfig",
+	"hostname-override": "hostnameOverride",
+	"bind-address":      "bindAddress",
+	"reserved-cpus":     "reservedCPUs",
+	"cpu-device-mode":   "cpuDeviceMode",
+	"group-by":          "groupBy",
+	"expose-pcie-roots": "exposePCIeRoots",
+}
+
+// Load merges the config file at filePath into base, giving CLI flags that were
+// explicitly set (reported by fs.Visit) priority over file values.
+// If filePath is empty, base is returned unchanged. fs must already be parsed.
+func Load(base Config, filePath string, fs *flag.FlagSet) (Config, error) {
+	if filePath == "" {
+		return base, nil
+	}
+
+	explicitJSONKeys := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		if jsonKey, ok := flagToJSONKey[f.Name]; ok {
+			explicitJSONKeys[jsonKey] = true
+		}
+	})
+
+	confMap := map[string]interface{}{}
+	if err := buildConfMap(confMap, filePath); err != nil {
+		return Config{}, fmt.Errorf("config file %q: %w", filePath, err)
+	}
+
+	// CLI-explicit flags win; drop their keys so the file doesn't override them.
+	for jsonKey := range explicitJSONKeys {
+		delete(confMap, jsonKey)
+	}
+
+	result := base
+	if err := applyMap(&result, confMap); err != nil {
+		return Config{}, fmt.Errorf("applying config file %q: %w", filePath, err)
+	}
+
+	if err := result.Validate(); err != nil {
+		return Config{}, fmt.Errorf("config file %q: %w", filePath, err)
+	}
+
+	return result, nil
+}

--- a/internal/driverconfig/load.go
+++ b/internal/driverconfig/load.go
@@ -19,6 +19,8 @@ package driverconfig
 import (
 	"flag"
 	"fmt"
+
+	"github.com/go-logr/logr"
 )
 
 // flagToJSONKey maps CLI flag names to their Config JSON keys.
@@ -31,25 +33,32 @@ var flagToJSONKey = map[string]string{
 	"cpu-device-mode":   "cpuDeviceMode",
 	"group-by":          "groupBy",
 	"expose-pcie-roots": "exposePCIeRoots",
+	"show-metrics":      "showMetrics",
+	"sysfs-overlay":     "sysfsOverlay",
 }
 
 // Load merges the config file at filePath into base, giving CLI flags that were
 // explicitly set (reported by fs.Visit) priority over file values.
 // If filePath is empty, base is returned unchanged. fs must already be parsed.
-func Load(base Config, filePath string, fs *flag.FlagSet) (Config, error) {
+func Load(base Config, filePath string, fs *flag.FlagSet, logger logr.Logger) (Config, error) {
+	logger.V(6).Info("config: after flags", base.LogValues()...)
+
 	if filePath == "" {
 		return base, nil
 	}
 
 	explicitJSONKeys := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) {
-		if jsonKey, ok := flagToJSONKey[f.Name]; ok {
-			explicitJSONKeys[jsonKey] = true
+		jsonKey, ok := flagToJSONKey[f.Name]
+		if !ok {
+			logger.Error(nil, "config: flag not found in flagToJSONKey map; its explicit CLI value may be silently overridden by the config file", "flag", f.Name)
+			return
 		}
+		explicitJSONKeys[jsonKey] = true
 	})
 
-	confMap := map[string]any{}
-	if err := buildConfMap(confMap, filePath); err != nil {
+	confMap, err := buildConfMap(filePath)
+	if err != nil {
 		return Config{}, fmt.Errorf("config file %q: %w", filePath, err)
 	}
 
@@ -62,6 +71,8 @@ func Load(base Config, filePath string, fs *flag.FlagSet) (Config, error) {
 	if err := applyMap(&result, confMap); err != nil {
 		return Config{}, fmt.Errorf("applying config file %q: %w", filePath, err)
 	}
+
+	logger.V(6).Info("config: after file", result.LogValues()...)
 
 	if err := result.Validate(); err != nil {
 		return Config{}, fmt.Errorf("config file %q: %w", filePath, err)

--- a/internal/driverconfig/load.go
+++ b/internal/driverconfig/load.go
@@ -48,7 +48,7 @@ func Load(base Config, filePath string, fs *flag.FlagSet) (Config, error) {
 		}
 	})
 
-	confMap := map[string]interface{}{}
+	confMap := map[string]any{}
 	if err := buildConfMap(confMap, filePath); err != nil {
 		return Config{}, fmt.Errorf("config file %q: %w", filePath, err)
 	}

--- a/internal/driverconfig/logvalues_internal_test.go
+++ b/internal/driverconfig/logvalues_internal_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Internal package test: uses reflection over the unexported Config fields.
+package driverconfig
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestConfigLogValues_CoversAllFields: every Config json field has a LogValues key.
+func TestConfigLogValues_CoversAllFields(t *testing.T) {
+	loggedKeys := map[string]bool{}
+	values := Config{}.LogValues()
+	for i := 0; i+1 < len(values); i += 2 {
+		if key, ok := values[i].(string); ok {
+			loggedKeys[key] = true
+		}
+	}
+
+	typ := reflect.TypeFor[Config]()
+	for field := range typ.Fields() {
+		jsonName, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if jsonName == "" || jsonName == "-" {
+			continue
+		}
+		if !loggedKeys[jsonName] {
+			t.Errorf("Config field %q (json key %q) is missing from LogValues", field.Name, jsonName)
+		}
+	}
+}

--- a/internal/gatherinfo/gatherinfo.go
+++ b/internal/gatherinfo/gatherinfo.go
@@ -296,8 +296,12 @@ func detectDriverConfig(defaults driverconfig.Config, driverCmdlinePath string) 
 	if configFile == "" {
 		return cfg
 	}
+	// Resolve configFile in the driver's mount namespace: when gatherinfo runs as a
+	// standalone tool (not sharing the driver's filesystem), the raw path from the
+	// driver's cmdline is only reachable via /proc/<pid>/root, same as overlayPath above.
+	configFile = driverFilesystemPath(driverCmdlinePath, configFile)
 	// If the file can't be read (e.g. run outside the driver container), fall back to CLI-parsed config.
-	loaded, err := driverconfig.Load(cfg, configFile, fs)
+	loaded, err := driverconfig.Load(cfg, configFile, fs, logr.Discard())
 	if err != nil {
 		return cfg
 	}

--- a/internal/gatherinfo/gatherinfo.go
+++ b/internal/gatherinfo/gatherinfo.go
@@ -285,14 +285,23 @@ func detectDriverConfig(defaults driverconfig.Config, driverCmdlinePath string) 
 	fs := flag.NewFlagSet("detect-driver-config", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	cfg.AddFlags(fs)
-	// The driver command line can include logging and other shared flags.
-	// Re-parse only the driver config flags so those unrelated flags do not
-	// make diagnostics fall back to defaults.
+	var configFile string
+	fs.StringVar(&configFile, "config", "", "")
+	// Filter to flags known to this FlagSet; unrecognised flags (e.g. logging
+	// flags) would cause Parse to fail and fall back to defaults.
 	if err := fs.Parse(knownConfigArgs(fs, cmdline[1:])); err != nil {
 		return defaults
 	}
 
-	return cfg
+	if configFile == "" {
+		return cfg
+	}
+	// If the file can't be read (e.g. run outside the driver container), fall back to CLI-parsed config.
+	loaded, err := driverconfig.Load(cfg, configFile, fs)
+	if err != nil {
+		return cfg
+	}
+	return loaded
 }
 
 func readCmdlineFile(path string) ([]string, error) {

--- a/internal/gatherinfo/gatherinfo_test.go
+++ b/internal/gatherinfo/gatherinfo_test.go
@@ -179,12 +179,14 @@ func TestRunFailsWhenDriverProcessIsMissing(t *testing.T) {
 
 // TestRunReadsConfigFile: config-file values appear in the report when --config is used.
 func TestRunReadsConfigFile(t *testing.T) {
-	cfgFile := filepath.Join(t.TempDir(), "driver-config.yaml")
-	if err := os.WriteFile(cfgFile, []byte("reservedCPUs: \"2-3\"\n"), 0600); err != nil {
-		t.Fatalf("failed to write config file: %v", err)
-	}
+	driverRoot := t.TempDir()
+	configPath := "/etc/dra-driver-cpu/driver-config.yaml"
+	writeTestFile(t, filepath.Join(driverRoot, strings.TrimPrefix(configPath, "/")), []byte("reservedCPUs: \"2-3\"\n"))
 
-	setupFakeHost(t, []byte("/dracpu\x00--config="+cfgFile+"\x00"))
+	hostRoot := setupFakeHost(t, []byte("/dracpu\x00--config="+configPath+"\x00"))
+	if err := os.Symlink(driverRoot, filepath.Join(hostRoot, "proc", "42", "root")); err != nil {
+		t.Fatalf("create driver root link: %v", err)
+	}
 
 	stdout, err := captureStdout(t, func() error {
 		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{

--- a/internal/gatherinfo/gatherinfo_test.go
+++ b/internal/gatherinfo/gatherinfo_test.go
@@ -177,6 +177,30 @@ func TestRunFailsWhenDriverProcessIsMissing(t *testing.T) {
 	}
 }
 
+// TestRunReadsConfigFile: config-file values appear in the report when --config is used.
+func TestRunReadsConfigFile(t *testing.T) {
+	cfgFile := filepath.Join(t.TempDir(), "driver-config.yaml")
+	if err := os.WriteFile(cfgFile, []byte("reservedCPUs: \"2-3\"\n"), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	setupFakeHost(t, []byte("/dracpu\x00--config="+cfgFile+"\x00"))
+
+	stdout, err := captureStdout(t, func() error {
+		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{
+			DriverConfig: driverconfig.Default(),
+		}, logr.Discard())
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	report := readReport(t, []byte(stdout))
+	if report.DriverConfig.ReservedCPUs != "2-3" {
+		t.Fatalf("reservedCPUs = %q, want 2-3 (from config file)", report.DriverConfig.ReservedCPUs)
+	}
+}
+
 func TestRunRejectsStdoutWithOutputDir(t *testing.T) {
 	err := gatherinfo.Run([]string{"--stdout", "--output-dir=/tmp"}, gatherinfo.Options{}, logr.Discard())
 	if err == nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it
Adds configuration file support. The driver now accepts `--config` pointing to a YAML file. Values from the file fill in any CLI flag not explicitly set. Deployments without `--config` are not affected. When deploying with helm, `driverConfig` in values.yaml is the primary way to pass configuration.  The chart serializes the map into yaml and stores it in a configMap, mounts it into the driver container and then passes `--config` automatically. Invalid values in the config file (unknown cpuDeviceMode, groupBy, or apiVersion) are rejected at startup. The helm schema also validates `driverConfig` fields at install time.

#### Which issue(s) this PR is related to
Fixes #48 

#### Special notes for reviewers
I've been going back and forth on the value this change brings vs the additional complexity it introduces, especially considering the current state of the project.

I can definitely see the value of introducing a config file, even though I wasn't sure fully while implementing this. My hesitation wasn't because I think it's a bad idea, but because we already have a mechanism for users to provide driver configuration through helm. For someone not aware of the follow up discussion, adding another configuration mechanism may seem unnecessary, especially since driver configuration can already be provided either through individual flags or the `driverConfig` flag.

That said, I do think this change adds value in the long run. We expect the number of configuration options to grow, whether because of internal changes or future changes to the DRA API. As that happens, the number of flags will inevitably grow as well. While we could continue exposing everything as flags and ask users to pass values through standard helm `--set` options, I think that eventually becomes a poor user experience from UX point.

@ffromani made a good point [here](https://github.com/kubernetes-sigs/dra-driver-cpu/issues/142#issuecomment-4806721823) about dropping the standalone flags in favor of a single configuration file. That argument ultimately convinced me as well that this direction makes sense.

So, what comes next? If everyone agrees, my proposal would be to remove the individual flags (which should be fairly straightforward after this change) and keep `driverConfig` as the single source of truth. Users would then be able to inspect the effective configuration either from the mounted ConfigMap or from the logs.

The remaining question is when we should make that transition. I'd really like to hear everyone's thoughts on this so we can pick a good time to do it without hurting the users. And sorry for the late submission.

#### Release note

```release-note
Add config file support via --config flag. When deploying with Helm, use driverConfig in values.yaml to pass driver settings as a map. The chart creates a ConfigMap and wires --config automatically behind the scenes. 
```

#### Documentation updates
- README: added configuration file section
- Helm chart README: updated with driverConfig usage