### PR TITLE
feat: add numa-mocking to helm chart for local testing

### DIFF
--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -36,6 +36,10 @@ helm install dra-driver-cpu ./deployment/helm/dra-driver-cpu -n kube-system -f m
 | args.hostnameOverride | string | `""` | Override the node name the driver registers under; omitted when empty |
 | args.logLevel | int | `4` | Log verbosity level passed as `--v` |
 | args.reservedCPUs | string | `""` | CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty |
+| extraEnv | list | `[]` | Additional environment variables for the dracpu container |
+| extraInitContainers | list | `[]` | Additional init containers for the DaemonSet pod |
+| extraVolumeMounts | list | `[]` | Additional volume mounts for the dracpu container |
+| extraVolumes | list | `[]` | Additional volumes for the DaemonSet pod |
 | fullnameOverride | string | `""` | Override the full release name |
 | healthzPath | string | `"/healthz"` | Path for liveness and readiness probes |
 | healthzPort | int | `8080` | Port the HTTP server binds to; used for the container port and probes |

--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: dracpu
         args:
@@ -100,6 +104,10 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN", "SYS_ADMIN"]
+        {{- with .Values.extraEnv }}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: device-plugin
           mountPath: /var/lib/kubelet/plugins
@@ -109,6 +117,9 @@ spec:
           mountPath: /var/run/nri
         - name: cdi-dir
           mountPath: /var/run/cdi
+        {{- with .Values.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
       - name: device-plugin
         hostPath:
@@ -123,3 +134,6 @@ spec:
         hostPath:
           path: /var/run/cdi
           type: DirectoryOrCreate
+      {{- with .Values.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -51,6 +51,34 @@
       },
       "additionalProperties": false
     },
+    "extraEnv": {
+      "description": "Additional environment variables for the dracpu container",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraInitContainers": {
+      "description": "Additional init containers for the DaemonSet pod",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "description": "Additional volume mounts for the dracpu container",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumes": {
+      "description": "Additional volumes for the DaemonSet pod",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "fullnameOverride": {
       "description": "Override the full release name",
       "type": "string"

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -43,6 +43,15 @@ podAnnotations: {}
 # -- Extra labels to add to pods
 podLabels: {}
 
+# -- Additional environment variables for the dracpu container
+extraEnv: [] # @schema item: object
+# -- Additional init containers for the DaemonSet pod
+extraInitContainers: [] # @schema item: object
+# -- Additional volume mounts for the dracpu container
+extraVolumeMounts: [] # @schema item: object
+# -- Additional volumes for the DaemonSet pod
+extraVolumes: [] # @schema item: object
+
 # @schema additionalProperties:false
 resources:
   # @schema additionalProperties:false

--- a/hack/examples/fake-sysfs-values.yaml
+++ b/hack/examples/fake-sysfs-values.yaml
@@ -1,0 +1,136 @@
+# This values file is intended only for testing. On each node, it discovers the
+# real online CPU IDs and splits them evenly across two synthetic sockets and
+# NUMA nodes. A single-CPU node gets one synthetic socket and NUMA node.
+#
+# Run from the repository root with:
+#
+#   helm upgrade --install dra-driver-cpu ./deployment/helm/dra-driver-cpu \
+#     --namespace kube-system \
+#     --values hack/examples/fake-sysfs-values.yaml
+#
+# This set of values was created with kind on Docker Desktop for MacOS in mind. In that set up no NUMA information is available
+# and the CPU DRA driver doesn't publish ResourceSlices due to the missing information.
+args:
+  cpuDeviceMode: grouped
+  groupBy: numanode
+  exposePCIeRoots: false
+
+# Keep topology discovery on the overlaid /sys tree. Setting this explicitly
+# also prevents test-cluster admission hooks from redirecting HOST_ROOT.
+extraEnv:
+  - name: HOST_ROOT
+    value: "/"
+
+extraVolumes:
+  - name: fake-sysfs
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: fake-sysfs
+    mountPath: /sys
+    readOnly: true
+
+extraInitContainers:
+  - name: create-fake-sysfs
+    image: busybox:1.36
+    command: ["/bin/sh", "-ceu"]
+    args:
+      - |
+        root=/work
+        discovered_cpus=/tmp/discovered-cpus
+        online_cpus_file=/tmp/online-cpus
+
+        : > "${discovered_cpus}"
+        for cpu_dir in /sys/devices/system/cpu/cpu[0-9]*; do
+          [ -d "${cpu_dir}" ] || continue
+          if [ -f "${cpu_dir}/online" ] && [ "$(cat "${cpu_dir}/online")" != "1" ]; then
+            continue
+          fi
+          cpu=${cpu_dir##*/cpu}
+          printf '%s\n' "${cpu}" >> "${discovered_cpus}"
+        done
+
+        sort -n "${discovered_cpus}" > "${online_cpus_file}"
+        num_cpus=$(wc -l < "${online_cpus_file}")
+        if [ "${num_cpus}" -eq 0 ]; then
+          echo "no online CPUs discovered" >&2
+          exit 1
+        fi
+
+        node0_count=$(((num_cpus + 1) / 2))
+        online_cpus=
+        node0_cpus=
+        node1_cpus=
+        index=0
+
+        while read -r cpu; do
+          if [ -n "${online_cpus}" ]; then
+            online_cpus="${online_cpus},${cpu}"
+          else
+            online_cpus=${cpu}
+          fi
+
+          if [ "${index}" -lt "${node0_count}" ]; then
+            if [ -n "${node0_cpus}" ]; then
+              node0_cpus="${node0_cpus},${cpu}"
+            else
+              node0_cpus=${cpu}
+            fi
+          else
+            if [ -n "${node1_cpus}" ]; then
+              node1_cpus="${node1_cpus},${cpu}"
+            else
+              node1_cpus=${cpu}
+            fi
+          fi
+          index=$((index + 1))
+        done < "${online_cpus_file}"
+
+        mkdir -p \
+          "${root}/devices/system/cpu/smt" \
+          "${root}/devices/system/node"
+
+        printf '%s\n' "${online_cpus}" > "${root}/devices/system/cpu/online"
+        printf 'off\n' > "${root}/devices/system/cpu/smt/control"
+
+        index=0
+        while read -r cpu; do
+          if [ "${index}" -lt "${node0_count}" ]; then
+            node=0
+            core=${index}
+            shared=${node0_cpus}
+          else
+            node=1
+            core=$((index - node0_count))
+            shared=${node1_cpus}
+          fi
+
+          mkdir -p \
+            "${root}/devices/system/cpu/cpu${cpu}/topology" \
+            "${root}/devices/system/cpu/cpu${cpu}/node${node}" \
+            "${root}/devices/system/cpu/cpu${cpu}/cache/index3"
+
+          printf '%s\n' "${node}" \
+            > "${root}/devices/system/cpu/cpu${cpu}/topology/physical_package_id"
+          printf '%s\n' "${core}" \
+            > "${root}/devices/system/cpu/cpu${cpu}/topology/core_id"
+          printf '3\n' \
+            > "${root}/devices/system/cpu/cpu${cpu}/cache/index3/level"
+          printf '%s\n' "${node}" \
+            > "${root}/devices/system/cpu/cpu${cpu}/cache/index3/id"
+          printf '%s\n' "${shared}" \
+            > "${root}/devices/system/cpu/cpu${cpu}/cache/index3/shared_cpu_list"
+
+          index=$((index + 1))
+        done < "${online_cpus_file}"
+
+        mkdir -p "${root}/devices/system/node/node0"
+        printf '%s\n' "${node0_cpus}" > "${root}/devices/system/node/node0/cpulist"
+
+        if [ -n "${node1_cpus}" ]; then
+          mkdir -p "${root}/devices/system/node/node1"
+          printf '%s\n' "${node1_cpus}" > "${root}/devices/system/node/node1/cpulist"
+        fi
+    volumeMounts:
+      - name: fake-sysfs
+        mountPath: /work


### PR DESCRIPTION
<!--
Thanks for contributing to dra-driver-cpu.

Please fill in the sections below so reviewers can quickly understand scope,
risk, and validation. If a section does not apply, write "N/A".
-->

#### What type of PR is this?

<!-- Add one or more labels in the PR comments, for example:
/kind bug
/kind documentation
/kind cleanup
/kind deprecation
/kind regression
-->
/kind feature

#### What this PR does / why we need it

This PR adds useful helm options and an example values.yaml for testing on hardware that doesn't expose NUMA information. This is the case when running kind on Docker Desktop for MacOS, but may also be the case for other setups.

Modifications to the script can be used to test a wider range of NUMA / socket scenarios locally.

None of the options exposed in helm are test-only - each enables adding native pod spec options - args, env, volumes, volumeMounts, init containers - which are then used to mount a fake sysfs for testing.

#### Which issue(s) this PR is related to

<!--
Use "Fixes #<issue>" when applicable.
For cross-repo issues, include the full URL.
-->

#### Special notes for reviewers

<!--
Call out anything that is useful for review:
- API or behavior changes
- migration impact
- compatibility concerns
- follow-up work
-->

#### Release note

<!--
If this change is not user-facing, write:
NONE
-->

```release-note
NONE
```

#### Documentation updates

<!--
List docs changed by this PR or write NONE.
Example:
- README updates
- Helm chart docs
- release process docs
-->
- Helm chart docs
