### PR TITLE
test: cover StopContainer claim release; document lifetime invariant

### DIFF
--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -200,6 +200,24 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 	return adjust, updates, nil
 }
 
+// StopContainer releases a guaranteed container's CPU claim back into the shared pool.
+//
+// CPU-allocation lifetime across the DRA and NRI hooks:
+//   - PrepareResourceClaims (DRA) records the claim's CPUs in cpuAllocationStore and writes the CDI
+//     spec carrying that cpuset.
+//   - CreateContainer (NRI) pins the guaranteed container and shrinks the other shared containers'
+//     pool accordingly.
+//   - StopContainer (NRI, here) releases the claim's CPUs back into the shared pool and re-broadens
+//     the surviving shared containers immediately, because NRI only lets us push cpuset updates to
+//     other containers during a container lifecycle event and UnprepareResourceClaims runs too late.
+//   - UnprepareResourceClaims (DRA) does the authoritative cleanup (remove the CDI device, then
+//     release the allocation); releasing an already-released claim is a no-op, so the early release
+//     here stays consistent with it.
+//   - Synchronize (NRI, on restart) rebuilds the stores from the running containers' CDI env.
+//
+// This relies on a ResourceClaim being owned by exactly one container (claim sharing is
+// unsupported), which is what makes the early release safe. Revisit before enabling claim sharing,
+// preemption, or mixed shared/isolated allocation.
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: StopContainer")
@@ -209,14 +227,8 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	entries := "none"
 	if len(claimUIDs) > 0 {
-		// This early release in StopContainer is a workaround for a lifecycle mismatch between DRA and NRI.
-		// The proper place to release claim allocations is in the DRA UnprepareResourceClaims hook.
-		// However, NRI only allows pushing CPU mask updates to other containers during container lifecycle events
-		// (like StopContainer). If we wait until UnprepareResourceClaims to release the CPUs, we miss the opportunity
-		// to update the shared pool of existing containers, leaving them on a restricted pool until a new
-		// container event occurs.
-		// TODO: This workaround assumes that ResourceClaims are NOT shared across pods/containers. If claim sharing
-		// is supported in the future, this early release of CPUS will need an update.
+		// Early release of the claim's CPUs; see the lifetime model in StopContainer's doc comment.
+		// TODO: assumes ResourceClaims are not shared across pods/containers; revisit if sharing lands.
 		for _, claimUID := range claimUIDs {
 			cLogger := logger.WithValues("claimUID", claimUID)
 			cp.cpuAllocationStore.RemoveResourceClaimAllocation(cLogger, claimUID)

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -460,3 +460,61 @@ func containerIDsFromUpdates(updates []*api.ContainerUpdate) []string {
 	sort.Strings(ids)
 	return ids
 }
+
+// TestStopContainerReleasesClaimToSharedPool asserts the DRA/NRI lifetime invariant tracked by #188:
+// stopping a guaranteed container releases its claim's CPUs back into the shared pool *during*
+// StopContainer (the documented early-release workaround), and immediately re-broadens the other
+// shared containers to the freed pool, rather than deferring the release to UnprepareResourceClaims.
+// The existing TestStopContainer only asserts which containers are updated; this asserts the actual
+// release (the shared-pool contents) and the re-broadened cpuset values.
+func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
+	logger := testr.New(t)
+	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
+	var infos []cpuinfo.CPUInfo
+	for _, cpuID := range allCPUs.UnsortedList() {
+		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NUMANodeID: 0})
+	}
+	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: infos}
+	topo, _ := mockProvider.GetCPUTopology(logger)
+
+	guaranteedPod := &api.PodSandbox{Id: "pod-id-g", Name: "guaranteed-pod", Namespace: "ns", Uid: "pod-uid-g"}
+	guaranteedCtr := &api.Container{Id: "ctr-id-g", PodSandboxId: guaranteedPod.Id, Name: "guaranteed-ctr"}
+	sharedPod := &api.PodSandbox{Id: "pod-id-s", Name: "shared-pod", Namespace: "ns", Uid: "pod-uid-s"}
+	sharedCtr := &api.Container{Id: "ctr-id-s", PodSandboxId: sharedPod.Id, Name: "shared-ctr"}
+	claimUID := types.UID("claim-uid-1")
+	claimedCPUs := cpuset.New(0, 1)
+
+	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
+	cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, claimedCPUs)
+
+	driver := &CPUDriver{
+		podConfigStore:     store.NewPodConfig(),
+		cpuAllocationStore: cpuAllocationStore,
+		claimTracker:       store.NewClaimTracker(),
+		cpuTopology:        topo,
+	}
+	driver.podConfigStore.SetContainerState(types.UID(guaranteedPod.Uid),
+		store.NewContainerState(guaranteedCtr.Name, types.UID(guaranteedCtr.Id), claimUID))
+	driver.podConfigStore.SetContainerState(types.UID(sharedPod.Uid),
+		store.NewContainerState(sharedCtr.Name, types.UID(sharedCtr.Id)))
+
+	// Precondition: the claimed CPUs are held out of the shared pool.
+	require.True(t, driver.cpuAllocationStore.GetSharedCPUs().Equals(allCPUs.Difference(claimedCPUs)),
+		"precondition: shared pool should exclude the claimed CPUs")
+
+	updates, err := driver.StopContainer(context.Background(), guaranteedPod, guaranteedCtr)
+	require.NoError(t, err)
+
+	// Invariant 1: the claim's CPUs are released back into the shared pool during StopContainer,
+	// not deferred to UnprepareResourceClaims.
+	require.True(t, driver.cpuAllocationStore.GetSharedCPUs().Equals(allCPUs),
+		"StopContainer should release the claim's CPUs back into the shared pool")
+
+	// Invariant 2: the surviving shared container is immediately re-broadened to the full pool.
+	require.Equal(t, []*api.ContainerUpdate{
+		{
+			ContainerId: sharedCtr.Id,
+			Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: allCPUs.String()}}},
+		},
+	}, updates)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

`StopContainer` is where a guaranteed container's claim CPUs are released back into the shared pool and the surviving shared containers are re-broadened. The existing `TestStopContainer` only asserted which containers received an update, not that the release and re-broadening actually happen. This adds a unit test for that release invariant, plus a doc comment on `StopContainer` that writes down the CPU-allocation lifetime model across the DRA and NRI hooks (Prepare -> Create -> Stop -> Unprepare -> Synchronize), and trims the now-redundant inline comment.

#### Which issue(s) this PR is related to

Part of #188

#### Special notes for reviewers

The rest of the lifetime is already covered, so I did not duplicate it: `UnprepareResourceClaims` (`TestUnprepareResourceClaims*`), `Synchronize` (`TestNRISynchronize`), and the store-level idempotency of `RemoveResourceClaimAllocation` (`cpu_allocation_test.go` "remove non-existent"). That idempotency is what keeps the StopContainer early-release consistent with the authoritative Unprepare cleanup, which the new doc comment makes explicit.

cc @AutuSnow

#### Release note

```release-note
NONE
```