### PR TITLE
chore: sysfs: move `SysFS` interface out of the `device` package

### DIFF
--- a/pkg/device/pciescan.go
+++ b/pkg/device/pciescan.go
@@ -18,13 +18,8 @@ package device
 
 import (
 	"fmt"
-	"io/fs"
 
 	"k8s.io/utils/cpuset"
-)
-
-const (
-	SysfsRoot = "/sys"
 )
 
 func FindOrphanedCPUs(domains []PCIeDomain, allCPUs cpuset.CPUSet) cpuset.CPUSet {
@@ -57,11 +52,6 @@ type PCIeDomain struct {
 
 func (pcd PCIeDomain) String() string {
 	return fmt.Sprintf("<PCIeRoot=%s CPUs=%s>", pcd.RootName, pcd.LocalCPUs.String())
-}
-
-type SysFS interface {
-	fs.ReadLinkFS
-	fs.ReadDirFS
 }
 
 // IsPCIeRootName matches the constructions of the pcie roots in the linux kernel.

--- a/pkg/device/pciescan_amd64.go
+++ b/pkg/device/pciescan_amd64.go
@@ -22,14 +22,15 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/sysfs"
 	"k8s.io/utils/cpuset"
 )
 
-func PCIeDomainsFromFS(logger logr.Logger, sysfs SysFS) ([]PCIeDomain, error) {
+func PCIeDomainsFromFS(logger logr.Logger, sfs sysfs.FS) ([]PCIeDomain, error) {
 	logger.V(6).Info("begin: processing PCIe domains")
 	defer logger.V(6).Info("end: processing PCIe domains")
 
-	entries, err := fs.ReadDir(sysfs, "devices")
+	entries, err := fs.ReadDir(sfs, "devices")
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +44,7 @@ func PCIeDomainsFromFS(logger logr.Logger, sysfs SysFS) ([]PCIeDomain, error) {
 
 		busID := strings.TrimPrefix(entryName, "pci")
 
-		busAffinityData, err := fs.ReadFile(sysfs, filepath.Join("devices", entryName, "pci_bus", busID, "cpulistaffinity"))
+		busAffinityData, err := fs.ReadFile(sfs, filepath.Join("devices", entryName, "pci_bus", busID, "cpulistaffinity"))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -28,9 +28,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/internal/ctxlog"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
-	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
 	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/sysfs"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -111,7 +111,7 @@ type CPUDriver struct {
 // Providers group the interfaces the CPUDriver depends on
 type Providers struct {
 	CPUInfo   CPUInfoProvider
-	SysFS     device.SysFS
+	SysFS     sysfs.FS
 	K8SClient kubernetes.Interface
 }
 
@@ -122,9 +122,9 @@ func (pr Providers) EnsureCPUInfo() CPUInfoProvider {
 	return pr.CPUInfo
 }
 
-func (pr Providers) EnsureSysFS() device.SysFS {
+func (pr Providers) EnsureSysFS() sysfs.FS {
 	if pr.SysFS == nil {
-		return os.DirFS(device.SysfsRoot).(device.SysFS)
+		return os.DirFS(sysfs.Root).(sysfs.FS)
 	}
 	return pr.SysFS
 }
@@ -173,9 +173,9 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 		devicesPerResourceSlice: config.DevicesPerResourceSlice(),
 		metrics:                 metricsRecorder,
 	}
-	sysfs := providers.EnsureSysFS()
+	sfs := providers.EnsureSysFS()
 
-	onlineCPUs, err := cpuinfo.OnlineCPUs(logger, sysfs)
+	onlineCPUs, err := cpuinfo.OnlineCPUs(logger, sfs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get online CPUs: %w", err)
 	}
@@ -192,7 +192,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 	plugin.cpuTopology = topo
 
 	if config.ExposePCIeRoots {
-		if err := plugin.pcieRootMapper.Probe(logger, sysfs, onlineCPUs); err != nil {
+		if err := plugin.pcieRootMapper.Probe(logger, sfs, onlineCPUs); err != nil {
 			return nil, fmt.Errorf("failed to list PCIe domains: %w", err)
 		}
 	}

--- a/pkg/store/pcieroot_mapper.go
+++ b/pkg/store/pcieroot_mapper.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/sysfs"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/cpuset"
 )
@@ -37,9 +38,9 @@ func NewPCIeRootMapper() *PCIeRootMapper {
 }
 
 // Probe scans the machine and builds the CPU -> PCIe root mapping
-func (prm *PCIeRootMapper) Probe(logger logr.Logger, sysfs device.SysFS, onlineCPUs cpuset.CPUSet) error {
+func (prm *PCIeRootMapper) Probe(logger logr.Logger, sfs sysfs.FS, onlineCPUs cpuset.CPUSet) error {
 	var err error
-	prm.pcieDomains, err = device.PCIeDomainsFromFS(logger, sysfs)
+	prm.pcieDomains, err = device.PCIeDomainsFromFS(logger, sfs)
 	if err != nil {
 		return fmt.Errorf("failed to list PCIe domains: %w", err)
 	}

--- a/pkg/sysfs/sysfs.go
+++ b/pkg/sysfs/sysfs.go
@@ -1,5 +1,3 @@
-//go:build !amd64
-
 /*
 Copyright The Kubernetes Authors.
 
@@ -16,18 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package device
+package sysfs
 
 import (
-	"github.com/go-logr/logr"
-	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/sysfs"
+	"io/fs"
 )
 
-// IMPORTANT NOTE: the code is functionally identical to the x86_64/amd64 variant,
-// we only scan sysfs and make logic on arch-neutral data; but we don't have yet
-// enough experience on and hw access to arm64 machine to fully support PCIe
-// processing on non-x86_64 hardware.
+const (
+	Root = "/sys"
+)
 
-func PCIeDomainsFromFS(_ logr.Logger, _ sysfs.FS) ([]PCIeDomain, error) {
-	return nil, nil
+type FS interface {
+	fs.ReadLinkFS
+	fs.ReadDirFS
 }

--- a/tools/gen-pcie-testdata/main.go
+++ b/tools/gen-pcie-testdata/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/sysfs"
 )
 
 const (
@@ -41,7 +42,7 @@ const (
 )
 
 func main() {
-	sysfsRoot := device.SysfsRoot
+	sysfsRoot := sysfs.Root
 	gen := newMapFSGen()
 
 	flag.StringVar(&sysfsRoot, "sysfs-root", sysfsRoot, "sysfs root path")
@@ -56,12 +57,12 @@ func main() {
 		}
 	}
 
-	sysfs := os.DirFS(sysfsRoot).(device.SysFS)
+	sfs := os.DirFS(sysfsRoot).(sysfs.FS)
 	logger := stdr.New(log.Default())
 
 	// need to silence output on the happy path so we can
 	// trivially redirect the output to a file
-	err := gen.Collect(logr.Discard(), sysfs)
+	err := gen.Collect(logr.Discard(), sfs)
 	if err != nil {
 		logger.Error(err, "failed to collect sysfs snapshot")
 		os.Exit(2)
@@ -100,8 +101,8 @@ func newMapFSGen() *mapFSGen {
 	}
 }
 
-func (gen *mapFSGen) ReadDataFrom(sysfs device.SysFS, sysPath string) error {
-	data, err := fs.ReadFile(sysfs, sysPath)
+func (gen *mapFSGen) ReadDataFrom(sfs sysfs.FS, sysPath string) error {
+	data, err := fs.ReadFile(sfs, sysPath)
 	if err != nil {
 		return fmt.Errorf("reading data %q: %w", sysPath, err)
 	}
@@ -120,9 +121,9 @@ func (gen *mapFSGen) Emit(w io.Writer) {
 	fmt.Fprintf(w, "}\n")
 }
 
-func (gen *mapFSGen) Collect(logger logr.Logger, sysfs device.SysFS) error {
+func (gen *mapFSGen) Collect(logger logr.Logger, sfs sysfs.FS) error {
 	devicesDir := "devices"
-	entries, err := fs.ReadDir(sysfs, devicesDir)
+	entries, err := fs.ReadDir(sfs, devicesDir)
 	if err != nil {
 		return fmt.Errorf("reading %q: %w", devicesDir, err)
 	}
@@ -133,14 +134,14 @@ func (gen *mapFSGen) Collect(logger logr.Logger, sysfs device.SysFS) error {
 		}
 		busID := strings.TrimPrefix(entry.Name(), "pci")
 		affinityPath := filepath.Join(devicesDir, entry.Name(), "pci_bus", busID, "cpulistaffinity")
-		if err := gen.ReadDataFrom(sysfs, affinityPath); err != nil {
+		if err := gen.ReadDataFrom(sfs, affinityPath); err != nil {
 			return err
 		}
 		logger.Info("collected PCIe root", "root", entry.Name(), "path", affinityPath)
 	}
 
 	cpuOnlinePath := filepath.Join(devicesDir, "system", "cpu", "online")
-	if err := gen.ReadDataFrom(sysfs, cpuOnlinePath); err != nil {
+	if err := gen.ReadDataFrom(sfs, cpuOnlinePath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it
we would eventually need to port` pkg/cpuinfo` to the `SysFS` abstraction.
To prevent unnecessary coupling, the simplest enabler is to move the `SysFS` abstractions and helpers in a tiny independent package `device` and `cpuinfo` can consume. Tiny *local* packages are no bother and generally a good practice - package tight scope and focus is a plus.

Mechanical change with only code movement and rename

#### Which issue(s) this PR is related to
N/A

#### Special notes for reviewers
Enabler for https://github.com/kubernetes-sigs/dra-driver-cpu/pull/222#issuecomment-4856649702
Internal only change
If we don't proceed with the overlay approach in #222 , we will still need to make the codebase consistent and port `pkg/cpuinfo` to our SysFS abstraction.

#### Release note
```release-note
NONE
```

#### Documentation updates

Internal only change