### PR TITLE
Preserve prepared CPU allocations across container restarts

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -374,6 +374,9 @@ func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplu
 	}
 	cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
 	cp.claimTracker.Cleanup(claim.UID)
+	// Existing shared containers pick up the expanded cpuset on their next CreateContainer
+	// or Synchronize. Updating them here requires NRI UpdateContainers support across all
+	// supported runtime versions.
 	return nil
 }
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -123,7 +123,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 	}
 
 	var cpuAssignment cpuset.CPUSet
-	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
+	allocatableCPUs := cp.cpuAllocationStore.GetAllocatableCPUs()
 	for _, alloc := range claim.Status.Allocation.Devices.Results {
 		if alloc.Driver != cp.driverName {
 			continue
@@ -153,7 +153,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 				return kubeletplugin.PrepareResult{Err: fmt.Errorf("no valid socket ID found for device %s", alloc.Device)}
 			}
 			socketCPUs := topo.CPUDetails.CPUsInSockets(socketID)
-			availableCPUsForDevice := sharedCPUs.Difference(cpuAssignment).Intersection(socketCPUs)
+			availableCPUsForDevice := allocatableCPUs.Difference(cpuAssignment).Intersection(socketCPUs)
 			logger.V(4).Info("socket CPU availability", "socketID", socketID, "socketCPUs", socketCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 			cur, err = cpumanager.TakeByTopologyNUMAPacked(logger, topo, availableCPUsForDevice, int(claimCPUCount), cpumanager.CPUSortingStrategyPacked, true)
 		case device.GROUP_BY_NUMA_NODE:
@@ -162,7 +162,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 				return kubeletplugin.PrepareResult{Err: fmt.Errorf("no valid NUMA node ID found for device %s", alloc.Device)}
 			}
 			numaCPUs := topo.CPUDetails.CPUsInNUMANodes(numaNodeID)
-			availableCPUsForDevice := sharedCPUs.Difference(cpuAssignment).Intersection(numaCPUs)
+			availableCPUsForDevice := allocatableCPUs.Difference(cpuAssignment).Intersection(numaCPUs)
 			logger.V(4).Info("NUMA node CPU availability", "numaNodeID", numaNodeID, "numaCPUs", numaCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 			cur, err = cpumanager.TakeByTopologyNUMAPacked(logger, topo, availableCPUsForDevice, int(claimCPUCount), cpumanager.CPUSortingStrategyPacked, true)
 		case device.GROUP_BY_MACHINE:
@@ -193,11 +193,14 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		return kubeletplugin.PrepareResult{}
 	}
 
+	if err := cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claim.UID, cpuAssignment); err != nil {
+		return kubeletplugin.PrepareResult{Err: err}
+	}
 	result := cp.prepareDevices(logger, claim, cpuAssignment)
 	if result.Err != nil {
+		cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
 		return result
 	}
-	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, cpuAssignment)
 	cp.metricsRecorder().RecordClaimAllocatedCPUs(cpuAssignment.Size())
 	cp.refreshAllocationMetrics()
 	return result
@@ -243,19 +246,22 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		return cp.prepareDevices(logger, claim, existingCPUs)
 	}
 
-	// All the CPUs allocated to a claim should currently be in the shared pool.
-	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
-	if !claimCPUSet.IsSubsetOf(sharedCPUs) {
+	// All the CPUs allocated to a claim must not be prepared for another claim.
+	allocatableCPUs := cp.cpuAllocationStore.GetAllocatableCPUs()
+	if !claimCPUSet.IsSubsetOf(allocatableCPUs) {
 		return kubeletplugin.PrepareResult{
 			Err: fmt.Errorf("claim %s/%s has overlapping device assignment with other claims", claim.Namespace, claim.Name),
 		}
 	}
 
+	if err := cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claim.UID, claimCPUSet); err != nil {
+		return kubeletplugin.PrepareResult{Err: err}
+	}
 	result := cp.prepareDevices(logger, claim, claimCPUSet)
 	if result.Err != nil {
+		cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
 		return result
 	}
-	cp.cpuAllocationStore.AddResourceClaimAllocation(logger, claim.UID, claimCPUSet)
 	cp.metricsRecorder().RecordClaimAllocatedCPUs(claimCPUSet.Size())
 	cp.refreshAllocationMetrics()
 	return result
@@ -365,6 +371,7 @@ func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplu
 		return err
 	}
 	cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
+	cp.claimTracker.Cleanup(claim.UID)
 	return nil
 }
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -193,6 +193,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		return kubeletplugin.PrepareResult{}
 	}
 
+	// Reserve before CDI I/O so concurrent Prepare calls cannot select the same CPUs.
 	if err := cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claim.UID, cpuAssignment); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
 	}
@@ -254,6 +255,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		}
 	}
 
+	// Reserve before CDI I/O so concurrent Prepare calls cannot select the same CPUs.
 	if err := cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claim.UID, claimCPUSet); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
 	}
@@ -461,7 +463,7 @@ func (cp *CPUDriver) validateOpaqueCPUSet(opaqueCPUSet cpuset.CPUSet, onlineCPUs
 	}
 
 	// Verify cores do not overlap with other active claims on this node
-	existingClaimCPUs := cp.cpuAllocationStore.GetAllocatedCPUs()
+	existingClaimCPUs := cp.cpuAllocationStore.GetPreparedCPUs()
 	if opaqueCPUSet.Intersection(existingClaimCPUs).Size() > 0 {
 		return fmt.Errorf("requested CPUs %s from opaque config conflict with already allocated claims", opaqueCPUSet.String())
 	}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -123,7 +123,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 	}
 
 	var cpuAssignment cpuset.CPUSet
-	allocatableCPUs := cp.cpuAllocationStore.GetAllocatableCPUs()
+	allocatableCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	for _, alloc := range claim.Status.Allocation.Devices.Results {
 		if alloc.Driver != cp.driverName {
 			continue
@@ -248,7 +248,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 	}
 
 	// All the CPUs allocated to a claim must not be prepared for another claim.
-	allocatableCPUs := cp.cpuAllocationStore.GetAllocatableCPUs()
+	allocatableCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	if !claimCPUSet.IsSubsetOf(allocatableCPUs) {
 		return kubeletplugin.PrepareResult{
 			Err: fmt.Errorf("claim %s/%s has overlapping device assignment with other claims", claim.Namespace, claim.Name),

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -374,9 +374,9 @@ func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplu
 	}
 	cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
 	cp.claimTracker.Cleanup(claim.UID)
-	// Existing shared containers pick up the expanded cpuset on their next CreateContainer
-	// or Synchronize. Updating them here requires NRI UpdateContainers support across all
-	// supported runtime versions.
+	// TODO(#279): Update existing shared containers here once all supported runtimes can
+	// safely process unsolicited NRI UpdateContainers calls. Until then, each container
+	// picks up the expanded cpuset on its next CreateContainer or Synchronize.
 	return nil
 }
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1392,7 +1392,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 			firstDevices:   []string{"cpudev000", "cpudev002"},
 			secondDevices:  []string{"cpudev000", "cpudev002"},
 			expectedCPUSet: cpuset.New(0, 1),
-			expectedShared: cpuset.New(2, 3),
+			expectedShared: cpuset.New(0, 1, 2, 3),
 			expectError:    false,
 		},
 		{
@@ -1400,7 +1400,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 			firstDevices:   []string{"cpudev000", "cpudev002"},
 			secondDevices:  []string{"cpudev001", "cpudev003"},
 			expectedCPUSet: cpuset.New(0, 1),
-			expectedShared: cpuset.New(2, 3),
+			expectedShared: cpuset.New(0, 1, 2, 3),
 			expectError:    true,
 		},
 	}
@@ -1529,7 +1529,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
 		},
 		{
 			name:           "different socket repeated",
@@ -1537,7 +1537,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket1": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
 		},
 		{
 			name:           "same NUMA node repeated",
@@ -1545,7 +1545,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
 		},
 		{
 			name:           "different NUMA node repeated",
@@ -1553,7 +1553,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma1": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
 		},
 	}
 
@@ -1669,6 +1669,7 @@ func TestUnprepareResourceClaimsKeepsAllocationWhenCDIRemoveFails(t *testing.T) 
 	require.True(t, ok)
 	require.True(t, allocatedCPUs.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, allocatedCPUs)
 	require.True(t, cpuset.New(1, 3).Equals(cp.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s", cp.cpuAllocationStore.GetSharedCPUs())
+	require.Equal(t, 1, cp.claimTracker.Len())
 	require.Contains(t, mockCdiMgr.devices, cdiDeviceName)
 }
 
@@ -1687,6 +1688,7 @@ func TestUnprepareResourceClaimsRemovesAllocationAfterCDIRemoveSucceeds(t *testi
 	_, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
 	require.False(t, ok)
 	require.True(t, cpuset.New(0, 1, 2, 3).Equals(cp.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s", cp.cpuAllocationStore.GetSharedCPUs())
+	require.Equal(t, 0, cp.claimTracker.Len())
 	require.NotContains(t, mockCdiMgr.devices, cdiDeviceName)
 }
 
@@ -1700,10 +1702,13 @@ func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID type
 	require.NoError(t, err)
 	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
 	cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, allocatedCPUs)
+	claimTracker := store.NewClaimTracker()
+	require.NoError(t, claimTracker.SetOwner(logger, claimUID, "pod", "container"))
 
 	return &CPUDriver{
 		cdiMgr:             mockCdiMgr,
 		cpuAllocationStore: cpuAllocationStore,
+		claimTracker:       claimTracker,
 	}, mockCdiMgr
 }
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1708,7 +1708,8 @@ func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID type
 	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
 	requirePreparedResourceClaim(t, logger, cpuAllocationStore, claimUID, allocatedCPUs)
 	claimTracker := store.NewClaimTracker()
-	require.NoError(t, claimTracker.SetOwner(logger, claimUID, "pod", "container"))
+	_, err = claimTracker.SetOwner(logger, "pod", "container", claimUID)
+	require.NoError(t, err)
 
 	return &CPUDriver{
 		cdiMgr:             mockCdiMgr,

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -47,6 +47,12 @@ const (
 	testDriverName = "dra-driver-cpu.k8s.io"
 )
 
+func requireEnforcedResourceClaim(t testing.TB, logger logr.Logger, allocationStore *store.CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
+	t.Helper()
+	require.NoError(t, allocationStore.ReserveResourceClaimAllocation(logger, claimUID, cpus))
+	require.NoError(t, allocationStore.EnforceResourceClaims(map[types.UID]cpuset.CPUSet{claimUID: cpus}))
+}
+
 // testSysFS enables full isolation and full mocking from the host filesystem.
 // It is not strictly speaking needed by the current tests, but it is added for better hygiene.
 func testSysFS(infos []cpuinfo.CPUInfo) fstest.MapFS {
@@ -758,7 +764,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 			setupDriver: func(t *testing.T) *CPUDriver {
 				t.Helper()
 				d := baseCPUDriver(t)
-				d.cpuAllocationStore.AddResourceClaimAllocation(testr.New(t), "claim0", cpuset.New(0))
+				requireEnforcedResourceClaim(t, testr.New(t), d.cpuAllocationStore, "claim0", cpuset.New(0))
 				return d
 			},
 			claims: []*resourceapi.ResourceClaim{
@@ -837,7 +843,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 		}
 		if withExistingAllocation {
-			driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, existingCPUs)
+			requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
 		}
 		return driver
 	}
@@ -858,7 +864,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 		}
 		if withExistingAllocation {
-			driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, existingCPUs)
+			requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
 		}
 		return driver
 	}
@@ -957,7 +963,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 		driver, err := New(testr.New(t), prov, &conf)
 		require.NoError(t, err)
 		for claimUID, cpus := range initialAllocations {
-			driver.cpuAllocationStore.AddResourceClaimAllocation(testr.New(t), claimUID, cpus)
+			requireEnforcedResourceClaim(t, testr.New(t), driver.cpuAllocationStore, claimUID, cpus)
 		}
 		return driver
 	}
@@ -1701,7 +1707,7 @@ func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID type
 	topo, err := mockProvider.GetCPUTopology(logger)
 	require.NoError(t, err)
 	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
-	cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, allocatedCPUs)
+	requireEnforcedResourceClaim(t, logger, cpuAllocationStore, claimUID, allocatedCPUs)
 	claimTracker := store.NewClaimTracker()
 	require.NoError(t, claimTracker.SetOwner(logger, claimUID, "pod", "container"))
 
@@ -2108,7 +2114,7 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 	driver.topology.onlineCPUs = driver.topology.cpuTopology.CPUDetails.CPUs()
 	driver.cpuAllocationStore = store.NewCPUAllocation(driver.topology.cpuTopology, reservedCPUs)
 	for claimUID, cpus := range initialAllocations {
-		driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, cpus)
+		requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpus)
 	}
 
 	topo, err := mockProvider.GetCPUTopology(logger)

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -47,10 +47,9 @@ const (
 	testDriverName = "dra-driver-cpu.k8s.io"
 )
 
-func requireEnforcedResourceClaim(t testing.TB, logger logr.Logger, allocationStore *store.CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
+func requirePreparedResourceClaim(t testing.TB, logger logr.Logger, allocationStore *store.CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
 	t.Helper()
 	require.NoError(t, allocationStore.ReserveResourceClaimAllocation(logger, claimUID, cpus))
-	require.NoError(t, allocationStore.EnforceResourceClaims(map[types.UID]cpuset.CPUSet{claimUID: cpus}))
 }
 
 // testSysFS enables full isolation and full mocking from the host filesystem.
@@ -764,7 +763,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 			setupDriver: func(t *testing.T) *CPUDriver {
 				t.Helper()
 				d := baseCPUDriver(t)
-				requireEnforcedResourceClaim(t, testr.New(t), d.cpuAllocationStore, "claim0", cpuset.New(0))
+				requirePreparedResourceClaim(t, testr.New(t), d.cpuAllocationStore, "claim0", cpuset.New(0))
 				return d
 			},
 			claims: []*resourceapi.ResourceClaim{
@@ -843,7 +842,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 		}
 		if withExistingAllocation {
-			requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
+			requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
 		}
 		return driver
 	}
@@ -864,7 +863,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 		}
 		if withExistingAllocation {
-			requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
+			requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
 		}
 		return driver
 	}
@@ -963,7 +962,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 		driver, err := New(testr.New(t), prov, &conf)
 		require.NoError(t, err)
 		for claimUID, cpus := range initialAllocations {
-			requireEnforcedResourceClaim(t, testr.New(t), driver.cpuAllocationStore, claimUID, cpus)
+			requirePreparedResourceClaim(t, testr.New(t), driver.cpuAllocationStore, claimUID, cpus)
 		}
 		return driver
 	}
@@ -1398,7 +1397,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 			firstDevices:   []string{"cpudev000", "cpudev002"},
 			secondDevices:  []string{"cpudev000", "cpudev002"},
 			expectedCPUSet: cpuset.New(0, 1),
-			expectedShared: cpuset.New(0, 1, 2, 3),
+			expectedShared: cpuset.New(2, 3),
 			expectError:    false,
 		},
 		{
@@ -1406,7 +1405,7 @@ func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 			firstDevices:   []string{"cpudev000", "cpudev002"},
 			secondDevices:  []string{"cpudev001", "cpudev003"},
 			expectedCPUSet: cpuset.New(0, 1),
-			expectedShared: cpuset.New(0, 1, 2, 3),
+			expectedShared: cpuset.New(2, 3),
 			expectError:    true,
 		},
 	}
@@ -1535,7 +1534,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
 		},
 		{
 			name:           "different socket repeated",
@@ -1543,7 +1542,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket1": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
 		},
 		{
 			name:           "same NUMA node repeated",
@@ -1551,7 +1550,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
 		},
 		{
 			name:           "different NUMA node repeated",
@@ -1559,7 +1558,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma0": 2}),
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma1": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
-			expectedShared: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
 		},
 	}
 
@@ -1707,7 +1706,7 @@ func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID type
 	topo, err := mockProvider.GetCPUTopology(logger)
 	require.NoError(t, err)
 	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
-	requireEnforcedResourceClaim(t, logger, cpuAllocationStore, claimUID, allocatedCPUs)
+	requirePreparedResourceClaim(t, logger, cpuAllocationStore, claimUID, allocatedCPUs)
 	claimTracker := store.NewClaimTracker()
 	require.NoError(t, claimTracker.SetOwner(logger, claimUID, "pod", "container"))
 
@@ -2114,7 +2113,7 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 	driver.topology.onlineCPUs = driver.topology.cpuTopology.CPUDetails.CPUs()
 	driver.cpuAllocationStore = store.NewCPUAllocation(driver.topology.cpuTopology, reservedCPUs)
 	for claimUID, cpus := range initialAllocations {
-		requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpus)
+		requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpus)
 	}
 
 	topo, err := mockProvider.GetCPUTopology(logger)

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -189,9 +189,9 @@ func TestMetricsNRIAllocationState(t *testing.T) {
 
 	_, err = driver.StopContainer(context.Background(), pod, container)
 	require.NoError(t, err)
-	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_allocated_cpus", nil))
-	require.Equal(t, float64(4), metricValue(t, reg, "dra_cpu_available_cpus", nil))
-	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_resource_claims_active", nil))
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_allocated_cpus", nil))
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_available_cpus", nil))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_resource_claims_active", nil))
 }
 
 func TestMetricsUnprepareResults(t *testing.T) {

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -95,7 +95,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 			if len(claimUIDs) == 0 {
 				state = store.NewContainerState(container.GetName(), containerUID)
 			} else {
-				if _, err := claimTracker.SetOwners(cLogger, claimUIDs, types.UID(pod.Uid), container.Name); err != nil {
+				if _, err := claimTracker.SetOwner(cLogger, types.UID(pod.Uid), container.Name, claimUIDs...); err != nil {
 					return nil, err
 				}
 				if err := cpuAllocationStore.ValidateResourceClaimAllocations(validatedClaimAllocations); err != nil {
@@ -228,7 +228,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 			guaranteedCPUs = guaranteedCPUs.Union(cpus)
 			claimUIDs = append(claimUIDs, uid)
 		}
-		newOwners, err := cp.claimTracker.SetOwners(logger, claimUIDs, podUID, ctr.Name)
+		newOwners, err := cp.claimTracker.SetOwner(logger, podUID, ctr.Name, claimUIDs...)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -98,7 +98,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 				if _, err := claimTracker.SetOwners(cLogger, claimUIDs, types.UID(pod.Uid), container.Name); err != nil {
 					return nil, err
 				}
-				if err := cpuAllocationStore.EnforceResourceClaims(validatedClaimAllocations); err != nil {
+				if err := cpuAllocationStore.ValidateResourceClaimAllocations(validatedClaimAllocations); err != nil {
 					return nil, err
 				}
 				cLogger.V(2).Info("found guaranteed CPUs", "cpus", allGuaranteedCPUs.String())
@@ -232,7 +232,7 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := cp.cpuAllocationStore.EnforceResourceClaims(claimAllocations); err != nil {
+		if err := cp.cpuAllocationStore.ValidateResourceClaimAllocations(claimAllocations); err != nil {
 			cp.claimTracker.Cleanup(newOwners...)
 			return nil, nil, err
 		}
@@ -240,52 +240,36 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
 		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
 		cp.podConfigStore.SetContainerState(podUID, state)
-		// Remove the guaranteed CPUs from the containers with shared CPUs.
-		updates = cp.getSharedContainerUpdates(logger, containerId)
+		// A new owner means this is the first CreateContainer after Prepare. On restart,
+		// the owner already exists and the shared cpuset has not changed.
+		if len(newOwners) > 0 {
+			updates = cp.getSharedContainerUpdates(logger, containerId)
+		}
 	}
 
 	return adjust, updates, nil
 }
 
-// StopContainer releases a guaranteed container's CPUs back into the shared pool.
+// StopContainer removes runtime container state without changing DRA-owned allocations.
 //
 // CPU-allocation lifetime across the DRA and NRI hooks:
-//   - PrepareResourceClaims (DRA) records a pending reservation and writes the CDI spec carrying
-//     that cpuset. Pending CPUs stay available to shared containers but not to new exclusive claims.
-//   - CreateContainer (NRI) validates and enforces the prepared allocation, then shrinks the shared
-//     pool.
-//   - StopContainer (NRI, here) marks the allocation pending and immediately re-broadens surviving
-//     shared containers. The prepared allocation and owner remain available for a restart.
-//   - UnprepareResourceClaims (DRA) is the authoritative cleanup point for the allocation and owner.
+//   - PrepareResourceClaims (DRA) reserves CPUs and writes the CDI spec carrying that cpuset.
+//   - CreateContainer (NRI) validates the CDI cpuset and applies it to the container.
+//   - StopContainer (NRI, here) removes only the matching runtime container state. The prepared
+//     allocation and owner remain unchanged so a restarted container reuses the same CPUs.
+//   - UnprepareResourceClaims (DRA) is the authoritative release point for the allocation and owner.
 //   - Synchronize (NRI, on restart) rebuilds the stores from the running containers' CDI env.
-//
-// This relies on a ResourceClaim being owned by exactly one container (claim sharing is
-// unsupported), which is what makes pending shared use safe. Revisit before enabling claim sharing,
-// preemption, or mixed shared/isolated allocation.
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: StopContainer")
 	defer logger.V(2).Info("end: StopContainer")
 
 	updates := []*api.ContainerUpdate{}
-	claimUIDs, removed := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName(), types.UID(ctr.GetId()))
+	_, removed := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName(), types.UID(ctr.GetId()))
 	if !removed {
 		logger.V(2).Info("ignoring stale or unknown StopContainer event")
 		return updates, nil
 	}
-	entries := "none"
-	if len(claimUIDs) > 0 {
-		// Stop enforcing the claim while retaining its prepared allocation for a restart.
-		// TODO: assumes ResourceClaims are not shared across pods/containers; revisit if sharing lands.
-		if err := cp.cpuAllocationStore.SetResourceClaimsEnforcementState(false, claimUIDs...); err != nil {
-			return nil, err
-		}
-		cp.refreshAllocationMetrics()
-		// Remove the guaranteed CPUs from the containers with shared CPUs.
-		updates = cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))
-		entries = fmt.Sprintf("%d entries", len(updates))
-	}
-	logger.V(2).Info("StopContainer updates needed", "entries", entries)
 	return updates, nil
 }
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -60,6 +60,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 			containerUID := types.UID(container.GetId())
 			var claimUIDs []types.UID
 			allGuaranteedCPUs := cpuset.New()
+			validatedClaimAllocations := make(map[types.UID]cpuset.CPUSet)
 			for uid, cpus := range claimAllocations {
 				caLogger := cLogger.WithValues("claimUID", uid)
 				if !cdiCacheRefreshAttempted {
@@ -81,20 +82,25 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 					caLogger.Error(err, "ignoring invalid claim allocation during synchronize")
 					continue
 				}
-				err = claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
-				if err != nil {
+				if err := cpuAllocationStore.ReserveResourceClaimAllocation(caLogger, uid, cpus); err != nil {
 					return nil, err
 				}
 
 				allGuaranteedCPUs = allGuaranteedCPUs.Union(cpus)
 				claimUIDs = append(claimUIDs, uid)
-				cpuAllocationStore.AddResourceClaimAllocation(caLogger, uid, cpus)
+				validatedClaimAllocations[uid] = cpus
 			}
 
 			var state *store.ContainerState
 			if len(claimUIDs) == 0 {
 				state = store.NewContainerState(container.GetName(), containerUID)
 			} else {
+				if _, err := claimTracker.SetOwners(cLogger, claimUIDs, types.UID(pod.Uid), container.Name); err != nil {
+					return nil, err
+				}
+				if err := cpuAllocationStore.EnforceResourceClaims(validatedClaimAllocations); err != nil {
+					return nil, err
+				}
 				cLogger.V(2).Info("found guaranteed CPUs", "cpus", allGuaranteedCPUs.String())
 				state = store.NewContainerState(container.GetName(), containerUID, claimUIDs...)
 
@@ -152,17 +158,6 @@ func parseDRAEnvToClaimAllocations(logger logr.Logger, envs []string) (map[types
 	return allocations, nil
 }
 
-func (cp *CPUDriver) validatePreparedClaimAllocation(uid types.UID, cpus cpuset.CPUSet) error {
-	preparedCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(uid)
-	if !ok {
-		return fmt.Errorf("claim %q is not prepared by this driver", uid)
-	}
-	if !preparedCPUs.Equals(cpus) {
-		return fmt.Errorf("validation failed for claim %q: cpuset mismatch (expected %q, got %q)", uid, preparedCPUs.String(), cpus.String())
-	}
-	return nil
-}
-
 func validateSynchronizedClaimAllocation(logger logr.Logger, uid types.UID, cpus cpuset.CPUSet, envs []string) error {
 	allocations, err := parseDRAEnvToClaimAllocations(logger, envs)
 	if err != nil {
@@ -178,7 +173,6 @@ func validateSynchronizedClaimAllocation(logger logr.Logger, uid types.UID, cpus
 	}
 	return nil
 }
-
 func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) []*api.ContainerUpdate {
 	updates := []*api.ContainerUpdate{}
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
@@ -231,20 +225,15 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		guaranteedCPUs := cpuset.New()
 		claimUIDs := []types.UID{}
 		for uid, cpus := range claimAllocations {
-			cLogger := logger.WithValues("claimUID", uid)
-			if err := cp.validatePreparedClaimAllocation(uid, cpus); err != nil {
-				return nil, nil, err
-			}
-
-			err := cp.claimTracker.SetOwner(cLogger, uid, types.UID(pod.Uid), ctr.Name)
-			if err != nil {
-				return nil, nil, err
-			}
-
 			guaranteedCPUs = guaranteedCPUs.Union(cpus)
 			claimUIDs = append(claimUIDs, uid)
 		}
+		newOwners, err := cp.claimTracker.SetOwners(logger, claimUIDs, podUID, ctr.Name)
+		if err != nil {
+			return nil, nil, err
+		}
 		if err := cp.cpuAllocationStore.EnforceResourceClaims(claimAllocations); err != nil {
+			cp.claimTracker.Cleanup(newOwners...)
 			return nil, nil, err
 		}
 		logger.V(2).Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
@@ -279,12 +268,18 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 	defer logger.V(2).Info("end: StopContainer")
 
 	updates := []*api.ContainerUpdate{}
-	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
+	claimUIDs, removed := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName(), types.UID(ctr.GetId()))
+	if !removed {
+		logger.V(2).Info("ignoring stale or unknown StopContainer event")
+		return updates, nil
+	}
 	entries := "none"
 	if len(claimUIDs) > 0 {
 		// Stop enforcing the claim while retaining its prepared allocation for a restart.
 		// TODO: assumes ResourceClaims are not shared across pods/containers; revisit if sharing lands.
-		cp.cpuAllocationStore.MarkResourceClaimsPending(claimUIDs...)
+		if err := cp.cpuAllocationStore.SetResourceClaimsEnforcementState(false, claimUIDs...); err != nil {
+			return nil, err
+		}
 		cp.refreshAllocationMetrics()
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
 		updates = cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))
@@ -300,7 +295,11 @@ func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, c
 	logger.V(2).Info("begin: RemoveContainer")
 	defer logger.V(2).Info("end: RemoveContainer")
 
-	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
+	claimUIDs, removed := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName(), types.UID(ctr.GetId()))
+	if !removed {
+		logger.V(2).Info("ignoring stale or unknown RemoveContainer event")
+		return nil
+	}
 	if len(claimUIDs) > 0 {
 		// this serves only for debugging purposes. We should never get here
 		logger.Info("RemoveContainer spurious updates needed (unexpected, please file a bug)", "updates", cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId())))

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -244,6 +244,9 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 			guaranteedCPUs = guaranteedCPUs.Union(cpus)
 			claimUIDs = append(claimUIDs, uid)
 		}
+		if err := cp.cpuAllocationStore.EnforceResourceClaims(claimAllocations); err != nil {
+			return nil, nil, err
+		}
 		logger.V(2).Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
 		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
 		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
@@ -255,23 +258,20 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 	return adjust, updates, nil
 }
 
-// StopContainer releases a guaranteed container's CPU claim back into the shared pool.
+// StopContainer releases a guaranteed container's CPUs back into the shared pool.
 //
 // CPU-allocation lifetime across the DRA and NRI hooks:
-//   - PrepareResourceClaims (DRA) records the claim's CPUs in cpuAllocationStore and writes the CDI
-//     spec carrying that cpuset.
-//   - CreateContainer (NRI) pins the guaranteed container and shrinks the other shared containers'
-//     pool accordingly.
-//   - StopContainer (NRI, here) releases the claim's CPUs back into the shared pool and re-broadens
-//     the surviving shared containers immediately, because NRI only lets us push cpuset updates to
-//     other containers during a container lifecycle event and UnprepareResourceClaims runs too late.
-//   - UnprepareResourceClaims (DRA) does the authoritative cleanup (remove the CDI device, then
-//     release the allocation); releasing an already-released claim is a no-op, so the early release
-//     here stays consistent with it.
+//   - PrepareResourceClaims (DRA) records a pending reservation and writes the CDI spec carrying
+//     that cpuset. Pending CPUs stay available to shared containers but not to new exclusive claims.
+//   - CreateContainer (NRI) validates and enforces the prepared allocation, then shrinks the shared
+//     pool.
+//   - StopContainer (NRI, here) marks the allocation pending and immediately re-broadens surviving
+//     shared containers. The prepared allocation and owner remain available for a restart.
+//   - UnprepareResourceClaims (DRA) is the authoritative cleanup point for the allocation and owner.
 //   - Synchronize (NRI, on restart) rebuilds the stores from the running containers' CDI env.
 //
 // This relies on a ResourceClaim being owned by exactly one container (claim sharing is
-// unsupported), which is what makes the early release safe. Revisit before enabling claim sharing,
+// unsupported), which is what makes pending shared use safe. Revisit before enabling claim sharing,
 // preemption, or mixed shared/isolated allocation.
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
@@ -282,16 +282,12 @@ func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr
 	claimUIDs := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName())
 	entries := "none"
 	if len(claimUIDs) > 0 {
-		// Early release of the claim's CPUs; see the lifetime model in StopContainer's doc comment.
+		// Stop enforcing the claim while retaining its prepared allocation for a restart.
 		// TODO: assumes ResourceClaims are not shared across pods/containers; revisit if sharing lands.
-		for _, claimUID := range claimUIDs {
-			cLogger := logger.WithValues("claimUID", claimUID)
-			cp.cpuAllocationStore.RemoveResourceClaimAllocation(cLogger, claimUID)
-		}
+		cp.cpuAllocationStore.MarkResourceClaimsPending(claimUIDs...)
 		cp.refreshAllocationMetrics()
 		// Remove the guaranteed CPUs from the containers with shared CPUs.
 		updates = cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))
-		cp.claimTracker.Cleanup(claimUIDs...)
 		entries = fmt.Sprintf("%d entries", len(updates))
 	}
 	logger.V(2).Info("StopContainer updates needed", "entries", entries)

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -378,7 +378,6 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, preparedCPUs.Equals(claimCPUs))
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
-	require.True(t, cpuStore.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 	require.Equal(t, 1, driver.claimTracker.Len())
 
 	restarted := container("container-2")
@@ -727,8 +726,6 @@ func TestStopContainerKeepsClaimOutOfSharedPoolUntilUnprepare(t *testing.T) {
 	preparedCPUs, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
 	require.True(t, ok, "StopContainer must retain the prepared claim")
 	require.True(t, preparedCPUs.Equals(claimedCPUs))
-	require.True(t, driver.cpuAllocationStore.GetAllocatableCPUs().Equals(allCPUs.Difference(claimedCPUs)),
-		"prepared CPUs must remain unavailable to new exclusive claims")
 	require.Empty(t, updates)
 
 	// UnprepareResourceClaims is the authoritative release point.

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -707,7 +707,8 @@ func TestStopContainerKeepsClaimOutOfSharedPoolUntilUnprepare(t *testing.T) {
 		topology:           deviceTopology{cpuTopology: topo},
 	}
 	driver.cdiMgr.(*mockCdiMgr).devices[getCDIDeviceName(claimUID)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, claimedCPUs.String())
-	require.NoError(t, driver.claimTracker.SetOwner(logger, claimUID, types.UID(guaranteedPod.Uid), guaranteedCtr.Name))
+	_, err := driver.claimTracker.SetOwner(logger, types.UID(guaranteedPod.Uid), guaranteedCtr.Name, claimUID)
+	require.NoError(t, err)
 	driver.podConfigStore.SetContainerState(types.UID(guaranteedPod.Uid),
 		store.NewContainerState(guaranteedCtr.Name, types.UID(guaranteedCtr.Id), claimUID))
 	driver.podConfigStore.SetContainerState(types.UID(sharedPod.Uid),

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -333,6 +333,60 @@ func TestStopContainer(t *testing.T) {
 	}
 }
 
+func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
+	logger := testr.New(t)
+	allCPUs := cpuset.New(0, 1, 2, 3)
+	var infos []cpuinfo.CPUInfo
+	for _, cpuID := range allCPUs.UnsortedList() {
+		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NUMANodeID: 0})
+	}
+	topo, err := (&cpuinfo.MockCPUInfoProvider{CPUInfos: infos}).GetCPUTopology(logger)
+	require.NoError(t, err)
+
+	claimUID := types.UID("claim-restart")
+	claimCPUs := cpuset.New(0, 1)
+	cpuStore := store.NewCPUAllocation(topo, cpuset.New())
+	require.NoError(t, cpuStore.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs))
+	driver := &CPUDriver{
+		podConfigStore:     store.NewPodConfig(),
+		cpuAllocationStore: cpuStore,
+		claimTracker:       store.NewClaimTracker(),
+		cpuTopology:        topo,
+	}
+
+	pod := &api.PodSandbox{Id: "sandbox", Uid: "pod", Name: "pod", Namespace: "ns"}
+	container := func(id string) *api.Container {
+		return &api.Container{
+			Id:           id,
+			PodSandboxId: pod.Id,
+			Name:         "app",
+			Env:          []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, claimCPUs.String())},
+		}
+	}
+
+	first := container("container-1")
+	adjustment, _, err := driver.CreateContainer(context.Background(), pod, first)
+	require.NoError(t, err)
+	require.Equal(t, claimCPUs.String(), adjustment.Linux.Resources.Cpu.Cpus)
+	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
+
+	_, err = driver.StopContainer(context.Background(), pod, first)
+	require.NoError(t, err)
+	preparedCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
+	require.True(t, ok)
+	require.True(t, preparedCPUs.Equals(claimCPUs))
+	require.True(t, cpuStore.GetSharedCPUs().Equals(allCPUs))
+	require.True(t, cpuStore.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
+	require.Equal(t, 1, driver.claimTracker.Len())
+
+	restarted := container("container-2")
+	adjustment, _, err = driver.CreateContainer(context.Background(), pod, restarted)
+	require.NoError(t, err)
+	require.Equal(t, claimCPUs.String(), adjustment.Linux.Resources.Cpu.Cpus)
+	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
+	require.Equal(t, 1, driver.claimTracker.Len())
+}
+
 func TestNRISynchronize(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
@@ -615,9 +669,9 @@ func containerIDsFromUpdates(updates []*api.ContainerUpdate) []string {
 }
 
 // TestStopContainerReleasesClaimToSharedPool asserts the DRA/NRI lifetime invariant tracked by #188:
-// stopping a guaranteed container releases its claim's CPUs back into the shared pool *during*
-// StopContainer (the documented early-release workaround), and immediately re-broadens the other
-// shared containers to the freed pool, rather than deferring the release to UnprepareResourceClaims.
+// stopping a guaranteed container releases its CPUs back into the shared pool *during*
+// StopContainer and immediately re-broadens the other shared containers, while retaining the
+// prepared claim reservation until UnprepareResourceClaims.
 // The existing TestStopContainer only asserts which containers are updated; this asserts the actual
 // release (the shared-pool contents) and the re-broadened cpuset values.
 func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
@@ -662,6 +716,11 @@ func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
 	// not deferred to UnprepareResourceClaims.
 	require.True(t, driver.cpuAllocationStore.GetSharedCPUs().Equals(allCPUs),
 		"StopContainer should release the claim's CPUs back into the shared pool")
+	preparedCPUs, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+	require.True(t, ok, "StopContainer must retain the prepared claim")
+	require.True(t, preparedCPUs.Equals(claimedCPUs))
+	require.True(t, driver.cpuAllocationStore.GetAllocatableCPUs().Equals(allCPUs.Difference(claimedCPUs)),
+		"pending CPUs must remain unavailable to new exclusive claims")
 
 	// Invariant 2: the surviving shared container is immediately re-broadened to the full pool.
 	require.Equal(t, []*api.ContainerUpdate{

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -19,7 +19,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/containerd/nri/pkg/api"
@@ -28,6 +27,7 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/utils/cpuset"
 )
 
@@ -140,7 +140,7 @@ func TestCreateContainer(t *testing.T) {
 			podConfigStore: store.NewPodConfig(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
+				requirePreparedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -166,7 +166,7 @@ func TestCreateContainer(t *testing.T) {
 			podConfigStore: store.NewPodConfig(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
+				requirePreparedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -186,7 +186,7 @@ func TestCreateContainer(t *testing.T) {
 			}(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(2, 3))
+				requirePreparedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -234,7 +234,7 @@ func TestCreateContainer(t *testing.T) {
 			podConfigStore: store.NewPodConfig(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1))
+				requirePreparedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -288,12 +288,11 @@ func TestStopContainer(t *testing.T) {
 	topo, _ := mockProvider.GetCPUTopology(logger)
 
 	testCases := []struct {
-		name               string
-		driver             *CPUDriver
-		expectedUpdatesFor []string
+		name   string
+		driver *CPUDriver
 	}{
 		{
-			name: "Stop guaranteed container sets update required for shared containers",
+			name: "Stop guaranteed container does not update shared containers",
 			driver: func() *CPUDriver {
 				driver := &CPUDriver{
 					podConfigStore:     store.NewPodConfig(),
@@ -302,12 +301,11 @@ func TestStopContainer(t *testing.T) {
 					topology:           deviceTopology{cpuTopology: topo},
 				}
 				claimUID := types.UID("claim-uid-1")
-				requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpuset.New(0, 1))
+				requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpuset.New(0, 1))
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), claimUID))
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
 				return driver
 			}(),
-			expectedUpdatesFor: []string{ctr2.Id},
 		},
 		{
 			name: "Stop non-guaranteed container does not set update required",
@@ -322,16 +320,14 @@ func TestStopContainer(t *testing.T) {
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
 				return driver
 			}(),
-			expectedUpdatesFor: []string{},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sort.Strings(tc.expectedUpdatesFor)
 			upd, err := tc.driver.StopContainer(context.Background(), pod1, ctr1)
 			require.NoError(t, err)
-			require.Equal(t, containerIDsFromUpdates(upd), tc.expectedUpdatesFor)
+			require.Empty(t, upd)
 		})
 	}
 }
@@ -356,6 +352,7 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 		claimTracker:       store.NewClaimTracker(),
 		cpuTopology:        topo,
 	}
+	driver.podConfigStore.SetContainerState("shared-pod", store.NewContainerState("shared", "shared-container"))
 
 	pod := &api.PodSandbox{Id: "sandbox", Uid: "pod", Name: "pod", Namespace: "ns"}
 	container := func(id string) *api.Container {
@@ -368,24 +365,27 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 	}
 
 	first := container("container-1")
-	adjustment, _, err := driver.CreateContainer(context.Background(), pod, first)
+	adjustment, updates, err := driver.CreateContainer(context.Background(), pod, first)
 	require.NoError(t, err)
 	require.Equal(t, claimCPUs.String(), adjustment.Linux.Resources.Cpu.Cpus)
+	require.Len(t, updates, 1)
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 
-	_, err = driver.StopContainer(context.Background(), pod, first)
+	updates, err = driver.StopContainer(context.Background(), pod, first)
 	require.NoError(t, err)
+	require.Empty(t, updates)
 	preparedCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
 	require.True(t, ok)
 	require.True(t, preparedCPUs.Equals(claimCPUs))
-	require.True(t, cpuStore.GetSharedCPUs().Equals(allCPUs))
+	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 	require.True(t, cpuStore.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 	require.Equal(t, 1, driver.claimTracker.Len())
 
 	restarted := container("container-2")
-	adjustment, _, err = driver.CreateContainer(context.Background(), pod, restarted)
+	adjustment, updates, err = driver.CreateContainer(context.Background(), pod, restarted)
 	require.NoError(t, err)
 	require.Equal(t, claimCPUs.String(), adjustment.Linux.Resources.Cpu.Cpus)
+	require.Empty(t, updates)
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 	require.Equal(t, 1, driver.claimTracker.Len())
 
@@ -394,15 +394,17 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 	require.NotNil(t, driver.podConfigStore.GetContainerState(types.UID(pod.Uid), restarted.Name))
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 
-	_, err = driver.StopContainer(context.Background(), pod, first)
+	updates, err = driver.StopContainer(context.Background(), pod, first)
 	require.NoError(t, err)
+	require.Empty(t, updates)
 	require.NotNil(t, driver.podConfigStore.GetContainerState(types.UID(pod.Uid), restarted.Name))
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 
-	_, err = driver.StopContainer(context.Background(), pod, restarted)
+	updates, err = driver.StopContainer(context.Background(), pod, restarted)
 	require.NoError(t, err)
+	require.Empty(t, updates)
 	require.Nil(t, driver.podConfigStore.GetContainerState(types.UID(pod.Uid), restarted.Name))
-	require.True(t, cpuStore.GetSharedCPUs().Equals(allCPUs))
+	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 }
 
 func TestNRISynchronize(t *testing.T) {
@@ -677,22 +679,7 @@ func TestNRISynchronize(t *testing.T) {
 	}
 }
 
-func containerIDsFromUpdates(updates []*api.ContainerUpdate) []string {
-	ids := make([]string, 0, len(updates))
-	for _, upd := range updates {
-		ids = append(ids, upd.ContainerId)
-	}
-	sort.Strings(ids)
-	return ids
-}
-
-// TestStopContainerReleasesClaimToSharedPool asserts the DRA/NRI lifetime invariant tracked by #188:
-// stopping a guaranteed container releases its CPUs back into the shared pool *during*
-// StopContainer and immediately re-broadens the other shared containers, while retaining the
-// prepared claim reservation until UnprepareResourceClaims.
-// The existing TestStopContainer only asserts which containers are updated; this asserts the actual
-// release (the shared-pool contents) and the re-broadened cpuset values.
-func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
+func TestStopContainerKeepsClaimOutOfSharedPoolUntilUnprepare(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	var infos []cpuinfo.CPUInfo
@@ -710,14 +697,17 @@ func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
 	claimedCPUs := cpuset.New(0, 1)
 
 	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
-	requireEnforcedResourceClaim(t, logger, cpuAllocationStore, claimUID, claimedCPUs)
+	requirePreparedResourceClaim(t, logger, cpuAllocationStore, claimUID, claimedCPUs)
 
 	driver := &CPUDriver{
+		cdiMgr:             newMockCdiMgr(),
 		podConfigStore:     store.NewPodConfig(),
 		cpuAllocationStore: cpuAllocationStore,
 		claimTracker:       store.NewClaimTracker(),
 		topology:           deviceTopology{cpuTopology: topo},
 	}
+	driver.cdiMgr.(*mockCdiMgr).devices[getCDIDeviceName(claimUID)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, claimedCPUs.String())
+	require.NoError(t, driver.claimTracker.SetOwner(logger, claimUID, types.UID(guaranteedPod.Uid), guaranteedCtr.Name))
 	driver.podConfigStore.SetContainerState(types.UID(guaranteedPod.Uid),
 		store.NewContainerState(guaranteedCtr.Name, types.UID(guaranteedCtr.Id), claimUID))
 	driver.podConfigStore.SetContainerState(types.UID(sharedPod.Uid),
@@ -730,21 +720,19 @@ func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
 	updates, err := driver.StopContainer(context.Background(), guaranteedPod, guaranteedCtr)
 	require.NoError(t, err)
 
-	// Invariant 1: the claim's CPUs are released back into the shared pool during StopContainer,
-	// not deferred to UnprepareResourceClaims.
-	require.True(t, driver.cpuAllocationStore.GetSharedCPUs().Equals(allCPUs),
-		"StopContainer should release the claim's CPUs back into the shared pool")
+	// StopContainer does not change DRA-owned allocation state or shared container cpusets.
+	require.True(t, driver.cpuAllocationStore.GetSharedCPUs().Equals(allCPUs.Difference(claimedCPUs)),
+		"StopContainer must keep the claim's CPUs out of the shared pool")
 	preparedCPUs, ok := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
 	require.True(t, ok, "StopContainer must retain the prepared claim")
 	require.True(t, preparedCPUs.Equals(claimedCPUs))
 	require.True(t, driver.cpuAllocationStore.GetAllocatableCPUs().Equals(allCPUs.Difference(claimedCPUs)),
-		"pending CPUs must remain unavailable to new exclusive claims")
+		"prepared CPUs must remain unavailable to new exclusive claims")
+	require.Empty(t, updates)
 
-	// Invariant 2: the surviving shared container is immediately re-broadened to the full pool.
-	require.Equal(t, []*api.ContainerUpdate{
-		{
-			ContainerId: sharedCtr.Id,
-			Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: allCPUs.String()}}},
-		},
-	}, updates)
+	// UnprepareResourceClaims is the authoritative release point.
+	unprepared, err := driver.UnprepareResourceClaims(context.Background(), []kubeletplugin.NamespacedObject{{UID: claimUID}})
+	require.NoError(t, err)
+	require.NoError(t, unprepared[claimUID])
+	require.True(t, driver.cpuAllocationStore.GetSharedCPUs().Equals(allCPUs))
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -350,7 +350,7 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 		podConfigStore:     store.NewPodConfig(),
 		cpuAllocationStore: cpuStore,
 		claimTracker:       store.NewClaimTracker(),
-		cpuTopology:        topo,
+		topology:           deviceTopology{cpuTopology: topo},
 	}
 	driver.podConfigStore.SetContainerState("shared-pod", store.NewContainerState("shared", "shared-container"))
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -140,7 +140,7 @@ func TestCreateContainer(t *testing.T) {
 			podConfigStore: store.NewPodConfig(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
+				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -166,7 +166,7 @@ func TestCreateContainer(t *testing.T) {
 			podConfigStore: store.NewPodConfig(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
+				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1, 2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -186,7 +186,7 @@ func TestCreateContainer(t *testing.T) {
 			}(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(2, 3))
+				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(2, 3))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -234,7 +234,7 @@ func TestCreateContainer(t *testing.T) {
 			podConfigStore: store.NewPodConfig(),
 			cpuAllocationStore: func() *store.CPUAllocation {
 				store := store.NewCPUAllocation(topo, cpuset.New())
-				store.AddResourceClaimAllocation(logger, types.UID(claimUID), cpuset.New(0, 1))
+				requireEnforcedResourceClaim(t, logger, store, types.UID(claimUID), cpuset.New(0, 1))
 				return store
 			}(),
 			claimTracker: store.NewClaimTracker(),
@@ -261,6 +261,7 @@ func TestCreateContainer(t *testing.T) {
 				require.Contains(t, err.Error(), tc.expectedErrorContains)
 				require.Nil(t, adjust)
 				require.Nil(t, updates)
+				require.Zero(t, tc.claimTracker.Len(), "failed CreateContainer must not retain claim owners")
 				return
 			}
 
@@ -300,7 +301,9 @@ func TestStopContainer(t *testing.T) {
 					claimTracker:       store.NewClaimTracker(),
 					topology:           deviceTopology{cpuTopology: topo},
 				}
-				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), types.UID("claim-uid-1")))
+				claimUID := types.UID("claim-uid-1")
+				requireEnforcedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpuset.New(0, 1))
+				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), claimUID))
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
 				return driver
 			}(),
@@ -385,6 +388,21 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 	require.Equal(t, claimCPUs.String(), adjustment.Linux.Resources.Cpu.Cpus)
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 	require.Equal(t, 1, driver.claimTracker.Len())
+
+	// Delayed events for the old runtime ID must not remove or release the replacement.
+	require.NoError(t, driver.RemoveContainer(context.Background(), pod, first))
+	require.NotNil(t, driver.podConfigStore.GetContainerState(types.UID(pod.Uid), restarted.Name))
+	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
+
+	_, err = driver.StopContainer(context.Background(), pod, first)
+	require.NoError(t, err)
+	require.NotNil(t, driver.podConfigStore.GetContainerState(types.UID(pod.Uid), restarted.Name))
+	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
+
+	_, err = driver.StopContainer(context.Background(), pod, restarted)
+	require.NoError(t, err)
+	require.Nil(t, driver.podConfigStore.GetContainerState(types.UID(pod.Uid), restarted.Name))
+	require.True(t, cpuStore.GetSharedCPUs().Equals(allCPUs))
 }
 
 func TestNRISynchronize(t *testing.T) {
@@ -692,7 +710,7 @@ func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
 	claimedCPUs := cpuset.New(0, 1)
 
 	cpuAllocationStore := store.NewCPUAllocation(topo, cpuset.New())
-	cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, claimedCPUs)
+	requireEnforcedResourceClaim(t, logger, cpuAllocationStore, claimUID, claimedCPUs)
 
 	driver := &CPUDriver{
 		podConfigStore:     store.NewPodConfig(),

--- a/pkg/store/claim_tracker.go
+++ b/pkg/store/claim_tracker.go
@@ -57,26 +57,42 @@ func NewClaimTracker() *ClaimTracker {
 }
 
 func (ctk *ClaimTracker) SetOwner(logger logr.Logger, claimUID, podUID k8stypes.UID, containerName string) error {
+	_, err := ctk.SetOwners(logger, []k8stypes.UID{claimUID}, podUID, containerName)
+	return err
+}
+
+// SetOwners atomically binds claims to a single container. It returns the claims
+// which were newly bound so callers can roll them back if a later operation fails.
+func (ctk *ClaimTracker) SetOwners(logger logr.Logger, claimUIDs []k8stypes.UID, podUID k8stypes.UID, containerName string) ([]k8stypes.UID, error) {
 	curIdent := OwnerIdent{
 		PodUID:        podUID,
 		ContainerName: containerName,
 	}
 	ctk.mu.Lock()
 	defer ctk.mu.Unlock()
-	owner, ok := ctk.ownerByClaimUID[claimUID]
-	if ok {
-		if owner.Equal(curIdent) {
-			logger.V(2).Info("claim bound again to the same owner")
-			return nil // not wrong, not suspicious enough to bail out
+
+	for _, claimUID := range claimUIDs {
+		owner, ok := ctk.ownerByClaimUID[claimUID]
+		if !ok || owner.Equal(curIdent) {
+			continue
 		}
-		return AlreadyOwned{
+		return nil, AlreadyOwned{
 			ClaimUID: claimUID,
 			Owner:    owner,
 		}
 	}
-	ctk.ownerByClaimUID[claimUID] = curIdent
-	logger.V(4).Info("claim bound")
-	return nil
+
+	newlyBound := make([]k8stypes.UID, 0, len(claimUIDs))
+	for _, claimUID := range claimUIDs {
+		if _, ok := ctk.ownerByClaimUID[claimUID]; ok {
+			logger.V(2).Info("claim bound again to the same owner", "claimUID", claimUID)
+			continue
+		}
+		ctk.ownerByClaimUID[claimUID] = curIdent
+		newlyBound = append(newlyBound, claimUID)
+		logger.V(4).Info("claim bound", "claimUID", claimUID)
+	}
+	return newlyBound, nil
 }
 
 func (ctk *ClaimTracker) Cleanup(claimUIDs ...k8stypes.UID) {

--- a/pkg/store/claim_tracker.go
+++ b/pkg/store/claim_tracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -56,14 +57,12 @@ func NewClaimTracker() *ClaimTracker {
 	}
 }
 
-func (ctk *ClaimTracker) SetOwner(logger logr.Logger, claimUID, podUID k8stypes.UID, containerName string) error {
-	_, err := ctk.SetOwners(logger, []k8stypes.UID{claimUID}, podUID, containerName)
-	return err
-}
-
-// SetOwners atomically binds claims to a single container. It returns the claims
+// SetOwner atomically binds claims to a single container. It returns the claims
 // which were newly bound so callers can roll them back if a later operation fails.
-func (ctk *ClaimTracker) SetOwners(logger logr.Logger, claimUIDs []k8stypes.UID, podUID k8stypes.UID, containerName string) ([]k8stypes.UID, error) {
+func (ctk *ClaimTracker) SetOwner(logger logr.Logger, podUID k8stypes.UID, containerName string, claimUIDs ...k8stypes.UID) ([]k8stypes.UID, error) {
+	if len(claimUIDs) == 0 {
+		return nil, errors.New("no claims to bind")
+	}
 	curIdent := OwnerIdent{
 		PodUID:        podUID,
 		ContainerName: containerName,

--- a/pkg/store/claim_tracker_test.go
+++ b/pkg/store/claim_tracker_test.go
@@ -149,6 +149,39 @@ func TestSetOwner(t *testing.T) {
 	}
 }
 
+func TestSetOwners(t *testing.T) {
+	logger := testr.New(t)
+	owner := OwnerIdent{PodUID: "pod-AAA", ContainerName: "cnt-1"}
+
+	t.Run("binds all claims atomically", func(t *testing.T) {
+		tracker := NewClaimTracker()
+		newlyBound, err := tracker.SetOwners(logger, []k8stypes.UID{"claim-1", "claim-2"}, owner.PodUID, owner.ContainerName)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []k8stypes.UID{"claim-1", "claim-2"}, newlyBound)
+		require.Equal(t, 2, tracker.Len())
+	})
+
+	t.Run("conflict leaves new claims unbound", func(t *testing.T) {
+		tracker := NewClaimTracker()
+		require.NoError(t, tracker.SetOwner(logger, "claim-2", "pod-BBB", "cnt-2"))
+
+		newlyBound, err := tracker.SetOwners(logger, []k8stypes.UID{"claim-1", "claim-2"}, owner.PodUID, owner.ContainerName)
+		require.Error(t, err)
+		require.Empty(t, newlyBound)
+		require.Equal(t, 1, tracker.Len())
+	})
+
+	t.Run("returns only newly bound claims", func(t *testing.T) {
+		tracker := NewClaimTracker()
+		require.NoError(t, tracker.SetOwner(logger, "claim-1", owner.PodUID, owner.ContainerName))
+
+		newlyBound, err := tracker.SetOwners(logger, []k8stypes.UID{"claim-1", "claim-2"}, owner.PodUID, owner.ContainerName)
+		require.NoError(t, err)
+		require.Equal(t, []k8stypes.UID{"claim-2"}, newlyBound)
+		require.Equal(t, 2, tracker.Len())
+	})
+}
+
 func TestLen(t *testing.T) {
 	logger := testr.New(t)
 	bindings := []binding{

--- a/pkg/store/claim_tracker_test.go
+++ b/pkg/store/claim_tracker_test.go
@@ -30,7 +30,7 @@ type binding struct {
 	expectOK bool
 }
 
-func TestSetOwner(t *testing.T) {
+func TestSetOwnerSequential(t *testing.T) {
 	type testCase struct {
 		name     string
 		bindings []binding
@@ -141,45 +141,76 @@ func TestSetOwner(t *testing.T) {
 			logger := testr.New(t)
 			bnd := NewClaimTracker()
 			for _, binding := range tcase.bindings {
-				err := bnd.SetOwner(logger, binding.claim, binding.owner.PodUID, binding.owner.ContainerName)
+				_, err := bnd.SetOwner(logger, binding.owner.PodUID, binding.owner.ContainerName, binding.claim)
 				ok := (err == nil)
-				require.Equal(t, ok, binding.expectOK, "setOwner failed for %v", binding)
+				require.Equal(t, binding.expectOK, ok, "setOwner failed for %v", binding)
 			}
 		})
 	}
 }
 
-func TestSetOwners(t *testing.T) {
+func TestSetOwnerAtomic(t *testing.T) {
 	logger := testr.New(t)
 	owner := OwnerIdent{PodUID: "pod-AAA", ContainerName: "cnt-1"}
+	testCases := []struct {
+		name            string
+		initialBindings []binding
+		claimUIDs       []k8stypes.UID
+		expectedNew     []k8stypes.UID
+		expectedLen     int
+		expectError     bool
+	}{
+		{
+			name:        "binds all claims atomically",
+			claimUIDs:   []k8stypes.UID{"claim-1", "claim-2"},
+			expectedNew: []k8stypes.UID{"claim-1", "claim-2"},
+			expectedLen: 2,
+		},
+		{
+			name: "conflict leaves new claims unbound",
+			initialBindings: []binding{{
+				claim: "claim-2",
+				owner: OwnerIdent{PodUID: "pod-BBB", ContainerName: "cnt-2"},
+			}},
+			claimUIDs:   []k8stypes.UID{"claim-1", "claim-2"},
+			expectedLen: 1,
+			expectError: true,
+		},
+		{
+			name: "returns only newly bound claims",
+			initialBindings: []binding{{
+				claim: "claim-1",
+				owner: owner,
+			}},
+			claimUIDs:   []k8stypes.UID{"claim-1", "claim-2"},
+			expectedNew: []k8stypes.UID{"claim-2"},
+			expectedLen: 2,
+		},
+		{
+			name:        "rejects empty claim list",
+			expectedLen: 0,
+			expectError: true,
+		},
+	}
 
-	t.Run("binds all claims atomically", func(t *testing.T) {
-		tracker := NewClaimTracker()
-		newlyBound, err := tracker.SetOwners(logger, []k8stypes.UID{"claim-1", "claim-2"}, owner.PodUID, owner.ContainerName)
-		require.NoError(t, err)
-		require.ElementsMatch(t, []k8stypes.UID{"claim-1", "claim-2"}, newlyBound)
-		require.Equal(t, 2, tracker.Len())
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := NewClaimTracker()
+			for _, initial := range tc.initialBindings {
+				_, err := tracker.SetOwner(logger, initial.owner.PodUID, initial.owner.ContainerName, initial.claim)
+				require.NoError(t, err)
+			}
 
-	t.Run("conflict leaves new claims unbound", func(t *testing.T) {
-		tracker := NewClaimTracker()
-		require.NoError(t, tracker.SetOwner(logger, "claim-2", "pod-BBB", "cnt-2"))
-
-		newlyBound, err := tracker.SetOwners(logger, []k8stypes.UID{"claim-1", "claim-2"}, owner.PodUID, owner.ContainerName)
-		require.Error(t, err)
-		require.Empty(t, newlyBound)
-		require.Equal(t, 1, tracker.Len())
-	})
-
-	t.Run("returns only newly bound claims", func(t *testing.T) {
-		tracker := NewClaimTracker()
-		require.NoError(t, tracker.SetOwner(logger, "claim-1", owner.PodUID, owner.ContainerName))
-
-		newlyBound, err := tracker.SetOwners(logger, []k8stypes.UID{"claim-1", "claim-2"}, owner.PodUID, owner.ContainerName)
-		require.NoError(t, err)
-		require.Equal(t, []k8stypes.UID{"claim-2"}, newlyBound)
-		require.Equal(t, 2, tracker.Len())
-	})
+			newlyBound, err := tracker.SetOwner(logger, owner.PodUID, owner.ContainerName, tc.claimUIDs...)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.ElementsMatch(t, tc.expectedNew, newlyBound)
+			require.Equal(t, tc.expectedLen, tracker.Len())
+		})
+	}
 }
 
 func TestLen(t *testing.T) {
@@ -213,7 +244,7 @@ func TestLen(t *testing.T) {
 
 	bnd := NewClaimTracker()
 	for _, binding := range bindings {
-		err := bnd.SetOwner(logger, binding.claim, binding.owner.PodUID, binding.owner.ContainerName)
+		_, err := bnd.SetOwner(logger, binding.owner.PodUID, binding.owner.ContainerName, binding.claim)
 		require.NoError(t, err)
 	}
 	require.Equal(t, bnd.Len(), len(bindings))

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -123,13 +123,6 @@ func (s *CPUAllocation) GetSharedCPUs() cpuset.CPUSet {
 	return s.availableCPUs.Difference(s.preparedCPUs)
 }
 
-// GetAllocatableCPUs returns CPUs available for a new exclusive claim.
-func (s *CPUAllocation) GetAllocatableCPUs() cpuset.CPUSet {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.availableCPUs.Difference(s.preparedCPUs)
-}
-
 // GetResourceClaimAllocation returns the cpuset for a given resource claim.
 func (s *CPUAllocation) GetResourceClaimAllocation(claimUID types.UID) (cpuset.CPUSet, bool) {
 	s.mu.RLock()

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -67,18 +67,6 @@ func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUS
 	}
 }
 
-// AddResourceClaimAllocation adds an allocation already enforced by a running container.
-// It is used while reconstructing state from the NRI runtime.
-func (s *CPUAllocation) AddResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.removeLocked(claimUID)
-	s.resourceClaimAllocations[claimUID] = claimAllocation{cpus: cpus, enforced: true}
-	s.preparedCPUs = s.preparedCPUs.Union(cpus)
-	s.enforcedCPUs = s.enforcedCPUs.Union(cpus)
-	logger.Info("added enforced allocation for resource claim", "cpus", cpus.String())
-}
-
 // ReserveResourceClaimAllocation records a prepared claim without removing its CPUs from
 // shared containers. The CPUs remain unavailable to other exclusive claims until Unprepare.
 func (s *CPUAllocation) ReserveResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) error {
@@ -104,6 +92,7 @@ func (s *CPUAllocation) EnforceResourceClaims(expected map[types.UID]cpuset.CPUS
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	claimUIDs := make([]types.UID, 0, len(expected))
 	for claimUID, cpus := range expected {
 		allocation, ok := s.resourceClaimAllocations[claimUID]
 		if !ok {
@@ -115,29 +104,38 @@ func (s *CPUAllocation) EnforceResourceClaims(expected map[types.UID]cpuset.CPUS
 	}
 
 	for claimUID := range expected {
-		allocation := s.resourceClaimAllocations[claimUID]
-		if allocation.enforced {
-			continue
-		}
-		allocation.enforced = true
-		s.resourceClaimAllocations[claimUID] = allocation
-		s.enforcedCPUs = s.enforcedCPUs.Union(allocation.cpus)
+		claimUIDs = append(claimUIDs, claimUID)
 	}
+	s.setResourceClaimsEnforcementStateLocked(true, claimUIDs...)
 	return nil
 }
 
-// MarkResourceClaimsPending stops enforcing claims while retaining their prepared reservations.
-func (s *CPUAllocation) MarkResourceClaimsPending(claimUIDs ...types.UID) {
+// SetResourceClaimsEnforcementState updates whether prepared claims are enforced by a running container.
+func (s *CPUAllocation) SetResourceClaimsEnforcementState(enforced bool, claimUIDs ...types.UID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, claimUID := range claimUIDs {
-		allocation, ok := s.resourceClaimAllocations[claimUID]
-		if !ok || !allocation.enforced {
+		if _, ok := s.resourceClaimAllocations[claimUID]; !ok {
+			return fmt.Errorf("claim %q is not prepared by this driver", claimUID)
+		}
+	}
+	s.setResourceClaimsEnforcementStateLocked(enforced, claimUIDs...)
+	return nil
+}
+
+func (s *CPUAllocation) setResourceClaimsEnforcementStateLocked(enforced bool, claimUIDs ...types.UID) {
+	for _, claimUID := range claimUIDs {
+		allocation := s.resourceClaimAllocations[claimUID]
+		if allocation.enforced == enforced {
 			continue
 		}
-		allocation.enforced = false
+		allocation.enforced = enforced
 		s.resourceClaimAllocations[claimUID] = allocation
-		s.enforcedCPUs = s.enforcedCPUs.Difference(allocation.cpus)
+		if enforced {
+			s.enforcedCPUs = s.enforcedCPUs.Union(allocation.cpus)
+		} else {
+			s.enforcedCPUs = s.enforcedCPUs.Difference(allocation.cpus)
+		}
 	}
 }
 
@@ -193,8 +191,8 @@ func (s *CPUAllocation) GetReservedCPUs() cpuset.CPUSet {
 	return s.reservedCPUs
 }
 
-// GetAllocatedCPUs returns the set of allocated CPUs.
-func (s *CPUAllocation) GetAllocatedCPUs() cpuset.CPUSet {
+// GetPreparedCPUs returns the CPUs reserved for prepared claims.
+func (s *CPUAllocation) GetPreparedCPUs() cpuset.CPUSet {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.preparedCPUs

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -25,13 +26,19 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
+type claimAllocation struct {
+	cpus     cpuset.CPUSet
+	enforced bool
+}
+
 // CPUAllocation is the single source of truth for CPU allocations.
 type CPUAllocation struct {
 	mu                       sync.RWMutex
 	availableCPUs            cpuset.CPUSet
 	reservedCPUs             cpuset.CPUSet
-	resourceClaimAllocations map[types.UID]cpuset.CPUSet
-	allocatedCPUs            cpuset.CPUSet
+	resourceClaimAllocations map[types.UID]claimAllocation
+	preparedCPUs             cpuset.CPUSet
+	enforcedCPUs             cpuset.CPUSet
 }
 
 // AllocationSnapshot is a point-in-time summary of CPU allocation state.
@@ -54,47 +61,129 @@ func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUS
 	return &CPUAllocation{
 		availableCPUs:            availableCPUs,
 		reservedCPUs:             reservedCPUs,
-		resourceClaimAllocations: make(map[types.UID]cpuset.CPUSet),
-		allocatedCPUs:            cpuset.New(),
+		resourceClaimAllocations: make(map[types.UID]claimAllocation),
+		preparedCPUs:             cpuset.New(),
+		enforcedCPUs:             cpuset.New(),
 	}
 }
 
-// AddResourceClaimAllocation adds a new resource claim allocation to the store.
+// AddResourceClaimAllocation adds an allocation already enforced by a running container.
+// It is used while reconstructing state from the NRI runtime.
 func (s *CPUAllocation) AddResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if old, ok := s.resourceClaimAllocations[claimUID]; ok {
-		s.allocatedCPUs = s.allocatedCPUs.Difference(old)
+	s.removeLocked(claimUID)
+	s.resourceClaimAllocations[claimUID] = claimAllocation{cpus: cpus, enforced: true}
+	s.preparedCPUs = s.preparedCPUs.Union(cpus)
+	s.enforcedCPUs = s.enforcedCPUs.Union(cpus)
+	logger.Info("added enforced allocation for resource claim", "cpus", cpus.String())
+}
+
+// ReserveResourceClaimAllocation records a prepared claim without removing its CPUs from
+// shared containers. The CPUs remain unavailable to other exclusive claims until Unprepare.
+func (s *CPUAllocation) ReserveResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if allocation, ok := s.resourceClaimAllocations[claimUID]; ok {
+		if allocation.cpus.Equals(cpus) {
+			return nil
+		}
+		return fmt.Errorf("claim %q is already prepared with CPUs %q (requested %q)", claimUID, allocation.cpus.String(), cpus.String())
 	}
-	s.resourceClaimAllocations[claimUID] = cpus
-	s.allocatedCPUs = s.allocatedCPUs.Union(cpus)
-	logger.Info("added allocation for resource claim", "cpus", cpus.String())
+	if !cpus.IsSubsetOf(s.availableCPUs.Difference(s.preparedCPUs)) {
+		return fmt.Errorf("claim %q has overlapping CPU assignment %q", claimUID, cpus.String())
+	}
+	s.resourceClaimAllocations[claimUID] = claimAllocation{cpus: cpus}
+	s.preparedCPUs = s.preparedCPUs.Union(cpus)
+	logger.Info("reserved allocation for resource claim", "cpus", cpus.String())
+	return nil
+}
+
+// EnforceResourceClaims validates and marks a container's claims as enforced.
+func (s *CPUAllocation) EnforceResourceClaims(expected map[types.UID]cpuset.CPUSet) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for claimUID, cpus := range expected {
+		allocation, ok := s.resourceClaimAllocations[claimUID]
+		if !ok {
+			return fmt.Errorf("claim %q is not prepared by this driver", claimUID)
+		}
+		if !allocation.cpus.Equals(cpus) {
+			return fmt.Errorf("validation failed for claim %q: cpuset mismatch (expected %q, got %q)", claimUID, allocation.cpus.String(), cpus.String())
+		}
+	}
+
+	for claimUID := range expected {
+		allocation := s.resourceClaimAllocations[claimUID]
+		if allocation.enforced {
+			continue
+		}
+		allocation.enforced = true
+		s.resourceClaimAllocations[claimUID] = allocation
+		s.enforcedCPUs = s.enforcedCPUs.Union(allocation.cpus)
+	}
+	return nil
+}
+
+// MarkResourceClaimsPending stops enforcing claims while retaining their prepared reservations.
+func (s *CPUAllocation) MarkResourceClaimsPending(claimUIDs ...types.UID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, claimUID := range claimUIDs {
+		allocation, ok := s.resourceClaimAllocations[claimUID]
+		if !ok || !allocation.enforced {
+			continue
+		}
+		allocation.enforced = false
+		s.resourceClaimAllocations[claimUID] = allocation
+		s.enforcedCPUs = s.enforcedCPUs.Difference(allocation.cpus)
+	}
 }
 
 // RemoveResourceClaimAllocation removes a resource claim allocation from the store.
 func (s *CPUAllocation) RemoveResourceClaimAllocation(logger logr.Logger, claimUID types.UID) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if cpus, ok := s.resourceClaimAllocations[claimUID]; ok {
-		delete(s.resourceClaimAllocations, claimUID)
-		s.allocatedCPUs = s.allocatedCPUs.Difference(cpus)
+	if _, ok := s.resourceClaimAllocations[claimUID]; ok {
+		s.removeLocked(claimUID)
 		logger.Info("removed allocation for resource claim")
 	}
 }
 
-// GetSharedCPUs returns the set of CPUs not reserved by any resource claim.
+func (s *CPUAllocation) removeLocked(claimUID types.UID) {
+	allocation, ok := s.resourceClaimAllocations[claimUID]
+	if !ok {
+		return
+	}
+	delete(s.resourceClaimAllocations, claimUID)
+	s.preparedCPUs = s.preparedCPUs.Difference(allocation.cpus)
+	if allocation.enforced {
+		s.enforcedCPUs = s.enforcedCPUs.Difference(allocation.cpus)
+	}
+}
+
+// GetSharedCPUs returns CPUs available to shared containers. Prepared claims only
+// leave this pool while they are enforced by a live container.
 func (s *CPUAllocation) GetSharedCPUs() cpuset.CPUSet {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.availableCPUs.Difference(s.allocatedCPUs)
+	return s.availableCPUs.Difference(s.enforcedCPUs)
+}
+
+// GetAllocatableCPUs returns CPUs available for a new exclusive claim.
+func (s *CPUAllocation) GetAllocatableCPUs() cpuset.CPUSet {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.availableCPUs.Difference(s.preparedCPUs)
 }
 
 // GetResourceClaimAllocation returns the cpuset for a given resource claim.
 func (s *CPUAllocation) GetResourceClaimAllocation(claimUID types.UID) (cpuset.CPUSet, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	cpus, ok := s.resourceClaimAllocations[claimUID]
-	return cpus, ok
+	allocation, ok := s.resourceClaimAllocations[claimUID]
+	return allocation.cpus, ok
 }
 
 // GetReservedCPUs returns the set of reserved CPUs.
@@ -108,7 +197,7 @@ func (s *CPUAllocation) GetReservedCPUs() cpuset.CPUSet {
 func (s *CPUAllocation) GetAllocatedCPUs() cpuset.CPUSet {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.allocatedCPUs
+	return s.preparedCPUs
 }
 
 // Snapshot returns a point-in-time summary of CPU allocation state.
@@ -116,8 +205,8 @@ func (s *CPUAllocation) Snapshot() AllocationSnapshot {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return AllocationSnapshot{
-		AllocatedCPUs:        s.allocatedCPUs.Size(),
-		AvailableCPUs:        s.availableCPUs.Difference(s.allocatedCPUs).Size(),
+		AllocatedCPUs:        s.preparedCPUs.Size(),
+		AvailableCPUs:        s.availableCPUs.Difference(s.preparedCPUs).Size(),
 		ReservedCPUs:         s.reservedCPUs.Size(),
 		ActiveResourceClaims: len(s.resourceClaimAllocations),
 	}

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -26,19 +26,13 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
-type claimAllocation struct {
-	cpus     cpuset.CPUSet
-	enforced bool
-}
-
 // CPUAllocation is the single source of truth for CPU allocations.
 type CPUAllocation struct {
 	mu                       sync.RWMutex
 	availableCPUs            cpuset.CPUSet
 	reservedCPUs             cpuset.CPUSet
-	resourceClaimAllocations map[types.UID]claimAllocation
+	resourceClaimAllocations map[types.UID]cpuset.CPUSet
 	preparedCPUs             cpuset.CPUSet
-	enforcedCPUs             cpuset.CPUSet
 }
 
 // AllocationSnapshot is a point-in-time summary of CPU allocation state.
@@ -61,82 +55,46 @@ func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUS
 	return &CPUAllocation{
 		availableCPUs:            availableCPUs,
 		reservedCPUs:             reservedCPUs,
-		resourceClaimAllocations: make(map[types.UID]claimAllocation),
+		resourceClaimAllocations: make(map[types.UID]cpuset.CPUSet),
 		preparedCPUs:             cpuset.New(),
-		enforcedCPUs:             cpuset.New(),
 	}
 }
 
-// ReserveResourceClaimAllocation records a prepared claim without removing its CPUs from
-// shared containers. The CPUs remain unavailable to other exclusive claims until Unprepare.
+// ReserveResourceClaimAllocation records a prepared claim. Its CPUs remain unavailable
+// to shared containers and other exclusive claims until Unprepare.
 func (s *CPUAllocation) ReserveResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if allocation, ok := s.resourceClaimAllocations[claimUID]; ok {
-		if allocation.cpus.Equals(cpus) {
+		if allocation.Equals(cpus) {
 			return nil
 		}
-		return fmt.Errorf("claim %q is already prepared with CPUs %q (requested %q)", claimUID, allocation.cpus.String(), cpus.String())
+		return fmt.Errorf("claim %q is already prepared with CPUs %q (requested %q)", claimUID, allocation.String(), cpus.String())
 	}
 	if !cpus.IsSubsetOf(s.availableCPUs.Difference(s.preparedCPUs)) {
 		return fmt.Errorf("claim %q has overlapping CPU assignment %q", claimUID, cpus.String())
 	}
-	s.resourceClaimAllocations[claimUID] = claimAllocation{cpus: cpus}
+	s.resourceClaimAllocations[claimUID] = cpus
 	s.preparedCPUs = s.preparedCPUs.Union(cpus)
 	logger.Info("reserved allocation for resource claim", "cpus", cpus.String())
 	return nil
 }
 
-// EnforceResourceClaims validates and marks a container's claims as enforced.
-func (s *CPUAllocation) EnforceResourceClaims(expected map[types.UID]cpuset.CPUSet) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// ValidateResourceClaimAllocations verifies that a container's claims match prepared allocations.
+func (s *CPUAllocation) ValidateResourceClaimAllocations(expected map[types.UID]cpuset.CPUSet) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	claimUIDs := make([]types.UID, 0, len(expected))
 	for claimUID, cpus := range expected {
 		allocation, ok := s.resourceClaimAllocations[claimUID]
 		if !ok {
 			return fmt.Errorf("claim %q is not prepared by this driver", claimUID)
 		}
-		if !allocation.cpus.Equals(cpus) {
-			return fmt.Errorf("validation failed for claim %q: cpuset mismatch (expected %q, got %q)", claimUID, allocation.cpus.String(), cpus.String())
+		if !allocation.Equals(cpus) {
+			return fmt.Errorf("validation failed for claim %q: cpuset mismatch (expected %q, got %q)", claimUID, allocation.String(), cpus.String())
 		}
 	}
-
-	for claimUID := range expected {
-		claimUIDs = append(claimUIDs, claimUID)
-	}
-	s.setResourceClaimsEnforcementStateLocked(true, claimUIDs...)
 	return nil
-}
-
-// SetResourceClaimsEnforcementState updates whether prepared claims are enforced by a running container.
-func (s *CPUAllocation) SetResourceClaimsEnforcementState(enforced bool, claimUIDs ...types.UID) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, claimUID := range claimUIDs {
-		if _, ok := s.resourceClaimAllocations[claimUID]; !ok {
-			return fmt.Errorf("claim %q is not prepared by this driver", claimUID)
-		}
-	}
-	s.setResourceClaimsEnforcementStateLocked(enforced, claimUIDs...)
-	return nil
-}
-
-func (s *CPUAllocation) setResourceClaimsEnforcementStateLocked(enforced bool, claimUIDs ...types.UID) {
-	for _, claimUID := range claimUIDs {
-		allocation := s.resourceClaimAllocations[claimUID]
-		if allocation.enforced == enforced {
-			continue
-		}
-		allocation.enforced = enforced
-		s.resourceClaimAllocations[claimUID] = allocation
-		if enforced {
-			s.enforcedCPUs = s.enforcedCPUs.Union(allocation.cpus)
-		} else {
-			s.enforcedCPUs = s.enforcedCPUs.Difference(allocation.cpus)
-		}
-	}
 }
 
 // RemoveResourceClaimAllocation removes a resource claim allocation from the store.
@@ -155,18 +113,14 @@ func (s *CPUAllocation) removeLocked(claimUID types.UID) {
 		return
 	}
 	delete(s.resourceClaimAllocations, claimUID)
-	s.preparedCPUs = s.preparedCPUs.Difference(allocation.cpus)
-	if allocation.enforced {
-		s.enforcedCPUs = s.enforcedCPUs.Difference(allocation.cpus)
-	}
+	s.preparedCPUs = s.preparedCPUs.Difference(allocation)
 }
 
-// GetSharedCPUs returns CPUs available to shared containers. Prepared claims only
-// leave this pool while they are enforced by a live container.
+// GetSharedCPUs returns CPUs available to shared containers.
 func (s *CPUAllocation) GetSharedCPUs() cpuset.CPUSet {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.availableCPUs.Difference(s.enforcedCPUs)
+	return s.availableCPUs.Difference(s.preparedCPUs)
 }
 
 // GetAllocatableCPUs returns CPUs available for a new exclusive claim.
@@ -181,7 +135,7 @@ func (s *CPUAllocation) GetResourceClaimAllocation(claimUID types.UID) (cpuset.C
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	allocation, ok := s.resourceClaimAllocations[claimUID]
-	return allocation.cpus, ok
+	return allocation, ok
 }
 
 // GetReservedCPUs returns the set of reserved CPUs.

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -38,6 +38,12 @@ func newTestCPUAllocation(logger logr.Logger, allCPUs, reserved cpuset.CPUSet) *
 	return NewCPUAllocation(topo, reserved)
 }
 
+func requireEnforcedAllocation(t testing.TB, logger logr.Logger, store *CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
+	t.Helper()
+	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, cpus))
+	require.NoError(t, store.EnforceResourceClaims(map[types.UID]cpuset.CPUSet{claimUID: cpus}))
+}
+
 func TestCPUAllocationPreparedEnforcedLifecycle(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3)
@@ -54,7 +60,7 @@ func TestCPUAllocationPreparedEnforcedLifecycle(t *testing.T) {
 	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 
-	store.MarkResourceClaimsPending(claimUID)
+	require.NoError(t, store.SetResourceClaimsEnforcementState(false, claimUID))
 	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
 	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 
@@ -106,7 +112,7 @@ func TestCPUAllocationResourceClaimAllocation(t *testing.T) {
 	cpus := cpuset.New(0, 1)
 
 	// Add allocation
-	store.AddResourceClaimAllocation(logger, claimUID, cpus)
+	requireEnforcedAllocation(t, logger, store, claimUID, cpus)
 	gotCPUs, ok := store.GetResourceClaimAllocation(claimUID)
 	require.True(t, ok)
 	require.True(t, cpus.Equals(gotCPUs))
@@ -133,47 +139,43 @@ func TestCPUAllocationGetSharedCPUs(t *testing.T) {
 	// With allocations
 	claimUID1 := types.UID("claim-uid-1")
 	cpus1 := cpuset.New(1, 2)
-	store.AddResourceClaimAllocation(logger, claimUID1, cpus1)
+	requireEnforcedAllocation(t, logger, store, claimUID1, cpus1)
 	expectedShared := available.Difference(cpus1)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 
 	claimUID2 := types.UID("claim-uid-2")
 	cpus2 := cpuset.New(3, 4)
-	store.AddResourceClaimAllocation(logger, claimUID2, cpus2)
+	requireEnforcedAllocation(t, logger, store, claimUID2, cpus2)
 	expectedShared = expectedShared.Difference(cpus2)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 }
 
-func TestAddResourceClaimAllocationRepeatedCalls(t *testing.T) {
+func TestReserveResourceClaimAllocationRepeatedCalls(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	testCases := []struct {
-		name           string
-		firstCPUs      cpuset.CPUSet
-		secondCPUs     cpuset.CPUSet
-		expectedClaim  cpuset.CPUSet
-		expectedShared cpuset.CPUSet
+		name        string
+		firstCPUs   cpuset.CPUSet
+		secondCPUs  cpuset.CPUSet
+		expectError bool
 	}{
 		{
-			name:           "same cpus repeated",
-			firstCPUs:      cpuset.New(0, 1),
-			secondCPUs:     cpuset.New(0, 1),
-			expectedClaim:  cpuset.New(0, 1),
-			expectedShared: cpuset.New(2, 3, 4, 5, 6, 7),
+			name:        "same cpus repeated",
+			firstCPUs:   cpuset.New(0, 1),
+			secondCPUs:  cpuset.New(0, 1),
+			expectError: false,
 		},
 		{
-			name:           "different cpus repeated",
-			firstCPUs:      cpuset.New(0, 1),
-			secondCPUs:     cpuset.New(2, 3),
-			expectedClaim:  cpuset.New(2, 3),
-			expectedShared: cpuset.New(0, 1, 4, 5, 6, 7),
+			name:        "different cpus repeated",
+			firstCPUs:   cpuset.New(0, 1),
+			secondCPUs:  cpuset.New(2, 3),
+			expectError: true,
 		},
 		{
-			name:           "overlapping cpus repeated",
-			firstCPUs:      cpuset.New(0, 1, 2),
-			secondCPUs:     cpuset.New(1, 2, 3),
-			expectedClaim:  cpuset.New(1, 2, 3),
-			expectedShared: cpuset.New(0, 4, 5, 6, 7),
+			name:        "overlapping cpus repeated",
+			firstCPUs:   cpuset.New(0, 1, 2),
+			secondCPUs:  cpuset.New(1, 2, 3),
+			expectError: true,
 		},
 	}
 	for _, tc := range testCases {
@@ -181,13 +183,18 @@ func TestAddResourceClaimAllocationRepeatedCalls(t *testing.T) {
 			store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 			claimUID := types.UID("claim-uid-1")
 
-			store.AddResourceClaimAllocation(logger, claimUID, tc.firstCPUs)
-			store.AddResourceClaimAllocation(logger, claimUID, tc.secondCPUs)
+			require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, tc.firstCPUs))
+			err := store.ReserveResourceClaimAllocation(logger, claimUID, tc.secondCPUs)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 
 			gotCPUs, ok := store.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
-			require.True(t, tc.expectedClaim.Equals(gotCPUs), "claim cpus mismatch: got %s, want %s", gotCPUs, tc.expectedClaim)
-			require.True(t, tc.expectedShared.Equals(store.GetSharedCPUs()), "shared cpus mismatch: got %s, want %s", store.GetSharedCPUs(), tc.expectedShared)
+			require.True(t, tc.firstCPUs.Equals(gotCPUs), "claim cpus mismatch: got %s, want %s", gotCPUs, tc.firstCPUs)
+			require.True(t, allCPUs.Difference(tc.firstCPUs).Equals(store.GetAllocatableCPUs()))
 		})
 	}
 }
@@ -197,9 +204,9 @@ func TestCPUAllocationStoreCacheConsistency(t *testing.T) {
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 
-	store.AddResourceClaimAllocation(logger, "claim-1", cpuset.New(0, 1))
-	store.AddResourceClaimAllocation(logger, "claim-2", cpuset.New(2, 3))
-	store.AddResourceClaimAllocation(logger, "claim-3", cpuset.New(4, 5))
+	requireEnforcedAllocation(t, logger, store, "claim-1", cpuset.New(0, 1))
+	requireEnforcedAllocation(t, logger, store, "claim-2", cpuset.New(2, 3))
+	requireEnforcedAllocation(t, logger, store, "claim-3", cpuset.New(4, 5))
 
 	expectedShared := cpuset.New(6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
@@ -224,20 +231,20 @@ func TestCPUAllocationGetReservedCPUs(t *testing.T) {
 	require.True(t, store.GetReservedCPUs().Equals(reserved))
 }
 
-func TestCPUAllocationGetAllocatedCPUs(t *testing.T) {
+func TestCPUAllocationGetPreparedCPUs(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
 	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 
-	require.True(t, store.GetAllocatedCPUs().IsEmpty())
+	require.True(t, store.GetPreparedCPUs().IsEmpty())
 
 	claimUID := types.UID("claim-1")
 	cpus := cpuset.New(2, 3)
-	store.AddResourceClaimAllocation(logger, claimUID, cpus)
-	require.True(t, store.GetAllocatedCPUs().Equals(cpus))
+	requireEnforcedAllocation(t, logger, store, claimUID, cpus)
+	require.True(t, store.GetPreparedCPUs().Equals(cpus))
 
 	store.RemoveResourceClaimAllocation(logger, claimUID)
-	require.True(t, store.GetAllocatedCPUs().IsEmpty())
+	require.True(t, store.GetPreparedCPUs().IsEmpty())
 }
 
 func TestCPUAllocationSnapshot(t *testing.T) {
@@ -253,7 +260,7 @@ func TestCPUAllocationSnapshot(t *testing.T) {
 		ActiveResourceClaims: 0,
 	}, store.Snapshot())
 
-	store.AddResourceClaimAllocation(logger, "claim-1", cpuset.New(2, 3))
+	requireEnforcedAllocation(t, logger, store, "claim-1", cpuset.New(2, 3))
 	require.Equal(t, AllocationSnapshot{
 		AllocatedCPUs:        2,
 		AvailableCPUs:        4,
@@ -261,7 +268,8 @@ func TestCPUAllocationSnapshot(t *testing.T) {
 		ActiveResourceClaims: 1,
 	}, store.Snapshot())
 
-	store.AddResourceClaimAllocation(logger, "claim-1", cpuset.New(4, 5, 6))
+	store.RemoveResourceClaimAllocation(logger, "claim-1")
+	requireEnforcedAllocation(t, logger, store, "claim-1", cpuset.New(4, 5, 6))
 	require.Equal(t, AllocationSnapshot{
 		AllocatedCPUs:        3,
 		AvailableCPUs:        3,
@@ -269,7 +277,7 @@ func TestCPUAllocationSnapshot(t *testing.T) {
 		ActiveResourceClaims: 1,
 	}, store.Snapshot())
 
-	store.AddResourceClaimAllocation(logger, "claim-2", cpuset.New(2, 3))
+	requireEnforcedAllocation(t, logger, store, "claim-2", cpuset.New(2, 3))
 	require.Equal(t, AllocationSnapshot{
 		AllocatedCPUs:        5,
 		AvailableCPUs:        1,
@@ -333,7 +341,7 @@ func BenchmarkGetSharedCPUs(b *testing.B) {
 		b.Run(tc.name+"/optimized", func(b *testing.B) {
 			store := NewCPUAllocation(topo, cpuset.New())
 			for claimUID, cpus := range allocations {
-				store.AddResourceClaimAllocation(logr.Discard(), claimUID, cpus)
+				requireEnforcedAllocation(b, logr.Discard(), store, claimUID, cpus)
 			}
 
 			b.ResetTimer()

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -38,6 +38,31 @@ func newTestCPUAllocation(logger logr.Logger, allCPUs, reserved cpuset.CPUSet) *
 	return NewCPUAllocation(topo, reserved)
 }
 
+func TestCPUAllocationPreparedEnforcedLifecycle(t *testing.T) {
+	logger := testr.New(t)
+	allCPUs := cpuset.New(0, 1, 2, 3)
+	claimUID := types.UID("claim-1")
+	claimCPUs := cpuset.New(0, 1)
+	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
+
+	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs))
+	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
+	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
+	require.Error(t, store.ReserveResourceClaimAllocation(logger, "claim-2", claimCPUs))
+
+	require.NoError(t, store.EnforceResourceClaims(map[types.UID]cpuset.CPUSet{claimUID: claimCPUs}))
+	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
+	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
+
+	store.MarkResourceClaimsPending(claimUID)
+	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
+	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
+
+	store.RemoveResourceClaimAllocation(logger, claimUID)
+	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
+	require.True(t, store.GetAllocatableCPUs().Equals(allCPUs))
+}
+
 func TestNewCPUAllocation(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -38,13 +38,12 @@ func newTestCPUAllocation(logger logr.Logger, allCPUs, reserved cpuset.CPUSet) *
 	return NewCPUAllocation(topo, reserved)
 }
 
-func requireEnforcedAllocation(t testing.TB, logger logr.Logger, store *CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
+func requirePreparedAllocation(t testing.TB, logger logr.Logger, store *CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
 	t.Helper()
 	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, cpus))
-	require.NoError(t, store.EnforceResourceClaims(map[types.UID]cpuset.CPUSet{claimUID: cpus}))
 }
 
-func TestCPUAllocationPreparedEnforcedLifecycle(t *testing.T) {
+func TestCPUAllocationPreparedLifecycle(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3)
 	claimUID := types.UID("claim-1")
@@ -52,16 +51,12 @@ func TestCPUAllocationPreparedEnforcedLifecycle(t *testing.T) {
 	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 
 	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs))
-	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
+	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 	require.Error(t, store.ReserveResourceClaimAllocation(logger, "claim-2", claimCPUs))
 
-	require.NoError(t, store.EnforceResourceClaims(map[types.UID]cpuset.CPUSet{claimUID: claimCPUs}))
+	require.NoError(t, store.ValidateResourceClaimAllocations(map[types.UID]cpuset.CPUSet{claimUID: claimCPUs}))
 	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
-	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
-
-	require.NoError(t, store.SetResourceClaimsEnforcementState(false, claimUID))
-	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
 	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 
 	store.RemoveResourceClaimAllocation(logger, claimUID)
@@ -112,7 +107,7 @@ func TestCPUAllocationResourceClaimAllocation(t *testing.T) {
 	cpus := cpuset.New(0, 1)
 
 	// Add allocation
-	requireEnforcedAllocation(t, logger, store, claimUID, cpus)
+	requirePreparedAllocation(t, logger, store, claimUID, cpus)
 	gotCPUs, ok := store.GetResourceClaimAllocation(claimUID)
 	require.True(t, ok)
 	require.True(t, cpus.Equals(gotCPUs))
@@ -139,13 +134,13 @@ func TestCPUAllocationGetSharedCPUs(t *testing.T) {
 	// With allocations
 	claimUID1 := types.UID("claim-uid-1")
 	cpus1 := cpuset.New(1, 2)
-	requireEnforcedAllocation(t, logger, store, claimUID1, cpus1)
+	requirePreparedAllocation(t, logger, store, claimUID1, cpus1)
 	expectedShared := available.Difference(cpus1)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 
 	claimUID2 := types.UID("claim-uid-2")
 	cpus2 := cpuset.New(3, 4)
-	requireEnforcedAllocation(t, logger, store, claimUID2, cpus2)
+	requirePreparedAllocation(t, logger, store, claimUID2, cpus2)
 	expectedShared = expectedShared.Difference(cpus2)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
 }
@@ -204,9 +199,9 @@ func TestCPUAllocationStoreCacheConsistency(t *testing.T) {
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 
-	requireEnforcedAllocation(t, logger, store, "claim-1", cpuset.New(0, 1))
-	requireEnforcedAllocation(t, logger, store, "claim-2", cpuset.New(2, 3))
-	requireEnforcedAllocation(t, logger, store, "claim-3", cpuset.New(4, 5))
+	requirePreparedAllocation(t, logger, store, "claim-1", cpuset.New(0, 1))
+	requirePreparedAllocation(t, logger, store, "claim-2", cpuset.New(2, 3))
+	requirePreparedAllocation(t, logger, store, "claim-3", cpuset.New(4, 5))
 
 	expectedShared := cpuset.New(6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 	require.True(t, store.GetSharedCPUs().Equals(expectedShared))
@@ -240,7 +235,7 @@ func TestCPUAllocationGetPreparedCPUs(t *testing.T) {
 
 	claimUID := types.UID("claim-1")
 	cpus := cpuset.New(2, 3)
-	requireEnforcedAllocation(t, logger, store, claimUID, cpus)
+	requirePreparedAllocation(t, logger, store, claimUID, cpus)
 	require.True(t, store.GetPreparedCPUs().Equals(cpus))
 
 	store.RemoveResourceClaimAllocation(logger, claimUID)
@@ -260,7 +255,7 @@ func TestCPUAllocationSnapshot(t *testing.T) {
 		ActiveResourceClaims: 0,
 	}, store.Snapshot())
 
-	requireEnforcedAllocation(t, logger, store, "claim-1", cpuset.New(2, 3))
+	requirePreparedAllocation(t, logger, store, "claim-1", cpuset.New(2, 3))
 	require.Equal(t, AllocationSnapshot{
 		AllocatedCPUs:        2,
 		AvailableCPUs:        4,
@@ -269,7 +264,7 @@ func TestCPUAllocationSnapshot(t *testing.T) {
 	}, store.Snapshot())
 
 	store.RemoveResourceClaimAllocation(logger, "claim-1")
-	requireEnforcedAllocation(t, logger, store, "claim-1", cpuset.New(4, 5, 6))
+	requirePreparedAllocation(t, logger, store, "claim-1", cpuset.New(4, 5, 6))
 	require.Equal(t, AllocationSnapshot{
 		AllocatedCPUs:        3,
 		AvailableCPUs:        3,
@@ -277,7 +272,7 @@ func TestCPUAllocationSnapshot(t *testing.T) {
 		ActiveResourceClaims: 1,
 	}, store.Snapshot())
 
-	requireEnforcedAllocation(t, logger, store, "claim-2", cpuset.New(2, 3))
+	requirePreparedAllocation(t, logger, store, "claim-2", cpuset.New(2, 3))
 	require.Equal(t, AllocationSnapshot{
 		AllocatedCPUs:        5,
 		AvailableCPUs:        1,
@@ -341,7 +336,7 @@ func BenchmarkGetSharedCPUs(b *testing.B) {
 		b.Run(tc.name+"/optimized", func(b *testing.B) {
 			store := NewCPUAllocation(topo, cpuset.New())
 			for claimUID, cpus := range allocations {
-				requireEnforcedAllocation(b, logr.Discard(), store, claimUID, cpus)
+				requirePreparedAllocation(b, logr.Discard(), store, claimUID, cpus)
 			}
 
 			b.ResetTimer()

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -52,16 +52,13 @@ func TestCPUAllocationPreparedLifecycle(t *testing.T) {
 
 	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs))
 	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
-	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 	require.Error(t, store.ReserveResourceClaimAllocation(logger, "claim-2", claimCPUs))
 
 	require.NoError(t, store.ValidateResourceClaimAllocations(map[types.UID]cpuset.CPUSet{claimUID: claimCPUs}))
 	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
-	require.True(t, store.GetAllocatableCPUs().Equals(cpuset.New(2, 3)))
 
 	store.RemoveResourceClaimAllocation(logger, claimUID)
 	require.True(t, store.GetSharedCPUs().Equals(allCPUs))
-	require.True(t, store.GetAllocatableCPUs().Equals(allCPUs))
 }
 
 func TestNewCPUAllocation(t *testing.T) {
@@ -189,7 +186,7 @@ func TestReserveResourceClaimAllocationRepeatedCalls(t *testing.T) {
 			gotCPUs, ok := store.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
 			require.True(t, tc.firstCPUs.Equals(gotCPUs), "claim cpus mismatch: got %s, want %s", gotCPUs, tc.firstCPUs)
-			require.True(t, allCPUs.Difference(tc.firstCPUs).Equals(store.GetAllocatableCPUs()))
+			require.True(t, allCPUs.Difference(tc.firstCPUs).Equals(store.GetSharedCPUs()))
 		})
 	}
 }

--- a/pkg/store/pod_config.go
+++ b/pkg/store/pod_config.go
@@ -94,6 +94,8 @@ func (s *PodConfig) GetContainerState(podUID types.UID, containerName string) *C
 
 // RemoveContainerState removes a container's state if its runtime ID still matches.
 // A replacement container can have the same name while an old Remove event is in flight.
+// It returns the removed state's claim UIDs and whether a matching state was removed. The
+// boolean distinguishes a removed shared container, which has no claims, from a stale event.
 func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string, containerUID types.UID) ([]types.UID, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/store/pod_config.go
+++ b/pkg/store/pod_config.go
@@ -92,19 +92,20 @@ func (s *PodConfig) GetContainerState(podUID types.UID, containerName string) *C
 	return nil
 }
 
-// RemoveContainerState removes a container's state from the store.
-func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string) []types.UID {
+// RemoveContainerState removes a container's state if its runtime ID still matches.
+// A replacement container can have the same name while an old Remove event is in flight.
+func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string, containerUID types.UID) ([]types.UID, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	podAssignments, ok := s.configs[podUID]
 	if !ok {
-		return []types.UID{}
+		return []types.UID{}, false
 	}
 
 	cs, ok := podAssignments[containerName]
-	if !ok {
-		return []types.UID{}
+	if !ok || cs.containerUID != containerUID {
+		return []types.UID{}, false
 	}
 
 	claimUIDs := cs.resourceClaimUIDs
@@ -120,7 +121,7 @@ func (s *PodConfig) RemoveContainerState(podUID types.UID, containerName string)
 		delete(s.configs, podUID)
 	}
 
-	return claimUIDs
+	return claimUIDs, true
 }
 
 // GetContainersWithSharedCPUs returns a list of container UIDs that have shared CPU allocation.

--- a/pkg/store/pod_config_test.go
+++ b/pkg/store/pod_config_test.go
@@ -54,18 +54,31 @@ func TestRemoveContainerState(t *testing.T) {
 	require.NotNil(t, store.GetContainerState(podUID, ctrName2))
 
 	// Remove one container
-	store.RemoveContainerState(podUID, ctrName1)
+	claimUIDs, removed := store.RemoveContainerState(podUID, ctrName1, "ctr-uid-1")
+	require.True(t, removed)
+	require.Equal(t, []types.UID{"claim-uid-1"}, claimUIDs)
 	require.Nil(t, store.GetContainerState(podUID, ctrName1))
 	require.NotNil(t, store.GetContainerState(podUID, ctrName2), "other container should still exist")
 
 	// Remove the second container, which should remove the pod entry
-	store.RemoveContainerState(podUID, ctrName2)
+	_, removed = store.RemoveContainerState(podUID, ctrName2, "ctr-uid-2")
+	require.True(t, removed)
 	require.Nil(t, store.GetContainerState(podUID, ctrName2))
 	_, podExists := store.configs[podUID]
 	require.False(t, podExists, "pod entry should be gone after last container is removed")
 
 	// Remove non-existent container, should not panic
-	store.RemoveContainerState(podUID, "non-existent-ctr")
+	_, removed = store.RemoveContainerState(podUID, "non-existent-ctr", "unknown-uid")
+	require.False(t, removed)
+
+	// A delayed event for an old container must not remove its replacement.
+	store.SetContainerState(podUID, NewContainerState(ctrName1, "old-uid", "claim-uid-1"))
+	store.SetContainerState(podUID, NewContainerState(ctrName1, "new-uid", "claim-uid-1"))
+	_, removed = store.RemoveContainerState(podUID, ctrName1, "old-uid")
+	require.False(t, removed)
+	require.Equal(t, types.UID("new-uid"), store.GetContainerState(podUID, ctrName1).containerUID)
+	_, removed = store.RemoveContainerState(podUID, ctrName1, "new-uid")
+	require.True(t, removed)
 }
 
 func TestGetSharedCPUContainerUIDs(t *testing.T) {
@@ -130,12 +143,14 @@ func TestSharedCPUContainersCacheConsistency(t *testing.T) {
 	require.Len(t, sharedUIDs, 2)
 	require.NotContains(t, sharedUIDs, types.UID("id1"))
 
-	store.RemoveContainerState("pod1", "c2")
+	_, removed := store.RemoveContainerState("pod1", "c2", "id2")
+	require.True(t, removed)
 	sharedUIDs = store.GetContainersWithSharedCPUs()
 	require.Len(t, sharedUIDs, 1)
 	require.ElementsMatch(t, []types.UID{"id3"}, sharedUIDs)
 
-	store.RemoveContainerState("pod2", "c3")
+	_, removed = store.RemoveContainerState("pod2", "c3", "id3")
+	require.True(t, removed)
 	sharedUIDs = store.GetContainersWithSharedCPUs()
 	require.Len(t, sharedUIDs, 0)
 }

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -233,6 +233,46 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				verifySharedPoolMatches(ctx, fxt, shrPod2, availableCPUs)
 			})
 
+			ginkgo.It("should preserve exclusive CPUs when a container restarts without re-preparing its claim", func(ctx context.Context) {
+				if cpuDeviceMode == "grouped" && groupBy == "machine" {
+					ginkgo.Skip("skipping this test in machine grouping mode as we do not configure opaque config in claim")
+				}
+
+				claimTemplate := resourcev1.ResourceClaimTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "cpu-claim-container-restart"},
+					Spec: resourcev1.ResourceClaimTemplateSpec{
+						Spec: makeResourceClaimSpec(cpusPerClaim, cpuDeviceMode == "grouped"),
+					},
+				}
+				createdTemplate, err := fxt.K8SClientset.ResourceV1().ResourceClaimTemplates(fxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				pod := makeTesterPodWithExclusiveCPUClaim(fxt.Namespace.Name, dracpuTesterImage, createdTemplate.Name, int64(cpusPerClaim), targetNode.Name)
+				pod.Spec.Containers[0].Args = []string{"--exit-after=10s"}
+				createdPod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, pod)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				initialAllocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod)
+				gomega.Expect(initialAllocation.CPUAssigned).To(cpusetmatchers.HaveSize(cpusPerClaim))
+				gomega.Expect(createdPod.Status.ContainerStatuses).ToNot(gomega.BeEmpty())
+				initialContainerID := createdPod.Status.ContainerStatuses[0].ContainerID
+
+				var restartedPod *v1.Pod
+				gomega.Eventually(func(g gomega.Gomega) {
+					current, err := fxt.K8SClientset.CoreV1().Pods(createdPod.Namespace).Get(ctx, createdPod.Name, metav1.GetOptions{})
+					g.Expect(err).ToNot(gomega.HaveOccurred())
+					g.Expect(current.Status.ContainerStatuses).ToNot(gomega.BeEmpty())
+					status := current.Status.ContainerStatuses[0]
+					g.Expect(status.RestartCount).To(gomega.BeNumerically(">=", 1))
+					g.Expect(status.ContainerID).ToNot(gomega.Equal(initialContainerID))
+					g.Expect(status.State.Running).ToNot(gomega.BeNil())
+					restartedPod = current
+				}, 2*time.Minute, 2*time.Second).Should(gomega.Succeed())
+
+				restartedAllocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, restartedPod)
+				gomega.Expect(restartedAllocation.CPUAssigned).To(cpusetmatchers.Equal(initialAllocation.CPUAssigned))
+			})
+
 			ginkgo.It("should allocate non-overlapping CPUs for multiple requests in the same grouped claim", func(ctx context.Context) {
 				if cpuDeviceMode != "grouped" {
 					ginkgo.Skip("this test only applies to grouped CPU device mode")

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -233,46 +233,6 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				verifySharedPoolMatches(ctx, fxt, shrPod2, availableCPUs)
 			})
 
-			ginkgo.It("should preserve exclusive CPUs when a container restarts without re-preparing its claim", func(ctx context.Context) {
-				if cpuDeviceMode == "grouped" && groupBy == "machine" {
-					ginkgo.Skip("skipping this test in machine grouping mode as we do not configure opaque config in claim")
-				}
-
-				claimTemplate := resourcev1.ResourceClaimTemplate{
-					ObjectMeta: metav1.ObjectMeta{Name: "cpu-claim-container-restart"},
-					Spec: resourcev1.ResourceClaimTemplateSpec{
-						Spec: makeResourceClaimSpec(cpusPerClaim, cpuDeviceMode == "grouped"),
-					},
-				}
-				createdTemplate, err := fxt.K8SClientset.ResourceV1().ResourceClaimTemplates(fxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				pod := makeTesterPodWithExclusiveCPUClaim(fxt.Namespace.Name, dracpuTesterImage, createdTemplate.Name, int64(cpusPerClaim), targetNode.Name)
-				pod.Spec.Containers[0].Args = []string{"--exit-after=10s"}
-				createdPod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, pod)
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-				initialAllocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdPod)
-				gomega.Expect(initialAllocation.CPUAssigned).To(cpusetmatchers.HaveSize(cpusPerClaim))
-				gomega.Expect(createdPod.Status.ContainerStatuses).ToNot(gomega.BeEmpty())
-				initialContainerID := createdPod.Status.ContainerStatuses[0].ContainerID
-
-				var restartedPod *v1.Pod
-				gomega.Eventually(func(g gomega.Gomega) {
-					current, err := fxt.K8SClientset.CoreV1().Pods(createdPod.Namespace).Get(ctx, createdPod.Name, metav1.GetOptions{})
-					g.Expect(err).ToNot(gomega.HaveOccurred())
-					g.Expect(current.Status.ContainerStatuses).ToNot(gomega.BeEmpty())
-					status := current.Status.ContainerStatuses[0]
-					g.Expect(status.RestartCount).To(gomega.BeNumerically(">=", 1))
-					g.Expect(status.ContainerID).ToNot(gomega.Equal(initialContainerID))
-					g.Expect(status.State.Running).ToNot(gomega.BeNil())
-					restartedPod = current
-				}, 2*time.Minute, 2*time.Second).Should(gomega.Succeed())
-
-				restartedAllocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, restartedPod)
-				gomega.Expect(restartedAllocation.CPUAssigned).To(cpusetmatchers.Equal(initialAllocation.CPUAssigned))
-			})
-
 			ginkgo.It("should allocate non-overlapping CPUs for multiple requests in the same grouped claim", func(ctx context.Context) {
 				if cpuDeviceMode != "grouped" {
 					ginkgo.Skip("this test only applies to grouped CPU device mode")

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -229,8 +229,9 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 					gomega.Expect(e2epod.DeleteSync(ctx, fxt.K8SClientset, pod)).To(gomega.Succeed(), "cannot delete pod %s", e2epod.Identify(pod))
 				}
 
-				verifySharedPoolMatches(ctx, fxt, shrPod1, availableCPUs)
-				verifySharedPoolMatches(ctx, fxt, shrPod2, availableCPUs)
+				ginkgo.By("checking existing shared containers keep their last cpuset until the next CreateContainer or Synchronize")
+				verifySharedPoolMatches(ctx, fxt, shrPod1, expectedSharedCPUs)
+				verifySharedPoolMatches(ctx, fxt, shrPod2, expectedSharedCPUs)
 			})
 
 			ginkgo.It("should allocate non-overlapping CPUs for multiple requests in the same grouped claim", func(ctx context.Context) {
@@ -363,8 +364,9 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 					gomega.Expect(e2epod.DeleteSync(ctx, fxt.K8SClientset, pod)).To(gomega.Succeed(), "cannot delete pod %s", e2epod.Identify(pod))
 				}
 
-				verifySharedPoolMatches(ctx, fxt, shrPod1, availableCPUs)
-				verifySharedPoolMatches(ctx, fxt, shrPod2, availableCPUs)
+				ginkgo.By("checking existing shared containers keep their last cpuset until the next CreateContainer or Synchronize")
+				verifySharedPoolMatches(ctx, fxt, shrPod1, expectedSharedCPUs)
+				verifySharedPoolMatches(ctx, fxt, shrPod2, expectedSharedCPUs)
 			})
 		})
 	})

--- a/test/image/dracputester/app.go
+++ b/test/image/dracputester/app.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/fs"
 	"log"
@@ -87,6 +88,9 @@ func affinityScanBoundFromTopology(topo *cpuinfo.CPUTopology) int {
 }
 
 func main() {
+	exitAfter := flag.Duration("exit-after", 0, "exit after this duration to exercise container restart handling")
+	flag.Parse()
+	started := time.Now()
 	logger := stdr.New(log.Default())
 	// Read the container's cgroup view, intentionally ignoring HOST_ROOT.
 	containerSysfs := os.DirFS("/sys")
@@ -114,6 +118,9 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error encoding info: %v\n", err)
 			os.Exit(2)
+		}
+		if *exitAfter > 0 && time.Since(started) >= *exitAfter {
+			os.Exit(42)
 		}
 
 		time.Sleep(5 * time.Second)

--- a/test/image/dracputester/app.go
+++ b/test/image/dracputester/app.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/fs"
 	"log"
@@ -88,9 +87,6 @@ func affinityScanBoundFromTopology(topo *cpuinfo.CPUTopology) int {
 }
 
 func main() {
-	exitAfter := flag.Duration("exit-after", 0, "exit after this duration to exercise container restart handling")
-	flag.Parse()
-	started := time.Now()
 	logger := stdr.New(log.Default())
 	// Read the container's cgroup view, intentionally ignoring HOST_ROOT.
 	containerSysfs := os.DirFS("/sys")
@@ -118,9 +114,6 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error encoding info: %v\n", err)
 			os.Exit(2)
-		}
-		if *exitAfter > 0 && time.Since(started) >= *exitAfter {
-			os.Exit(42)
 		}
 
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes guaranteed CPU containers failing to restart when kubelet creates a replacement container without calling `NodePrepareResources` again.

Previously, `StopContainer` removed the allocation and ownership state used to validate the CDI-injected `DRA_CPUSET_<claimUID>` value. The replacement container still received that value, but `CreateContainer` rejected it because the trusted prepared state was gone.

This change separates prepared reservations from allocations enforced by running containers:

1. `NodePrepareResources` reserves the CPUs for the claim.
2. `CreateContainer` validates the CDI allocation and marks it enforced.
3. `StopContainer` marks it pending, returning the CPUs to the shared pool while retaining the reservation and owner.
4. A replacement container can enforce the same allocation without another prepare call.
5. `NodeUnprepareResources` removes the allocation and owner.

It also makes reservation and multi-claim enforcement atomic, rolls back reservations when CDI preparation fails, and adds unit and end-to-end coverage for the restart flow.

Prepared state remains in memory. Persisting it across driver restarts is tracked separately in #<checkpoint-issue>.

#### Which issue(s) this PR fixes:

Fixes #235

#### Special notes for your reviewer:

The implementation still assumes that a ResourceClaim is owned by one container. Claim sharing, preemption, and mixed shared/exclusive use remain out of scope.