### PR TITLE
 Improve e2e reliability and reuse shared setup helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ PLATFORMS?=linux/amd64,linux/arm64
 LOCAL_PLATFORM?=linux/$(ARCH)
 
 # set convenient defaults for user variables
+DRACPU_E2E_TEST_IMAGE ?= $(IMAGE_TEST)
 DRACPU_E2E_CPU_DEVICE_MODE ?= grouped
 DRACPU_E2E_CPU_GROUP_BY ?= numanode
 DRACPU_E2E_RESERVED_CPUS ?= 0
@@ -228,7 +229,10 @@ build-test-dracpuinfo: ## build helper to expose hardware info in the internal d
 	go build -v -o "$(OUT_DIR)/dracpuinfo" ./test/image/dracpuinfo
 
 test-e2e: ## run e2e test against an existing configured cluster
-	env DRACPU_E2E_TEST_IMAGE=$(IMAGE_TEST) DRACPU_E2E_RESERVED_CPUS=$(DRACPU_E2E_RESERVED_CPUS) go test -v ./test/e2e/ --ginkgo.v
+	@test -n "$(DRACPU_E2E_TEST_IMAGE)" || { echo "DRACPU_E2E_TEST_IMAGE must be set for make test-e2e"; exit 1; }
+	@test -n "$(KUBECONFIG)" || { echo "KUBECONFIG must be set for make test-e2e"; exit 1; }
+	@test -f "$(KUBECONFIG)" || { echo "KUBECONFIG does not exist: $(KUBECONFIG)"; exit 1; }
+	env KUBECONFIG=$(KUBECONFIG) DRACPU_E2E_TEST_IMAGE=$(DRACPU_E2E_TEST_IMAGE) DRACPU_E2E_RESERVED_CPUS=$(DRACPU_E2E_RESERVED_CPUS) go test -v ./test/e2e/ --ginkgo.v
 
 test-e2e-kind: ci-kind-setup test-e2e ## run e2e test against a purpose-built kind cluster
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -33,7 +33,8 @@ honor these settings, where applicable.
   There's no support for verbosity levels.
 - `DRACPU_E2E_TEST_IMAGE`: (mandatory) the full pullSpec of the test image the suite should
   use as container image to run test containers. The default CI configuration sets this
-  value automatically.
+  value automatically. `make test-e2e` defaults this to `IMAGE_TEST`, but it can be
+  overridden explicitly when running against an existing cluster.
 - `DRACPU_E2E_TARGET_NODE`: (optional) the CPU-related tests don't need any specific node.
   If this variable is set, it should be the `hostname` of a valid worker node in
   the cluster against which the tests run.
@@ -71,15 +72,23 @@ To run against an existing cluster with the driver already deployed:
 make test-e2e
 ```
 
+`make test-e2e` is intentionally strict: it fails fast if `KUBECONFIG` does not point at an
+existing file or if `DRACPU_E2E_TEST_IMAGE` is empty. This keeps CI and the standard make-based
+workflow from silently reporting green after skipping the suite.
+
 Note: `make test-e2e` does not build or load the test image; it only runs the Go e2e suite.
-The `make test-e2e-kind` target builds and loads the image
-automatically into a kind cluster, but for an arbitrary cluster the default `IMAGE_TEST` value
-points at the local CI image name and will not be pullable. Either make sure the
-test image is available to the cluster, or override the image explicitly:
+The `make test-e2e-kind` target builds and loads the image automatically into a kind cluster,
+but for an arbitrary cluster the default `IMAGE_TEST` value points at the local CI image name
+and will not be pullable. Either make sure the test image is available to the cluster, or
+override both prerequisites explicitly:
 
 ```bash
-DRACPU_E2E_TEST_IMAGE=<image> make test-e2e
+KUBECONFIG=/path/to/kubeconfig DRACPU_E2E_TEST_IMAGE=<image> make test-e2e
 ```
+
+The `healthz` suite reaches driver pods through the apiserver pod proxy. The kubeconfig used
+for the tests therefore needs permission to `get` the `pods/proxy` subresource in addition to
+the usual pod listing and exec/log access. Cluster-admin kubeconfigs already satisfy this.
 
 ### troubleshooting
 

--- a/test/e2e/contextual_logging_test.go
+++ b/test/e2e/contextual_logging_test.go
@@ -18,12 +18,14 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 
+	e2eclient "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/client"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/logcheck"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
@@ -46,6 +48,10 @@ var _ = ginkgo.ReportAfterSuite("contextual logging", func(report ginkgo.Report)
 	ctx := context.Background()
 
 	rootFxt, err := fixture.ForGinkgo()
+	if errors.Is(err, e2eclient.ErrMissingKubeconfig) {
+		fmt.Fprintln(ginkgo.GinkgoWriter, err.Error())
+		return
+	}
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture: %v", err)
 	ctxlogFxt := rootFxt.WithPrefix("ctxlog")
 	gomega.Expect(ctxlogFxt.Setup(ctx)).To(gomega.Succeed())

--- a/test/e2e/contextual_logging_test.go
+++ b/test/e2e/contextual_logging_test.go
@@ -18,15 +18,12 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 
-	e2eclient "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/client"
-	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/logcheck"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
@@ -47,14 +44,12 @@ var _ = ginkgo.ReportAfterSuite("contextual logging", func(report ginkgo.Report)
 
 	ctx := context.Background()
 
-	rootFxt, err := fixture.ForGinkgo()
-	if errors.Is(err, e2eclient.ErrMissingKubeconfig) {
-		fmt.Fprintln(ginkgo.GinkgoWriter, err.Error())
+	rootFxt, ok := createFixtureForReport()
+	if !ok {
 		return
 	}
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture: %v", err)
 	ctxlogFxt := rootFxt.WithPrefix("ctxlog")
-	gomega.Expect(ctxlogFxt.Setup(ctx)).To(gomega.Succeed())
+	mustSetupFixture(ctx, ctxlogFxt)
 	defer func() { gomega.Expect(ctxlogFxt.Teardown(ctx)).To(gomega.Succeed()) }()
 
 	driverPods, err := listDriverPods(ctx, ctxlogFxt.K8SClientset)

--- a/test/e2e/contextual_logging_test.go
+++ b/test/e2e/contextual_logging_test.go
@@ -23,14 +23,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/logcheck"
-	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ReportAfterSuite runs after all specs in the suite have completed,
@@ -41,7 +40,7 @@ import (
 // which seems more fragile and cumbersome.
 var _ = ginkgo.ReportAfterSuite("contextual logging", func(report ginkgo.Report) {
 	if !report.SuiteSucceeded {
-		return
+		fmt.Fprintln(ginkgo.GinkgoWriter, "contextual logging audit continuing despite earlier suite failures")
 	}
 
 	ctx := context.Background()
@@ -52,55 +51,101 @@ var _ = ginkgo.ReportAfterSuite("contextual logging", func(report ginkgo.Report)
 	gomega.Expect(ctxlogFxt.Setup(ctx)).To(gomega.Succeed())
 	defer func() { gomega.Expect(ctxlogFxt.Teardown(ctx)).To(gomega.Succeed()) }()
 
-	targetNode, err := e2enode.PickWorker(ctx, ctxlogFxt.K8SClientset, 5*time.Second, 1*time.Minute, ctxlogFxt.Log)
+	driverPods, err := listDriverPods(ctx, ctxlogFxt.K8SClientset)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	ctxlogFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
+	gomega.Expect(driverPods).ToNot(gomega.BeEmpty(), "no driver pods found for contextual logging audit")
 
-	dracpuPod, err := e2epod.GetDRACPUPod(ctx, ctxlogFxt.K8SClientset, targetNode.Name)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	sort.Slice(driverPods, func(i, j int) bool {
+		if driverPods[i].Spec.NodeName != driverPods[j].Spec.NodeName {
+			return driverPods[i].Spec.NodeName < driverPods[j].Spec.NodeName
+		}
+		return driverPods[i].Name < driverPods[j].Name
+	})
 
-	logs, err := e2epod.GetLogs(ctx, ctxlogFxt.K8SClientset, dracpuPod)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from the dracpu pod: %v", err)
-
+	dumpRawLogs := false
 	if envVal, ok := os.LookupEnv("DRACPU_E2E_DUMP_RAW_LOGS"); ok {
-		if val, err := strconv.ParseBool(envVal); err == nil && val {
-			fmt.Fprintf(ginkgo.GinkgoWriter, "logs:\n%s", logs)
+		if val, err := strconv.ParseBool(envVal); err == nil {
+			dumpRawLogs = val
 		}
 	}
 
-	parsedLog := logcheck.NewParsedLog(logs)
-	parsedLog.OpaqueKeys = []string{"response"}
-	ctxlogFxt.Log.Info("ingested log lines", "count", parsedLog.Len())
+	var logFetchErrors []string
+	var duplicateKeyReports []string
+	var imbalanceReports []string
+	var anomalyReports []string
+	var flowBoundaryReports []string
 
-	dupKeys := logcheck.DuplicateKeys(parsedLog)
-	if len(dupKeys) > 0 {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "lines with duplicated keys:\n%s", logcheck.FormatDuplicateKeyResult(parsedLog, dupKeys...))
+	for _, dracpuPod := range driverPods {
+		podKey := identifyDriverPod(dracpuPod)
+		logs, err := e2epod.GetLogs(ctx, ctxlogFxt.K8SClientset, &dracpuPod)
+		if err != nil {
+			logFetchErrors = append(logFetchErrors, fmt.Sprintf("%s: %v", podKey, err))
+			continue
+		}
+
+		if dumpRawLogs {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "logs for %s:\n%s\n", podKey, logs)
+		}
+
+		parsedLog := logcheck.NewParsedLog(logs)
+		parsedLog.OpaqueKeys = []string{"response"}
+		ctxlogFxt.Log.Info("ingested log lines", "pod", podKey, "count", parsedLog.Len())
+
+		dupKeys := logcheck.DuplicateKeys(parsedLog)
+		if len(dupKeys) > 0 {
+			duplicateKeyReports = append(duplicateKeyReports,
+				fmt.Sprintf("%s:\n%s", podKey, logcheck.FormatDuplicateKeyResult(parsedLog, dupKeys...)))
+		}
+
+		imbalances := logcheck.ImbalancedFlowTags(parsedLog)
+		if len(imbalances) > 0 {
+			imbalanceReports = append(imbalanceReports,
+				fmt.Sprintf("%s:\n%s", podKey, logcheck.FormatOperationFlowTagSummary(imbalances...)))
+		}
+
+		operations, anomalies := parsedLog.DemuxFlows()
+		if len(anomalies) > 0 {
+			anomalyReports = append(anomalyReports,
+				fmt.Sprintf("%s:\n%s", podKey, formatAnomalies(parsedLog, anomalies)))
+		}
+		ctxlogFxt.Log.Info("detected operations", "pod", podKey, "count", len(operations))
+
+		for opID, opLines := range operations {
+			if len(opLines.Indexes) == 0 {
+				flowBoundaryReports = append(flowBoundaryReports,
+					fmt.Sprintf("%s: operation %q has no log entries", podKey, opID))
+				continue
+			}
+
+			beginMessage, _ := parsedLog.MessageAt(opLines.First())
+			if !strings.HasPrefix(beginMessage, "begin: ") {
+				flowBoundaryReports = append(flowBoundaryReports,
+					fmt.Sprintf("%s: operation %q does not start with begin: (got %q)", podKey, opID, beginMessage))
+			}
+
+			endMessage, _ := parsedLog.MessageAt(opLines.Last())
+			if !strings.HasPrefix(endMessage, "end: ") {
+				flowBoundaryReports = append(flowBoundaryReports,
+					fmt.Sprintf("%s: operation %q does not end with end: (got %q)", podKey, opID, endMessage))
+			}
+		}
 	}
-	gomega.Expect(dupKeys).To(gomega.BeEmpty(), "found %d lines with duplicated keys", len(dupKeys))
 
-	imbalances := logcheck.ImbalancedFlowTags(parsedLog)
-	if len(imbalances) > 0 {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "begin/end imbalances:\n%s", logcheck.FormatOperationFlowTagSummary(imbalances...))
-	}
-	gomega.Expect(imbalances).To(gomega.BeEmpty(), "found %d operations with begin/end imbalance", len(imbalances))
-
-	operations, anomalies := parsedLog.DemuxFlows()
-	if len(anomalies) > 0 {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "lines with anomalies:\n%s", formatAnomalies(parsedLog, anomalies))
-	}
-	gomega.Expect(anomalies).To(gomega.BeEmpty(), "found %d lines with invalid opID", len(anomalies))
-	ctxlogFxt.Log.Info("detected operations", "count", len(operations))
-
-	for opID, opLines := range operations {
-		gomega.Expect(opLines.Indexes).ToNot(gomega.BeEmpty(), "no log entries for operation %q", opID)
-
-		beginMessage, _ := parsedLog.MessageAt(opLines.First())
-		gomega.Expect(beginMessage).To(gomega.HavePrefix("begin: "), "operation %q does not start with begin:", opID)
-
-		endMessage, _ := parsedLog.MessageAt(opLines.Last())
-		gomega.Expect(endMessage).To(gomega.HavePrefix("end: "), "operation %q does not end with end:", opID)
-	}
+	gomega.Expect(logFetchErrors).To(gomega.BeEmpty(),
+		"failed to fetch logs from %d driver pods:\n%s", len(logFetchErrors), strings.Join(logFetchErrors, "\n"))
+	gomega.Expect(duplicateKeyReports).To(gomega.BeEmpty(),
+		"found duplicated log keys in %d driver pods:\n%s", len(duplicateKeyReports), strings.Join(duplicateKeyReports, "\n\n"))
+	gomega.Expect(imbalanceReports).To(gomega.BeEmpty(),
+		"found begin/end imbalances in %d driver pods:\n%s", len(imbalanceReports), strings.Join(imbalanceReports, "\n\n"))
+	gomega.Expect(anomalyReports).To(gomega.BeEmpty(),
+		"found invalid opID lines in %d driver pods:\n%s", len(anomalyReports), strings.Join(anomalyReports, "\n\n"))
+	gomega.Expect(flowBoundaryReports).To(gomega.BeEmpty(),
+		"found invalid operation boundaries in %d places:\n%s", len(flowBoundaryReports), strings.Join(flowBoundaryReports, "\n"))
 })
+
+func identifyDriverPod(pod v1.Pod) string {
+	return fmt.Sprintf("%s/%s@%s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+}
 
 func formatAnomalies(parsedLog logcheck.ParsedLog, anomalies map[int]error) string {
 	lineNums := make([]int, 0, len(anomalies))

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -18,15 +18,12 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	cpusetmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/cpuset"
-	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -77,56 +74,32 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 		dracpuTesterImage = requireEnvOrSkip("DRACPU_E2E_TEST_IMAGE")
 		ginkgo.GinkgoLogr.Info("discovery image", "pullSpec", dracpuTesterImage)
 
-		var err error
-		if reservedCPUVal := os.Getenv("DRACPU_E2E_RESERVED_CPUS"); len(reservedCPUVal) > 0 {
-			reservedCPUs, err = cpuset.Parse(reservedCPUVal)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		reservedCPUs = parseOptionalCPUSetEnv("DRACPU_E2E_RESERVED_CPUS")
+		if reservedCPUs.Size() > 0 {
 			ginkgo.GinkgoLogr.Info("reserved CPUs", "value", reservedCPUs.String())
 		}
 
 		rootFxt = mustCreateFixture()
 		infraFxt := rootFxt.WithPrefix("infra")
-		gomega.Expect(infraFxt.Setup(ctx)).To(gomega.Succeed())
+		mustSetupFixture(ctx, infraFxt)
 		ginkgo.DeferCleanup(infraFxt.Teardown)
 
 		ginkgo.By("checking the daemonset configuration matches the test configuration")
-		daemonSet, err := rootFxt.K8SClientset.AppsV1().DaemonSets("kube-system").Get(ctx, "dracpu", metav1.GetOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
-		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
-		var dsReservedCPUs cpuset.CPUSet
-		cnt := &daemonSet.Spec.Template.Spec.Containers[0]
-		if val, ok := findArgInContainer(cnt, argReservedCPUs); ok {
-			dsReservedCPUs, err = cpuset.Parse(val)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse daemonset reserved cpus: %v", err)
-		}
-		if val, ok := findArgInContainer(cnt, argCPUDeviceMode); ok {
-			cpuDeviceMode = val
-		}
-		if val, ok := findArgInContainer(cnt, argGroupBy); ok {
-			groupBy = val
-		}
-		rootFxt.Log.Info("daemonset --reserved-cpus configuration", "cpus", dsReservedCPUs.String())
-		gomega.Expect(dsReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
+		driverConfig := mustLoadDriverDaemonSetConfig(ctx, rootFxt)
+		cpuDeviceMode = driverConfig.CPUDeviceMode
+		groupBy = driverConfig.GroupBy
+		rootFxt.Log.Info("daemonset --reserved-cpus configuration", "cpus", driverConfig.ReservedCPUs.String())
+		gomega.Expect(driverConfig.ReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
 		rootFxt.Log.Info("daemonset --cpu-device-mode configuration", "mode", cpuDeviceMode, "groupBy", groupBy)
 
-		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
-
-		infoPod := discovery.MakePod(infraFxt.Namespace.Name, dracpuTesterImage)
-		infoPod = e2epod.PinToNode(infoPod, targetNode.Name)
-		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create discovery pod: %v", err)
-		data, err := e2epod.GetLogs(ctx, infraFxt.K8SClientset, infoPod)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from discovery pod: %v", err)
-		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
+		targetNode, targetNodeCPUInfo = mustDiscoverTargetNodeCPUInfo(ctx, rootFxt, infraFxt, dracpuTesterImage)
 
 		allocatableCPUs := makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
 		availableCPUs = allocatableCPUs.Difference(reservedCPUs)
 		if reservedCPUs.Size() > 0 {
 			gomega.Expect(availableCPUs).To(cpusetmatchers.HaveNoOverlapWith(reservedCPUs))
 		}
-		rootFxt.Log.Info("checking worker node", "nodeName", infoPod.Spec.NodeName, "coreCount", len(targetNodeCPUInfo.CPUs), "allocatableCPUs", allocatableCPUs.String(), "reservedCPUs", reservedCPUs.String(), "availableCPUs", availableCPUs.String())
+		rootFxt.Log.Info("checking worker node", "nodeName", targetNode.Name, "coreCount", len(targetNodeCPUInfo.CPUs), "allocatableCPUs", allocatableCPUs.String(), "reservedCPUs", reservedCPUs.String(), "availableCPUs", availableCPUs.String())
 	})
 
 	ginkgo.When("setting resource claims", func() {

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -74,8 +74,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		// early cheap check before to create the Fixture, so we use GinkgoLogr directly
-		dracpuTesterImage = os.Getenv("DRACPU_E2E_TEST_IMAGE")
-		gomega.Expect(dracpuTesterImage).ToNot(gomega.BeEmpty(), "missing environment variable DRACPU_E2E_TEST_IMAGE")
+		dracpuTesterImage = requireEnvOrSkip("DRACPU_E2E_TEST_IMAGE")
 		ginkgo.GinkgoLogr.Info("discovery image", "pullSpec", dracpuTesterImage)
 
 		var err error
@@ -85,8 +84,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 			ginkgo.GinkgoLogr.Info("reserved CPUs", "value", reservedCPUs.String())
 		}
 
-		rootFxt, err = fixture.ForGinkgo()
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture: %v", err)
+		rootFxt = mustCreateFixture()
 		infraFxt := rootFxt.WithPrefix("infra")
 		gomega.Expect(infraFxt.Setup(ctx)).To(gomega.Succeed())
 		ginkgo.DeferCleanup(infraFxt.Teardown)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	podmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/pod"
+	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -75,6 +76,16 @@ func mustCreateFixture() *fixture.Fixture {
 	skipIfMissingKubeconfig(err)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create fixture")
 	return fxt
+}
+
+func createFixtureForReport() (*fixture.Fixture, bool) {
+	fxt, err := fixture.ForGinkgo()
+	if errors.Is(err, e2eclient.ErrMissingKubeconfig) {
+		fmt.Fprintln(ginkgo.GinkgoWriter, err.Error())
+		return nil, false
+	}
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create fixture")
+	return fxt, true
 }
 
 // shared code which is not ready yet to be moved into a test/pkg/... package
@@ -146,6 +157,77 @@ func makeCPUSetFromDiscoveredCPUInfo(cpuInfo discovery.DRACPUInfo) cpuset.CPUSet
 type CPUAllocation struct {
 	CPUAssigned cpuset.CPUSet
 	CPUAffinity cpuset.CPUSet
+}
+
+type driverDaemonSetConfig struct {
+	ReservedCPUs  cpuset.CPUSet
+	CPUDeviceMode string
+	GroupBy       string
+}
+
+func mustSetupFixture(ctx context.Context, fxt *fixture.Fixture) {
+	ginkgo.GinkgoHelper()
+	gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
+}
+
+func parseOptionalCPUSetEnv(name string) cpuset.CPUSet {
+	ginkgo.GinkgoHelper()
+
+	value, ok := os.LookupEnv(name)
+	if !ok || value == "" {
+		return cpuset.New()
+	}
+
+	parsed, err := cpuset.Parse(value)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse %s: %q", name, value)
+	return parsed
+}
+
+func driverConfigFromContainer(container *v1.Container) driverDaemonSetConfig {
+	ginkgo.GinkgoHelper()
+
+	config := driverDaemonSetConfig{}
+	if val, ok := findArgInContainer(container, argReservedCPUs); ok {
+		var err error
+		config.ReservedCPUs, err = cpuset.Parse(val)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse daemonset reserved cpus: %v", err)
+	}
+	if val, ok := findArgInContainer(container, argCPUDeviceMode); ok {
+		config.CPUDeviceMode = val
+	}
+	if val, ok := findArgInContainer(container, argGroupBy); ok {
+		config.GroupBy = val
+	}
+	return config
+}
+
+func mustLoadDriverDaemonSetConfig(ctx context.Context, fxt *fixture.Fixture) driverDaemonSetConfig {
+	ginkgo.GinkgoHelper()
+
+	daemonSet, err := fxt.K8SClientset.AppsV1().DaemonSets(daemonSetNamespace).Get(ctx, "dracpu", metav1.GetOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
+	gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
+	return driverConfigFromContainer(&daemonSet.Spec.Template.Spec.Containers[0])
+}
+
+func mustDiscoverTargetNodeCPUInfo(ctx context.Context, rootFxt, infraFxt *fixture.Fixture, testerImage string) (*v1.Node, discovery.DRACPUInfo) {
+	ginkgo.GinkgoHelper()
+
+	targetNode, err := e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
+
+	infoPod := discovery.MakePod(infraFxt.Namespace.Name, testerImage)
+	infoPod = e2epod.PinToNode(infoPod, targetNode.Name)
+	infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create discovery pod: %v", err)
+
+	data, err := e2epod.GetLogs(ctx, infraFxt.K8SClientset, infoPod)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from discovery pod: %v", err)
+
+	var cpuInfo discovery.DRACPUInfo
+	gomega.Expect(json.Unmarshal([]byte(data), &cpuInfo)).To(gomega.Succeed())
+	return targetNode, cpuInfo
 }
 
 func getTesterPodCPUAllocation(cs kubernetes.Interface, ctx context.Context, pod *v1.Pod) CPUAllocation {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -19,12 +19,15 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/api/v1alpha1"
+	e2eclient "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/client"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	podmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/pod"
@@ -45,6 +48,33 @@ func TestE2E(t *testing.T) {
 	klog.SetLoggerWithOptions(ginkgo.GinkgoLogr, klog.ContextualLogger(true))
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "DRA CPU Driver E2E Suite")
+}
+
+func requireEnvOrSkip(name string) string {
+	ginkgo.GinkgoHelper()
+
+	value, ok := os.LookupEnv(name)
+	if !ok || value == "" {
+		ginkgo.Skip("missing environment variable " + name)
+	}
+	return value
+}
+
+func skipIfMissingKubeconfig(err error) {
+	ginkgo.GinkgoHelper()
+
+	if errors.Is(err, e2eclient.ErrMissingKubeconfig) {
+		ginkgo.Skip(err.Error())
+	}
+}
+
+func mustCreateFixture() *fixture.Fixture {
+	ginkgo.GinkgoHelper()
+
+	fxt, err := fixture.ForGinkgo()
+	skipIfMissingKubeconfig(err)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create fixture")
+	return fxt
 }
 
 // shared code which is not ready yet to be moved into a test/pkg/... package

--- a/test/e2e/e2e_suite_unit_test.go
+++ b/test/e2e/e2e_suite_unit_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/cpuset"
+)
+
+func TestParseOptionalCPUSetEnvReturnsEmptyWhenUnset(t *testing.T) {
+	t.Setenv("DRACPU_E2E_RESERVED_CPUS", "")
+
+	got := parseOptionalCPUSetEnv("DRACPU_E2E_RESERVED_CPUS")
+	if !got.Equals(cpuset.New()) {
+		t.Fatalf("expected empty cpuset, got %s", got.String())
+	}
+}
+
+func TestParseOptionalCPUSetEnvParsesValue(t *testing.T) {
+	t.Setenv("DRACPU_E2E_RESERVED_CPUS", "1-2,5")
+
+	got := parseOptionalCPUSetEnv("DRACPU_E2E_RESERVED_CPUS")
+	want := cpuset.New(1, 2, 5)
+	if !got.Equals(want) {
+		t.Fatalf("expected %s, got %s", want.String(), got.String())
+	}
+}
+
+func TestDriverConfigFromContainerParsesRelevantArgs(t *testing.T) {
+	container := &v1.Container{
+		Args: []string{
+			"--reserved-cpus=1-2",
+			"--cpu-device-mode=grouped",
+			"--group-by=socket",
+			"--something-else=ignored",
+		},
+	}
+
+	got := driverConfigFromContainer(container)
+	if !got.ReservedCPUs.Equals(cpuset.New(1, 2)) {
+		t.Fatalf("expected reserved cpus 1-2, got %s", got.ReservedCPUs.String())
+	}
+	if got.CPUDeviceMode != "grouped" {
+		t.Fatalf("expected cpu device mode grouped, got %q", got.CPUDeviceMode)
+	}
+	if got.GroupBy != "socket" {
+		t.Fatalf("expected group-by socket, got %q", got.GroupBy)
+	}
+}

--- a/test/e2e/gatherinfo_test.go
+++ b/test/e2e/gatherinfo_test.go
@@ -38,9 +38,9 @@ var _ = ginkgo.Describe("dracpu-gatherinfo", ginkgo.Ordered, func() {
 
 	ginkgo.BeforeAll(func() {
 		var err error
-		fxt, err = fixture.ForGinkgo()
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create fixture")
+		fxt = mustCreateFixture()
 		restConfig, err = e2eclient.NewK8SConfig()
+		skipIfMissingKubeconfig(err)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create Kubernetes config")
 	})
 

--- a/test/e2e/healthz_http_test.go
+++ b/test/e2e/healthz_http_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetPodHealthzViaAPIProxyReturnsHTTP200(t *testing.T) {
+	var requestPath string
+	server := mustNewHTTPTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.EscapedPath()
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET request, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	coreClient := mustNewTestCoreV1Client(t, server)
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "driver-pod",
+			Namespace: daemonSetNamespace,
+		},
+	}
+
+	statusCode, body, err := getPodHealthzViaAPIProxy(context.Background(), coreClient, pod)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", statusCode)
+	}
+	if body != "ok" {
+		t.Fatalf("expected body %q, got %q", "ok", body)
+	}
+	const expectedPath = "/api/v1/namespaces/kube-system/pods/http:driver-pod:8080/proxy/healthz"
+	if requestPath != expectedPath {
+		t.Fatalf("expected request path %q, got %q", expectedPath, requestPath)
+	}
+}
+
+func TestGetPodHealthzViaAPIProxyReturnsStatusOnFailure(t *testing.T) {
+	server := mustNewHTTPTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	}))
+
+	coreClient := mustNewTestCoreV1Client(t, server)
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "driver-pod",
+			Namespace: daemonSetNamespace,
+		},
+	}
+
+	statusCode, body, err := getPodHealthzViaAPIProxy(context.Background(), coreClient, pod)
+	if err == nil {
+		t.Fatal("expected an error for a non-2xx response")
+	}
+	if statusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", statusCode)
+	}
+	if body != "" {
+		t.Fatalf("expected empty body on error, got %q", body)
+	}
+}
+
+func mustNewTestCoreV1Client(t *testing.T, server *httptest.Server) *typedcorev1.CoreV1Client {
+	t.Helper()
+
+	gv := schema.GroupVersion{Version: "v1"}
+	coreClient, err := typedcorev1.NewForConfigAndClient(&rest.Config{
+		Host:    server.URL,
+		APIPath: "/api",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &gv,
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		},
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("creating core v1 client: %v", err)
+	}
+	return coreClient
+}
+
+func mustNewHTTPTestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("creating test listener: %v", err)
+	}
+
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.Start()
+	t.Cleanup(server.Close)
+	return server
+}

--- a/test/e2e/healthz_test.go
+++ b/test/e2e/healthz_test.go
@@ -19,15 +19,15 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"time"
+	"strconv"
+	"strings"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -36,30 +36,23 @@ const (
 	driverHTTPPort = 8080
 )
 
-func waitForPodIP(ctx context.Context, client kubernetes.Interface, podName string) (string, error) {
-	var podIP string
-	err := wait.PollUntilContextTimeout(ctx, driverPodPollInterval, driverPodPollTimeout, true,
-		func(ctx context.Context) (bool, error) {
-			pod, err := client.CoreV1().Pods(daemonSetNamespace).Get(ctx, podName, metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-			if pod.Status.PodIP == "" {
-				return false, nil
-			}
-			podIP = pod.Status.PodIP
-			return true, nil
-		})
-	if err != nil {
-		return "", fmt.Errorf("waiting for PodIP on %q: %w", podName, err)
-	}
-	return podIP, nil
-}
+func getPodHealthzViaAPIProxy(ctx context.Context, client kubernetes.Interface, pod v1.Pod) (int, string, error) {
+	subPath := strings.TrimPrefix(healthzPath, "/")
+	target := net.JoinSchemeNamePort("http", pod.Name, strconv.Itoa(driverHTTPPort))
 
-// healthzURL returns the full URL the test will GET, using the pod's IP
-// directly rather than going through a Service, so each pod is probed individually.
-func healthzURL(podIP string) string {
-	return fmt.Sprintf("http://%s:%d%s", podIP, driverHTTPPort, healthzPath)
+	request := client.CoreV1().RESTClient().Get().
+		Namespace(pod.Namespace).
+		Resource("pods").
+		SubResource("proxy").
+		Name(target).
+		Suffix(subPath)
+
+	var statusCode int
+	body, err := request.Do(ctx).StatusCode(&statusCode).Raw()
+	if err != nil {
+		return 0, "", err
+	}
+	return statusCode, string(body), nil
 }
 
 var _ = ginkgo.Describe("dra-driver-cpu HTTP health endpoints", ginkgo.Ordered, func() {
@@ -74,42 +67,31 @@ var _ = ginkgo.Describe("dra-driver-cpu HTTP health endpoints", ginkgo.Ordered, 
 	ginkgo.Context("when the driver DaemonSet is deployed and running", func() {
 
 		// Test 1: verify the HTTP handler itself.
-		// We hit /healthz directly on each pod IP and assert HTTP 200. The call
-		// is wrapped in Eventually to tolerate the initialDelaySeconds window
-		// (10 s liveness / 5 s readiness) during which Kubernetes hasn't started
-		// probing yet either — so the server may still be initialising.
+		// We route the request through the apiserver pod proxy so the test does
+		// not depend on the machine running `go test` being able to reach Pod IPs
+		// directly.
 		ginkgo.It("should return HTTP 200 from /healthz on each driver pod", func(ctx context.Context) {
 			pods := waitForRunningDriverPods(ctx, fxt.K8SClientset)
 
-			httpClient := &http.Client{Timeout: 10 * time.Second}
-
 			for _, pod := range pods {
-				podIP, err := waitForPodIP(ctx, fxt.K8SClientset, pod.Name)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-					"obtaining PodIP for pod %q", pod.Name)
-
-				url := healthzURL(podIP)
-				ginkgo.By(fmt.Sprintf("GET %s (pod %s, node %s)", url, pod.Name, pod.Spec.NodeName))
+				ginkgo.By(fmt.Sprintf("GET %s for pod %s (node %s) through the apiserver pod proxy",
+					healthzPath, pod.Name, pod.Spec.NodeName))
 
 				var lastStatus int
 				var lastBody string
 				gomega.Eventually(func(g gomega.Gomega) {
-					resp, err := httpClient.Get(url) //nolint:noctx // httpClient.Timeout covers this
+					statusCode, body, err := getPodHealthzViaAPIProxy(ctx, fxt.K8SClientset, pod)
 					g.Expect(err).NotTo(gomega.HaveOccurred(),
-						"GET %s failed for pod %q on node %q", url, pod.Name, pod.Spec.NodeName)
-					defer resp.Body.Close()
+						"GET %s through pod proxy failed for pod %q on node %q", healthzPath, pod.Name, pod.Spec.NodeName)
+					lastStatus = statusCode
+					lastBody = body
 
-					bodyBytes, readErr := io.ReadAll(resp.Body)
-					g.Expect(readErr).NotTo(gomega.HaveOccurred(), "reading response body")
-					lastStatus = resp.StatusCode
-					lastBody = string(bodyBytes)
-
-					g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK),
-						"expected HTTP 200 from %s (pod %q, node %q), got %d; body: %s",
-						url, pod.Name, pod.Spec.NodeName, resp.StatusCode, lastBody)
+					g.Expect(statusCode).To(gomega.Equal(200),
+						"expected HTTP 200 from %s via pod proxy (pod %q, node %q), got %d; body: %s",
+						healthzPath, pod.Name, pod.Spec.NodeName, statusCode, lastBody)
 				}, driverPodPollTimeout, driverPodPollInterval).Should(gomega.Succeed(),
-					"/healthz on %s did not return 200 within timeout (last status=%d, body=%q)",
-					url, lastStatus, lastBody)
+					"%s via pod proxy for pod %q did not return 200 within timeout (last status=%d, body=%q)",
+					healthzPath, pod.Name, lastStatus, lastBody)
 			}
 		})
 

--- a/test/e2e/healthz_test.go
+++ b/test/e2e/healthz_test.go
@@ -18,15 +18,19 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (
@@ -34,14 +38,26 @@ const (
 	driverHTTPPort = 8080
 )
 
-func getPodHealthzViaAPIProxy(ctx context.Context, client kubernetes.Interface, pod v1.Pod) (string, error) {
-	body, err := client.CoreV1().Pods(pod.Namespace).
-		ProxyGet("http", pod.Name, strconv.Itoa(driverHTTPPort), healthzPath, nil).
-		DoRaw(ctx)
+func getPodHealthzViaAPIProxy(ctx context.Context, client corev1client.CoreV1Interface, pod v1.Pod) (int, string, error) {
+	var statusCode int
+	result := client.RESTClient().Get().
+		Namespace(pod.Namespace).
+		Resource("pods").
+		SubResource("proxy").
+		Name(utilnet.JoinSchemeNamePort("http", pod.Name, strconv.Itoa(driverHTTPPort))).
+		Suffix(healthzPath).
+		Do(ctx).
+		StatusCode(&statusCode)
+
+	body, err := result.Raw()
 	if err != nil {
-		return "", err
+		var statusErr *apierrors.StatusError
+		if statusCode == 0 && errors.As(err, &statusErr) {
+			statusCode = int(statusErr.ErrStatus.Code)
+		}
+		return statusCode, "", err
 	}
-	return string(body), nil
+	return statusCode, string(body), nil
 }
 
 var _ = ginkgo.Describe("dra-driver-cpu HTTP health endpoints", ginkgo.Ordered, func() {
@@ -65,14 +81,18 @@ var _ = ginkgo.Describe("dra-driver-cpu HTTP health endpoints", ginkgo.Ordered, 
 					healthzPath, pod.Name, pod.Spec.NodeName))
 
 				var lastBody string
+				var lastStatusCode int
 				gomega.Eventually(func(g gomega.Gomega) {
-					body, err := getPodHealthzViaAPIProxy(ctx, fxt.K8SClientset, pod)
+					statusCode, body, err := getPodHealthzViaAPIProxy(ctx, fxt.K8SClientset.CoreV1(), pod)
 					g.Expect(err).NotTo(gomega.HaveOccurred(),
 						"GET %s through pod proxy failed for pod %q on node %q", healthzPath, pod.Name, pod.Spec.NodeName)
+					g.Expect(statusCode).To(gomega.Equal(http.StatusOK),
+						"GET %s through pod proxy returned unexpected status for pod %q on node %q", healthzPath, pod.Name, pod.Spec.NodeName)
+					lastStatusCode = statusCode
 					lastBody = body
 				}, driverPodPollTimeout, driverPodPollInterval).Should(gomega.Succeed(),
-					"%s via pod proxy for pod %q did not succeed within timeout (last body=%q)",
-					healthzPath, pod.Name, lastBody)
+					"%s via pod proxy for pod %q did not succeed within timeout (last status=%d, last body=%q)",
+					healthzPath, pod.Name, lastStatusCode, lastBody)
 			}
 		})
 

--- a/test/e2e/healthz_test.go
+++ b/test/e2e/healthz_test.go
@@ -20,14 +20,12 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -36,23 +34,14 @@ const (
 	driverHTTPPort = 8080
 )
 
-func getPodHealthzViaAPIProxy(ctx context.Context, client kubernetes.Interface, pod v1.Pod) (int, string, error) {
-	subPath := strings.TrimPrefix(healthzPath, "/")
-	target := net.JoinSchemeNamePort("http", pod.Name, strconv.Itoa(driverHTTPPort))
-
-	request := client.CoreV1().RESTClient().Get().
-		Namespace(pod.Namespace).
-		Resource("pods").
-		SubResource("proxy").
-		Name(target).
-		Suffix(subPath)
-
-	var statusCode int
-	body, err := request.Do(ctx).StatusCode(&statusCode).Raw()
+func getPodHealthzViaAPIProxy(ctx context.Context, client kubernetes.Interface, pod v1.Pod) (string, error) {
+	body, err := client.CoreV1().Pods(pod.Namespace).
+		ProxyGet("http", pod.Name, strconv.Itoa(driverHTTPPort), healthzPath, nil).
+		DoRaw(ctx)
 	if err != nil {
-		return 0, "", err
+		return "", err
 	}
-	return statusCode, string(body), nil
+	return string(body), nil
 }
 
 var _ = ginkgo.Describe("dra-driver-cpu HTTP health endpoints", ginkgo.Ordered, func() {
@@ -75,21 +64,15 @@ var _ = ginkgo.Describe("dra-driver-cpu HTTP health endpoints", ginkgo.Ordered, 
 				ginkgo.By(fmt.Sprintf("GET %s for pod %s (node %s) through the apiserver pod proxy",
 					healthzPath, pod.Name, pod.Spec.NodeName))
 
-				var lastStatus int
 				var lastBody string
 				gomega.Eventually(func(g gomega.Gomega) {
-					statusCode, body, err := getPodHealthzViaAPIProxy(ctx, fxt.K8SClientset, pod)
+					body, err := getPodHealthzViaAPIProxy(ctx, fxt.K8SClientset, pod)
 					g.Expect(err).NotTo(gomega.HaveOccurred(),
 						"GET %s through pod proxy failed for pod %q on node %q", healthzPath, pod.Name, pod.Spec.NodeName)
-					lastStatus = statusCode
 					lastBody = body
-
-					g.Expect(statusCode).To(gomega.Equal(200),
-						"expected HTTP 200 from %s via pod proxy (pod %q, node %q), got %d; body: %s",
-						healthzPath, pod.Name, pod.Spec.NodeName, statusCode, lastBody)
 				}, driverPodPollTimeout, driverPodPollInterval).Should(gomega.Succeed(),
-					"%s via pod proxy for pod %q did not return 200 within timeout (last status=%d, body=%q)",
-					healthzPath, pod.Name, lastStatus, lastBody)
+					"%s via pod proxy for pod %q did not succeed within timeout (last body=%q)",
+					healthzPath, pod.Name, lastBody)
 			}
 		})
 

--- a/test/e2e/healthz_test.go
+++ b/test/e2e/healthz_test.go
@@ -59,9 +59,7 @@ var _ = ginkgo.Describe("dra-driver-cpu HTTP health endpoints", ginkgo.Ordered, 
 	var fxt *fixture.Fixture
 
 	ginkgo.BeforeAll(func() {
-		var err error
-		fxt, err = fixture.ForGinkgo()
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create fixture")
+		fxt = mustCreateFixture()
 	})
 
 	ginkgo.Context("when the driver DaemonSet is deployed and running", func() {

--- a/test/e2e/nri_reconciliation_test.go
+++ b/test/e2e/nri_reconciliation_test.go
@@ -57,8 +57,7 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		// early cheap check before to create the Fixture, so we use GinkgoLogr directly
-		dracpuTesterImage = os.Getenv("DRACPU_E2E_TEST_IMAGE")
-		gomega.Expect(dracpuTesterImage).ToNot(gomega.BeEmpty(), "missing environment variable DRACPU_E2E_TEST_IMAGE")
+		dracpuTesterImage = requireEnvOrSkip("DRACPU_E2E_TEST_IMAGE")
 		ginkgo.GinkgoLogr.Info("discovery image", "pullSpec", dracpuTesterImage)
 
 		var err error
@@ -68,8 +67,7 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 			ginkgo.GinkgoLogr.Info("reserved CPUs", "value", reservedCPUs.String())
 		}
 
-		rootFxt, err = fixture.ForGinkgo()
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create fixture")
+		rootFxt = mustCreateFixture()
 		infraFxt := rootFxt.WithPrefix("infra")
 		gomega.Expect(infraFxt.Setup(ctx)).To(gomega.Succeed())
 		ginkgo.DeferCleanup(infraFxt.Teardown)

--- a/test/e2e/nri_reconciliation_test.go
+++ b/test/e2e/nri_reconciliation_test.go
@@ -18,14 +18,11 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
-	"os"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	cpusetmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/cpuset"
-	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -60,43 +57,25 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 		dracpuTesterImage = requireEnvOrSkip("DRACPU_E2E_TEST_IMAGE")
 		ginkgo.GinkgoLogr.Info("discovery image", "pullSpec", dracpuTesterImage)
 
-		var err error
-		if reservedCPUVal := os.Getenv("DRACPU_E2E_RESERVED_CPUS"); len(reservedCPUVal) > 0 {
-			reservedCPUs, err = cpuset.Parse(reservedCPUVal)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		reservedCPUs = parseOptionalCPUSetEnv("DRACPU_E2E_RESERVED_CPUS")
+		if reservedCPUs.Size() > 0 {
 			ginkgo.GinkgoLogr.Info("reserved CPUs", "value", reservedCPUs.String())
 		}
 
 		rootFxt = mustCreateFixture()
 		infraFxt := rootFxt.WithPrefix("infra")
-		gomega.Expect(infraFxt.Setup(ctx)).To(gomega.Succeed())
+		mustSetupFixture(ctx, infraFxt)
 		ginkgo.DeferCleanup(infraFxt.Teardown)
 
 		ginkgo.By("getting the daemonset configuration")
+		var err error
 		orgDaemonSet, err = rootFxt.K8SClientset.AppsV1().DaemonSets(daemonSetNamespaceRule).Get(ctx, "dracpu", metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
-		gomega.Expect(orgDaemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
+		driverConfig := driverConfigFromContainer(&orgDaemonSet.Spec.Template.Spec.Containers[0])
+		cpuDeviceMode = driverConfig.CPUDeviceMode
+		groupBy = driverConfig.GroupBy
 
-		if val, ok := findArgInContainer(&orgDaemonSet.Spec.Template.Spec.Containers[0], argCPUDeviceMode); ok {
-			cpuDeviceMode = val
-		}
-		if val, ok := findArgInContainer(&orgDaemonSet.Spec.Template.Spec.Containers[0], argGroupBy); ok {
-			groupBy = val
-		}
-
-		// Find target node
-		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
-
-		// Discover topology
-		infoPod := discovery.MakePod(infraFxt.Namespace.Name, dracpuTesterImage)
-		infoPod = e2epod.PinToNode(infoPod, targetNode.Name)
-		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		data, err := e2epod.GetLogs(ctx, infraFxt.K8SClientset, infoPod)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
+		targetNode, targetNodeCPUInfo = mustDiscoverTargetNodeCPUInfo(ctx, rootFxt, infraFxt, dracpuTesterImage)
 		allocatableCPUs = makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
 	})
 

--- a/test/e2e/resource_slice_test.go
+++ b/test/e2e/resource_slice_test.go
@@ -63,8 +63,7 @@ var _ = ginkgo.Describe("Resource Attributes", ginkgo.Ordered, ginkgo.ContinueOn
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		var err error
-		fxt, err = fixture.ForGinkgo()
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create fixture")
+		fxt = mustCreateFixture()
 
 		ginkgo.By("reading daemonset configuration")
 		daemonSet, err := fxt.K8SClientset.AppsV1().DaemonSets(daemonSetNamespace).Get(ctx, "dracpu", metav1.GetOptions{})

--- a/test/e2e/resource_slice_test.go
+++ b/test/e2e/resource_slice_test.go
@@ -25,8 +25,33 @@ import (
 	"github.com/onsi/gomega"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/dynamic-resource-allocation/deviceattribute"
 )
+
+func waitForDriverResourceSlices(ctx context.Context, client kubernetes.Interface, driverName string) []resourcev1.ResourceSlice {
+	ginkgo.GinkgoHelper()
+
+	var slices []resourcev1.ResourceSlice
+	gomega.Eventually(func(g gomega.Gomega) {
+		sliceList, err := client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{
+			FieldSelector: "spec.driver=" + driverName,
+		})
+		g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot list ResourceSlices")
+		g.Expect(sliceList.Items).ToNot(gomega.BeEmpty(), "no ResourceSlices found for driver %s", driverName)
+
+		totalDevices := 0
+		for _, slice := range sliceList.Items {
+			totalDevices += len(slice.Spec.Devices)
+		}
+		g.Expect(totalDevices).To(gomega.BeNumerically(">", 0), "no devices found across all ResourceSlices")
+
+		slices = sliceList.Items
+	}, driverPodPollTimeout, driverPodPollInterval).Should(gomega.Succeed(),
+		"timed out waiting for ResourceSlices for driver %q to be published", driverName)
+
+	return slices
+}
 
 var _ = ginkgo.Describe("Resource Attributes", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
@@ -55,13 +80,8 @@ var _ = ginkgo.Describe("Resource Attributes", ginkgo.Ordered, ginkgo.ContinueOn
 		}
 		fxt.Log.Info("daemonset configuration", "cpuDeviceMode", cpuDeviceMode, "groupBy", groupBy)
 
-		ginkgo.By("listing ResourceSlices for driver " + driverName)
-		sliceList, err := fxt.K8SClientset.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{
-			FieldSelector: "spec.driver=" + driverName,
-		})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot list ResourceSlices")
-		gomega.Expect(sliceList.Items).ToNot(gomega.BeEmpty(), "no ResourceSlices found for driver %s", driverName)
-		slices = sliceList.Items
+		ginkgo.By("waiting for ResourceSlices for driver " + driverName)
+		slices = waitForDriverResourceSlices(ctx, fxt.K8SClientset, driverName)
 		fxt.Log.Info("found ResourceSlices", "count", len(slices))
 	})
 

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -18,14 +18,10 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
-	"os"
-	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
 	cpusetmatchers "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/matchers/cpuset"
-	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -39,7 +35,6 @@ import (
 var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		rootFxt           *fixture.Fixture
-		targetNode        *v1.Node
 		targetNodeCPUInfo discovery.DRACPUInfo
 		availableCPUs     cpuset.CPUSet
 		dracpuTesterImage string
@@ -53,57 +48,32 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 		dracpuTesterImage = requireEnvOrSkip("DRACPU_E2E_TEST_IMAGE")
 		ginkgo.GinkgoLogr.Info("discovery image", "pullSpec", dracpuTesterImage)
 
-		var err error
-		if reservedCPUVal := os.Getenv("DRACPU_E2E_RESERVED_CPUS"); len(reservedCPUVal) > 0 {
-			reservedCPUs, err = cpuset.Parse(reservedCPUVal)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		reservedCPUs = parseOptionalCPUSetEnv("DRACPU_E2E_RESERVED_CPUS")
+		if reservedCPUs.Size() > 0 {
 			ginkgo.GinkgoLogr.Info("reserved CPUs", "value", reservedCPUs.String())
 		}
 
 		rootFxt = mustCreateFixture()
 		infraFxt := rootFxt.WithPrefix("infra")
-		gomega.Expect(infraFxt.Setup(ctx)).To(gomega.Succeed())
+		mustSetupFixture(ctx, infraFxt)
 		ginkgo.DeferCleanup(infraFxt.Teardown)
 
 		ginkgo.By("checking the daemonset configuration matches the test configuration")
-		daemonSet, err := rootFxt.K8SClientset.AppsV1().DaemonSets("kube-system").Get(ctx, "dracpu", metav1.GetOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
-		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
-		var dsReservedCPUs cpuset.CPUSet
-		cnt := &daemonSet.Spec.Template.Spec.Containers[0]
-		if val, ok := findArgInContainer(cnt, argReservedCPUs); ok {
-			dsReservedCPUs, err = cpuset.Parse(val)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse daemonset reserved cpus: %v", err)
-		}
-		if val, ok := findArgInContainer(cnt, argCPUDeviceMode); ok {
-			cpuDeviceMode = val
-		}
-		if val, ok := findArgInContainer(cnt, argGroupBy); ok {
-			groupBy = val
-		}
-		gomega.Expect(dsReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
+		driverConfig := mustLoadDriverDaemonSetConfig(ctx, rootFxt)
+		cpuDeviceMode = driverConfig.CPUDeviceMode
+		groupBy = driverConfig.GroupBy
+		gomega.Expect(driverConfig.ReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
 
-		rootFxt.Log.Info("daemonset configuration", "reservedCPUs", dsReservedCPUs.String(), "deviceMode", cpuDeviceMode, "groupBy", groupBy)
+		rootFxt.Log.Info("daemonset configuration", "reservedCPUs", driverConfig.ReservedCPUs.String(), "deviceMode", cpuDeviceMode, "groupBy", groupBy)
 
-		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
-
-		infoPod := discovery.MakePod(infraFxt.Namespace.Name, dracpuTesterImage)
-		infoPod = e2epod.PinToNode(infoPod, targetNode.Name)
-		infoPod, err = e2epod.RunToCompletion(ctx, infraFxt.K8SClientset, infoPod)
-
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create discovery pod: %v", err)
-		data, err := e2epod.GetLogs(ctx, infraFxt.K8SClientset, infoPod)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get logs from discovery pod: %v", err)
-		gomega.Expect(json.Unmarshal([]byte(data), &targetNodeCPUInfo)).To(gomega.Succeed())
+		_, targetNodeCPUInfo = mustDiscoverTargetNodeCPUInfo(ctx, rootFxt, infraFxt, dracpuTesterImage)
 
 		allocatableCPUs := makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
 		availableCPUs = allocatableCPUs.Difference(reservedCPUs)
 		if reservedCPUs.Size() > 0 {
 			gomega.Expect(availableCPUs).To(cpusetmatchers.HaveNoOverlapWith(reservedCPUs))
 		}
-		rootFxt.Log.Info("checking worker node", "nodeName", infoPod.Spec.NodeName, "coreCount", len(targetNodeCPUInfo.CPUs), "allocatableCPUs", allocatableCPUs.String(), "reservedCPUs", reservedCPUs.String(), "availableCPUs", availableCPUs.String())
+		rootFxt.Log.Info("checking worker node", "coreCount", len(targetNodeCPUInfo.CPUs), "allocatableCPUs", allocatableCPUs.String(), "reservedCPUs", reservedCPUs.String(), "availableCPUs", availableCPUs.String())
 	})
 
 	ginkgo.When("sharing a CPU claim", func() {

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -50,8 +50,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		// early cheap check before to create the Fixture, so we use GinkgoLogr directly
-		dracpuTesterImage = os.Getenv("DRACPU_E2E_TEST_IMAGE")
-		gomega.Expect(dracpuTesterImage).ToNot(gomega.BeEmpty(), "missing environment variable DRACPU_E2E_TEST_IMAGE")
+		dracpuTesterImage = requireEnvOrSkip("DRACPU_E2E_TEST_IMAGE")
 		ginkgo.GinkgoLogr.Info("discovery image", "pullSpec", dracpuTesterImage)
 
 		var err error
@@ -61,8 +60,7 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 			ginkgo.GinkgoLogr.Info("reserved CPUs", "value", reservedCPUs.String())
 		}
 
-		rootFxt, err = fixture.ForGinkgo()
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture: %v", err)
+		rootFxt = mustCreateFixture()
 		infraFxt := rootFxt.WithPrefix("infra")
 		gomega.Expect(infraFxt.Setup(ctx)).To(gomega.Succeed())
 		ginkgo.DeferCleanup(infraFxt.Teardown)

--- a/test/pkg/client/k8s.go
+++ b/test/pkg/client/k8s.go
@@ -26,10 +26,12 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var ErrMissingKubeconfig = errors.New("missing environment variable KUBECONFIG")
+
 func NewK8SConfig() (*rest.Config, error) {
 	kubeconfig, ok := os.LookupEnv("KUBECONFIG")
-	if !ok {
-		return nil, errors.New("missing environment variable KUBECONFIG")
+	if !ok || kubeconfig == "" {
+		return nil, ErrMissingKubeconfig
 	}
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {

--- a/test/pkg/client/k8s_test.go
+++ b/test/pkg/client/k8s_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewK8SConfigMissingKubeconfigReturnsSentinel(t *testing.T) {
+	t.Setenv("KUBECONFIG", "")
+
+	_, err := NewK8SConfig()
+	if !errors.Is(err, ErrMissingKubeconfig) {
+		t.Fatalf("expected ErrMissingKubeconfig, got %v", err)
+	}
+}
+
+func TestNewK8SConfigInvalidPathIsNotMissingKubeconfig(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/definitely/not/here")
+
+	_, err := NewK8SConfig()
+	if err == nil {
+		t.Fatal("expected an error for invalid kubeconfig path")
+	}
+	if errors.Is(err, ErrMissingKubeconfig) {
+		t.Fatalf("expected invalid-path error, got ErrMissingKubeconfig: %v", err)
+	}
+}


### PR DESCRIPTION
This PR improves the reliability and maintainability of the e2e test suite by:
﻿
- probing driver `/healthz` endpoints through the apiserver pod proxy instead of requiring the test runner to reach Pod IPs directly
- making the `ResourceSlice` suite wait for published slices and devices before asserting
- auditing contextual logs across every driver pod instead of sampling a single random worker pod
- skipping e2e suites when required prerequisites such as `KUBECONFIG` or `DRACPU_E2E_TEST_IMAGE` are missing
- reusing shared e2e setup helpers to reduce repeated daemonset/discovery/bootstrap logic across CPU-oriented suites