### PR TITLE
driver: propagate context in Start method

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -216,7 +216,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 // Start registers the plugin with kubelet, starts the NRI plugin, and begins
 // async resource publication. Setup must have been called first.
 func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
-	_, logger := ctxlog.WithValues(ctx, "driver", cp.driverName)
+	ctx, logger := ctxlog.WithValues(ctx, "driver", cp.driverName)
 
 	asyncErr := make(chan error, 1)
 


### PR DESCRIPTION
In the Start method, we discarded the context returned from ctxlog.WithValues(ctx, "driver", cp.driverName). This drops the "driver" structured log field for downstream callers (such as kubeletplugin.Start, wait.PollUntilContextTimeout, runNRIPluginWithRetry, and PublishResources) that retrieve the logger from the context.\n\nThis patch propagates the context properly.