### PR TITLE
driver: improve NRI test assertions and error matching

### DIFF
--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,6 +28,13 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/cpuset"
+)
+
+var (
+	errMalformedDRAEnv         = errors.New("malformed DRA env entry")
+	errParseCPUSet             = errors.New("failed to parse cpuset value")
+	errClaimNotPrepared        = errors.New("claim is not prepared by this driver")
+	errClaimAllocationMismatch = errors.New("claim cpuset does not match prepared allocation")
 )
 
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
@@ -109,7 +117,7 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 		logger.V(4).Info("parsing DRA env entry", "env", env)
 		parts := strings.SplitN(env, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("malformed DRA env entry %q", env)
+			return nil, fmt.Errorf("%w: %q", errMalformedDRAEnv, env)
 		}
 		key, value := parts[0], parts[1]
 		var claimUID types.UID
@@ -122,7 +130,7 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 
 		parsedSet, err := cpuset.Parse(value)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse cpuset value %q from env %q: %w", value, env, err)
+			return nil, fmt.Errorf("%w: value %q from env %q: %v", errParseCPUSet, value, env, err)
 		}
 		allocations[claimUID] = parsedSet
 	}
@@ -133,10 +141,10 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 func (cp *CPUDriver) validatePreparedClaimAllocation(uid types.UID, cpus cpuset.CPUSet) error {
 	preparedCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(uid)
 	if !ok {
-		return fmt.Errorf("claim %q is not prepared by this driver", uid)
+		return fmt.Errorf("%w: claim %q", errClaimNotPrepared, uid)
 	}
 	if !preparedCPUs.Equals(cpus) {
-		return fmt.Errorf("validation failed for claim %q: cpuset mismatch (expected %q, got %q)", uid, preparedCPUs.String(), cpus.String())
+		return fmt.Errorf("%w for claim %q: expected %q, got %q", errClaimAllocationMismatch, uid, preparedCPUs.String(), cpus.String())
 	}
 	return nil
 }

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -130,7 +130,7 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 
 		parsedSet, err := cpuset.Parse(value)
 		if err != nil {
-			return nil, fmt.Errorf("%w: value %q from env %q: %v", errParseCPUSet, value, env, err)
+			return nil, fmt.Errorf("%w: value %q from env %q: %w", errParseCPUSet, value, env, err)
 		}
 		allocations[claimUID] = parsedSet
 	}

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -37,6 +37,35 @@ var (
 	errClaimAllocationMismatch = errors.New("claim cpuset does not match prepared allocation")
 )
 
+type nriContextError struct {
+	kind  error
+	msg   string
+	cause error
+}
+
+func (e *nriContextError) Error() string {
+	if e.cause == nil {
+		return e.msg
+	}
+	return fmt.Sprintf("%s: %v", e.msg, e.cause)
+}
+
+func (e *nriContextError) Unwrap() error {
+	return e.cause
+}
+
+func (e *nriContextError) Is(target error) bool {
+	return target == e.kind
+}
+
+func newNRIContextError(kind error, cause error, format string, args ...any) error {
+	return &nriContextError{
+		kind:  kind,
+		msg:   fmt.Sprintf(format, args...),
+		cause: cause,
+	}
+}
+
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
 func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen))
@@ -117,7 +146,7 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 		logger.V(4).Info("parsing DRA env entry", "env", env)
 		parts := strings.SplitN(env, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("%w: %q", errMalformedDRAEnv, env)
+			return nil, newNRIContextError(errMalformedDRAEnv, nil, "malformed DRA env entry %q", env)
 		}
 		key, value := parts[0], parts[1]
 		var claimUID types.UID
@@ -130,7 +159,7 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 
 		parsedSet, err := cpuset.Parse(value)
 		if err != nil {
-			return nil, fmt.Errorf("%w: value %q from env %q: %w", errParseCPUSet, value, env, err)
+			return nil, newNRIContextError(errParseCPUSet, err, "failed to parse cpuset value %q from env %q", value, env)
 		}
 		allocations[claimUID] = parsedSet
 	}
@@ -141,10 +170,10 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 func (cp *CPUDriver) validatePreparedClaimAllocation(uid types.UID, cpus cpuset.CPUSet) error {
 	preparedCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(uid)
 	if !ok {
-		return fmt.Errorf("%w: claim %q", errClaimNotPrepared, uid)
+		return newNRIContextError(errClaimNotPrepared, nil, "claim %q is not prepared by this driver", uid)
 	}
 	if !preparedCPUs.Equals(cpus) {
-		return fmt.Errorf("%w for claim %q: expected %q, got %q", errClaimAllocationMismatch, uid, preparedCPUs.String(), cpus.String())
+		return newNRIContextError(errClaimAllocationMismatch, nil, "validation failed for claim %q: cpuset mismatch (expected %q, got %q)", uid, preparedCPUs.String(), cpus.String())
 	}
 	return nil
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/containerd/nri/pkg/api"
@@ -38,6 +39,7 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 		envs                []string
 		expectedAllocations map[types.UID]cpuset.CPUSet
 		expectedErr         error
+		expectedCause       error
 	}{
 		{
 			name: "single valid env",
@@ -68,9 +70,10 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 			expectedErr: errMalformedDRAEnv,
 		},
 		{
-			name:        "malformed env - invalid cpuset",
-			envs:        []string{fmt.Sprintf("%s_claim-uid-1=%s", cdiEnvVarPrefix, "a-b")},
-			expectedErr: errParseCPUSet,
+			name:          "malformed env - invalid cpuset",
+			envs:          []string{fmt.Sprintf("%s_claim-uid-1=%s", cdiEnvVarPrefix, "a-b")},
+			expectedErr:   errParseCPUSet,
+			expectedCause: strconv.ErrSyntax,
 		},
 		{
 			name:                "empty env",
@@ -85,6 +88,9 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 			if tc.expectedErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tc.expectedErr)
+				if tc.expectedCause != nil {
+					require.ErrorIs(t, err, tc.expectedCause)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, len(tc.expectedAllocations), len(allocations))

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -34,10 +34,10 @@ import (
 func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 	logger := testr.New(t)
 	testCases := []struct {
-		name                  string
-		envs                  []string
-		expectedAllocations   map[types.UID]cpuset.CPUSet
-		expectedErrorContains string
+		name                string
+		envs                []string
+		expectedAllocations map[types.UID]cpuset.CPUSet
+		expectedErr         error
 	}{
 		{
 			name: "single valid env",
@@ -63,14 +63,14 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 			expectedAllocations: map[types.UID]cpuset.CPUSet{},
 		},
 		{
-			name:                  "malformed env - no equals",
-			envs:                  []string{fmt.Sprintf("%s_claim-uid-1", cdiEnvVarPrefix)},
-			expectedErrorContains: "malformed DRA env entry",
+			name:        "malformed env - no equals",
+			envs:        []string{fmt.Sprintf("%s_claim-uid-1", cdiEnvVarPrefix)},
+			expectedErr: errMalformedDRAEnv,
 		},
 		{
-			name:                  "malformed env - invalid cpuset",
-			envs:                  []string{fmt.Sprintf("%s_claim-uid-1=%s", cdiEnvVarPrefix, "a-b")},
-			expectedErrorContains: "failed to parse cpuset value",
+			name:        "malformed env - invalid cpuset",
+			envs:        []string{fmt.Sprintf("%s_claim-uid-1=%s", cdiEnvVarPrefix, "a-b")},
+			expectedErr: errParseCPUSet,
 		},
 		{
 			name:                "empty env",
@@ -82,9 +82,9 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			allocations, err := parseDRAEnvToClaimAllocations(logger, tc.envs)
-			if tc.expectedErrorContains != "" {
+			if tc.expectedErr != nil {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErrorContains)
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, len(tc.expectedAllocations), len(allocations))
@@ -133,7 +133,7 @@ func TestCreateContainer(t *testing.T) {
 		container                   *api.Container
 		expectedContainerAdjustment *api.ContainerAdjustment
 		expectedContainerUpdates    []*api.ContainerUpdate
-		expectedErrorContains       string
+		expectedErr                 error
 	}{
 		{
 			name:           "guaranteed container triggers container adjustment with cpus in resource claim",
@@ -216,7 +216,7 @@ func TestCreateContainer(t *testing.T) {
 				Name:         "my-ctr",
 				Env:          []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, "a-b")},
 			},
-			expectedErrorContains: "failed to parse cpuset value",
+			expectedErr: errParseCPUSet,
 		},
 		{
 			name:               "container with DRA env for unprepared claim fails closed",
@@ -224,10 +224,7 @@ func TestCreateContainer(t *testing.T) {
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 			claimTracker:       store.NewClaimTracker(),
 			container:          newTestContainer(claimUID, "0-3"),
-			expectedErrorContains: fmt.Sprintf(
-				"claim %q is not prepared by this driver",
-				claimUID,
-			),
+			expectedErr:        errClaimNotPrepared,
 		},
 		{
 			name:           "container with DRA env that differs from prepared allocation fails closed",
@@ -239,12 +236,7 @@ func TestCreateContainer(t *testing.T) {
 			}(),
 			claimTracker: store.NewClaimTracker(),
 			container:    newTestContainer(claimUID, "0-3"),
-			expectedErrorContains: fmt.Sprintf(
-				"validation failed for claim %q: cpuset mismatch (expected %q, got %q)",
-				claimUID,
-				"0-1",
-				"0-3",
-			),
+			expectedErr:  errClaimAllocationMismatch,
 		},
 	}
 
@@ -256,9 +248,9 @@ func TestCreateContainer(t *testing.T) {
 				claimTracker:       tc.claimTracker,
 			}
 			adjust, updates, err := driver.CreateContainer(context.Background(), pod, tc.container)
-			if tc.expectedErrorContains != "" {
+			if tc.expectedErr != nil {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErrorContains)
+				require.ErrorIs(t, err, tc.expectedErr)
 				require.Nil(t, adjust)
 				require.Nil(t, updates)
 				return
@@ -287,9 +279,9 @@ func TestStopContainer(t *testing.T) {
 	topo, _ := mockProvider.GetCPUTopology(logger)
 
 	testCases := []struct {
-		name               string
-		driver             *CPUDriver
-		expectedUpdatesFor []string
+		name            string
+		driver          *CPUDriver
+		expectedUpdates []*api.ContainerUpdate
 	}{
 		{
 			name: "Stop guaranteed container sets update required for shared containers",
@@ -300,11 +292,17 @@ func TestStopContainer(t *testing.T) {
 					claimTracker:       store.NewClaimTracker(),
 					cpuTopology:        topo,
 				}
+				driver.cpuAllocationStore.AddResourceClaimAllocation(logger, types.UID("claim-uid-1"), cpuset.New(2, 3))
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), types.UID("claim-uid-1")))
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
 				return driver
 			}(),
-			expectedUpdatesFor: []string{ctr2.Id},
+			expectedUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: ctr2.Id,
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
+				},
+			},
 		},
 		{
 			name: "Stop non-guaranteed container does not set update required",
@@ -319,16 +317,15 @@ func TestStopContainer(t *testing.T) {
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
 				return driver
 			}(),
-			expectedUpdatesFor: []string{},
+			expectedUpdates: []*api.ContainerUpdate{},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sort.Strings(tc.expectedUpdatesFor)
 			upd, err := tc.driver.StopContainer(context.Background(), pod1, ctr1)
 			require.NoError(t, err)
-			require.Equal(t, containerIDsFromUpdates(upd), tc.expectedUpdatesFor)
+			require.ElementsMatch(t, tc.expectedUpdates, upd)
 		})
 	}
 }
@@ -352,7 +349,7 @@ func TestNRISynchronize(t *testing.T) {
 		runtimePods     []*api.PodSandbox
 		runtimeCtrs     []*api.Container
 		expectedUpdates []*api.ContainerUpdate
-		expectedError   string
+		expectedErr     error
 	}{
 		{
 			name: "empty runtime state clears the store",
@@ -479,7 +476,7 @@ func TestNRISynchronize(t *testing.T) {
 				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
 				{Id: "p1-malformed", PodSandboxId: pod1.Id, Name: "malformed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "a-b")}},
 			},
-			expectedError: "failed to parse cpuset value",
+			expectedErr: errParseCPUSet,
 		},
 	}
 
@@ -487,9 +484,9 @@ func TestNRISynchronize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			updates, err := tc.driver.Synchronize(context.Background(), tc.runtimePods, tc.runtimeCtrs)
 
-			if tc.expectedError != "" {
+			if tc.expectedErr != nil {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
+				require.ErrorIs(t, err, tc.expectedErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strconv"
 	"testing"
 
@@ -502,15 +501,6 @@ func TestNRISynchronize(t *testing.T) {
 			require.ElementsMatch(t, tc.expectedUpdates, updates)
 		})
 	}
-}
-
-func containerIDsFromUpdates(updates []*api.ContainerUpdate) []string {
-	ids := make([]string, 0, len(updates))
-	for _, upd := range updates {
-		ids = append(ids, upd.ContainerId)
-	}
-	sort.Strings(ids)
-	return ids
 }
 
 // TestStopContainerReleasesClaimToSharedPool asserts the DRA/NRI lifetime invariant tracked by #188:

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -90,6 +91,7 @@ func TestParseDRAEnvToClaimAllocations(t *testing.T) {
 				require.ErrorIs(t, err, tc.expectedErr)
 				if tc.expectedCause != nil {
 					require.ErrorIs(t, err, tc.expectedCause)
+					require.ErrorIs(t, errors.Unwrap(err), tc.expectedCause)
 				}
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
Related to #204.


This PR improves NRI unit test maintainability by replacing fragile error-string matching with stable error-category assertions, and by tightening observable-behavior checks where practical.
