### PR TITLE
ci: wait for worker node to exist before labeling it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ ifneq ($(DRACPU_E2E_VERBOSE),)
 	@echo "creating a kind cluster for mode=$(DRACPU_E2E_CPU_DEVICE_MODE)"
 endif
 	kind create cluster --name ${CLUSTER_NAME} --image=kindest/node:$(KIND_K8S_VERSION) --config hack/ci/kind-ci.yaml
+	kubectl wait --for=create node/${CLUSTER_NAME}-worker --timeout=120s
 	kubectl label node ${CLUSTER_NAME}-worker node-role.kubernetes.io/worker=''
 	kind load docker-image --name ${CLUSTER_NAME} ${IMAGE_CI} ${IMAGE_TEST}
 	$(HELM) install dra-driver-cpu ${HELM_CHART} ${HELM_COMMON_ARGS} \


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
`kind create cluster` can return before the worker node's kubelet finishes registering its node. This in some runs causes labeling the Node to fail with NotFound. We could add `kubectl wait --for=create` to block until the node exists before we start labeling.

Noticed it some time ago but the most recent one was in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/213. 
```
Set kubectl context to "kind-dra-driver-cpu"
You can now use your cluster with:
kubectl cluster-info --context kind-dra-driver-cpu
Have a nice day! 👋
kubectl label node dra-driver-cpu-worker node-role.kubernetes.io/worker=''
Error from server (NotFound): nodes "dra-driver-cpu-worker" not found
make: *** [Makefile:190: ci-kind-setup] Error 1
```

xref to the failed run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_dra-driver-cpu/213/pull-dra-driver-cpu-e2e-device-mode-individual-amd64/2076933281105842176
#### Which issue(s) this PR is related to

NONE

#### Special notes for reviewers

<!--
Call out anything that is useful for review:
- API or behavior changes
- migration impact
- compatibility concerns
- follow-up work
-->

#### Release note

<!--
If this change is not user-facing, write:
NONE
-->

```release-note

```

#### Documentation updates

<!--
List docs changed by this PR or write NONE.
Example:
- README updates
- Helm chart docs
- release process docs
-->
