### PR TITLE
Validate grouped CPU capacities for KEP-5075

### DIFF
--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -26,7 +26,7 @@ The driver supports two modes of operation. Each mode has a complete example man
 
 ### Grouped Mode (default)
 
-In grouped mode, CPUs are requested as a consumable capacity from a device group (e.g., NUMA node or socket). This example requests 10 CPUs.
+In grouped mode, CPUs are requested as a consumable capacity from a device group (e.g., NUMA node or socket). The `dra.cpu/cpu` capacity must be a positive whole number of logical CPUs; fractional, zero, and negative quantities are rejected during claim preparation. This example requests 10 CPUs.
 
 - `kubectl apply -f hack/examples/pod_with_resource_claim_grouped_mode.yaml`
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -129,7 +129,13 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			continue
 		}
 		if quantity, ok := alloc.ConsumedCapacity[device.CPUResourceQualifiedName]; ok {
+			if quantity.Sign() <= 0 {
+				return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q must be positive, got %s", alloc.Device, quantity.String())}
+			}
 			count := quantity.Value()
+			if quantity.CmpInt64(count) != 0 {
+				return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q must be a whole number, got %s", alloc.Device, quantity.String())}
+			}
 			claimCPUCount = count
 			logger.V(4).Info("found CPU request", "numCPUs", count, "device", alloc.Device)
 		}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1233,6 +1233,62 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 	}
 }
 
+func TestPrepareResourceClaimsGroupedModeRejectsInvalidCPUCapacity(t *testing.T) {
+	testCases := []struct {
+		name          string
+		capacity      string
+		expectedError string
+	}{
+		{name: "fractional below one", capacity: "500m", expectedError: "must be a whole number"},
+		{name: "fractional above one", capacity: "1500m", expectedError: "must be a whole number"},
+		{name: "zero", capacity: "0", expectedError: "must be positive"},
+		{name: "negative", capacity: "-1", expectedError: "must be positive"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := Providers{
+				CPUInfo: &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT},
+				SysFS:   testSysFS(mockCPUInfos_SingleSocket_4CPUS_HT),
+			}
+			conf := Config{
+				DriverName:       testDriverName,
+				NodeName:         testNodeName,
+				CPUDeviceMode:    devattr.CPU_DEVICE_MODE_GROUPED,
+				CPUDeviceGroupBy: devattr.GROUP_BY_SOCKET,
+			}
+			driver, err := New(testr.New(t), prov, &conf)
+			require.NoError(t, err)
+			mockCdiMgr := newMockCdiMgr()
+			driver.cdiMgr = mockCdiMgr
+
+			claimUID := types.UID("claim-invalid-capacity")
+			claim := testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+				{
+					Driver:  testDriverName,
+					Pool:    testNodeName,
+					Device:  "cpudevsocket000",
+					Request: string(claimUID),
+					ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
+						devattr.CPUResourceQualifiedName: resource.MustParse(tc.capacity),
+					},
+				},
+			})
+
+			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{claim})
+			require.NoError(t, err)
+			result := preparedClaims[claimUID]
+			require.ErrorContains(t, result.Err, tc.expectedError)
+			require.Empty(t, result.Devices)
+			require.Empty(t, mockCdiMgr.devices)
+
+			_, allocated := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+			require.False(t, allocated)
+			require.True(t, cpuset.New(0, 1, 2, 3).Equals(driver.cpuAllocationStore.GetSharedCPUs()))
+		})
+	}
+}
+
 func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 	claimUID := types.UID("claim-1")
 	cdiDeviceName := getCDIDeviceName(claimUID)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation

#### What this PR does / why we need it

This driver uses the consumable-capacity model introduced by KEP-5075 for grouped CPU devices. The KEP was merged in kubernetes/enhancements#5104, and the v1.37 update in kubernetes/enhancements#6254 is extending `CapacityRange` and `ValidValues` with fractional quantity semantics.

The DRA allocator preserves exact fractional consumed capacities, while this driver currently converts `dra.cpu/cpu` with `resource.Quantity.Value()`. That conversion rounds away from zero, which can pin one CPU for `500m` or two CPUs for `1500m` and diverge from scheduler capacity accounting.

Because this driver allocates indivisible logical CPUs, this PR rejects fractional, zero, and negative quantities before CPU allocation. It adds regression coverage and documents the positive whole-CPU constraint.

#### Which issue(s) this PR is related to

Fixes #246

KEP: https://github.com/kubernetes/enhancements/issues/5075
Original merged KEP PR: https://github.com/kubernetes/enhancements/pull/5104
v1.37 fractional quantity update (currently open): https://github.com/kubernetes/enhancements/pull/6254

#### Special notes for reviewers

This intentionally does not add fractional CPU pinning. Positive whole CPU quantities retain their existing behavior, while unsupported quantities fail before CPU allocation or CDI device creation.

Validated with `go test ./pkg/driver`.

#### Release note

```release-note
Reject fractional, zero, and negative CPU capacity quantities when preparing grouped-mode claims.
```

#### Documentation updates

- README grouped-mode capacity constraints