### PR TITLE
feat: implement device health reporting via WatchHealthStatus

### DIFF
--- a/docs/user/feature-support.md
+++ b/docs/user/feature-support.md
@@ -14,6 +14,7 @@
   (NUMA/socket/machine aggregates exposed as consumable capacity — fewer API objects, scales
   to large systems). See [Configuration](configuration.md#driver-configuration) for the
   full description and how to choose.
+- **Device Health Reporting**: The driver reports per-device health to the kubelet via the DRA `WatchHealthStatus` gRPC API, reflected in `pod.status.containerStatuses[].allocatedResourcesStatus`. Devices are reported `Healthy` and go `Unknown` if the driver stops sending updates. `Unhealthy` is reserved for future use. See [Device Health Reporting](workload-requirements.md#device-health-reporting).
 
 ## Not Supported
 

--- a/docs/user/workload-requirements.md
+++ b/docs/user/workload-requirements.md
@@ -134,3 +134,11 @@ Kubernetes `status.extendedResourceClaimStatus` is for DRA-backed extended resou
 For example, a Pod that references a CPU `ResourceClaim` explicitly through `containers[].resources.claims` follows this driver's supported path. A Pod that only patches `status.extendedResourceClaimStatus` with `requestMappings[].resourceName: cpu` does not, because `cpu` is a native resource rather than a DRA-backed extended resource.
 
 For integrations that model native `cpu`, use the Kubernetes node-allocatable DRA status path when available instead.
+
+## Device Health Reporting
+
+The driver reports the health of every device it manages to the kubelet over the DRA `WatchHealthStatus` gRPC API, so the kubelet can reflect it in `pod.status.containerStatuses[].allocatedResourcesStatus`.
+
+- `Healthy`: the default state. The driver has not observed any failure for this device.
+- `Unhealthy`: reserved for failures attributable to the device itself. The driver does not currently report this for any condition. A claim that fails to prepare (for example, a CDI spec write error) surfaces as a claim error instead, not a device health change.
+- `Unknown`: reported by the kubelet itself and not the driver, when it stops receiving health updates for a device within its lease window (for example, if the driver process is down).

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -380,12 +380,6 @@ func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplu
 	return nil
 }
 
-// WatchHealthStatus is required by the kubeletplugin.DRAPlugin interface in the 1.37-dev
-// dynamic-resource-allocation library. This driver does not implement device health reporting.
-func (cp *CPUDriver) WatchHealthStatus(ctx context.Context, reports chan<- kubeletplugin.DeviceHealthReport) error {
-	return kubeletplugin.ErrHealthNotSupported
-}
-
 // HandleError is called by the kubelet plugin framework when an error occurs in the background,
 // for example while publishing ResourceSlices.
 func (cp *CPUDriver) HandleError(ctx context.Context, err error, msg string) {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -899,40 +899,47 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 	}
 
 	testCases := []struct {
-		name                       string
-		driver                     *CPUDriver
-		claim                      *resourceapi.ResourceClaim
-		expectExistingAllocation   bool
-		expectedExistingAllocation cpuset.CPUSet
-		expectedSharedCPUs         cpuset.CPUSet
+		name               string
+		driver             *CPUDriver
+		claim              *resourceapi.ResourceClaim
+		expectAllocation   bool
+		expectedAllocation cpuset.CPUSet
+		expectedSharedCPUs cpuset.CPUSet
 	}{
 		{
+			// New claim: the reservation is removed again on failure so the
+			// CPUs go back to the shared pool immediately instead of being
+			// left stuck for a future Unprepare to find.
 			name:               "individual mode new claim",
 			driver:             individualDriver(false),
 			claim:              individualClaim("cpudev2", "cpudev3"),
+			expectAllocation:   false,
 			expectedSharedCPUs: cpuset.New(0, 1, 2, 3),
 		},
 		{
-			name:                       "individual mode existing claim",
-			driver:                     individualDriver(true),
-			claim:                      individualClaim("cpudev0", "cpudev1"),
-			expectExistingAllocation:   true,
-			expectedExistingAllocation: existingCPUs,
-			expectedSharedCPUs:         cpuset.New(2, 3),
+			// Existing claim: prepare reuses the already-committed allocation
+			// and never reserves/removes it, so it must remain untouched.
+			name:               "individual mode existing claim",
+			driver:             individualDriver(true),
+			claim:              individualClaim("cpudev0", "cpudev1"),
+			expectAllocation:   true,
+			expectedAllocation: existingCPUs,
+			expectedSharedCPUs: cpuset.New(2, 3),
 		},
 		{
 			name:               "grouped mode new claim",
 			driver:             groupedDriver(false),
 			claim:              groupedClaim(),
+			expectAllocation:   false,
 			expectedSharedCPUs: cpuset.New(0, 1, 2, 3),
 		},
 		{
-			name:                       "grouped mode existing claim",
-			driver:                     groupedDriver(true),
-			claim:                      groupedClaim(),
-			expectExistingAllocation:   true,
-			expectedExistingAllocation: existingCPUs,
-			expectedSharedCPUs:         cpuset.New(2, 3),
+			name:               "grouped mode existing claim",
+			driver:             groupedDriver(true),
+			claim:              groupedClaim(),
+			expectAllocation:   true,
+			expectedAllocation: existingCPUs,
+			expectedSharedCPUs: cpuset.New(2, 3),
 		},
 	}
 
@@ -949,9 +956,9 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			require.Empty(t, mockCdiMgr.devices)
 
 			gotCPUs, ok := tc.driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
-			require.Equal(t, tc.expectExistingAllocation, ok)
-			if tc.expectExistingAllocation {
-				require.True(t, tc.expectedExistingAllocation.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedExistingAllocation)
+			require.Equal(t, tc.expectAllocation, ok)
+			if tc.expectAllocation {
+				require.True(t, tc.expectedAllocation.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedAllocation)
 			}
 			require.True(t, tc.expectedSharedCPUs.Equals(tc.driver.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s, want %s", tc.driver.cpuAllocationStore.GetSharedCPUs(), tc.expectedSharedCPUs)
 		})

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -92,8 +92,15 @@ type CPUDriver struct {
 	pcieRootMapper          *store.PCIeRootMapper
 	devicesPerResourceSlice int
 	metrics                 cpumetrics.Recorder
+	health                  healthTracker
 
 	kubeletRootDir string
+}
+
+// deviceHealthEntry is the last known health of a single device.
+type deviceHealthEntry struct {
+	status  kubeletplugin.HealthStatus
+	message string
 }
 
 // deviceTopology holds the CPU topology and device-to-CPU/socket/NUMA
@@ -182,6 +189,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 		pcieRootMapper:          store.NewPCIeRootMapper(),
 		devicesPerResourceSlice: config.DevicesPerResourceSlice(),
 		metrics:                 metricsRecorder,
+		health:                  newHealthTracker(),
 		kubeletRootDir:          config.KubeletRootDir,
 	}
 	sfs := providers.EnsureSysFS()
@@ -231,6 +239,14 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 		// Chunk devices into slices of at most devicesPerResourceSlice
 		plugin.topology.deviceSlices = slices.Collect(slices.Chunk(devices, plugin.devicesPerResourceSlice))
 	}
+
+	for _, d := range devices {
+		plugin.health.devices[d.Name] = &deviceHealthEntry{
+			status:  kubeletplugin.HealthStatusHealthy,
+			message: "device initialized",
+		}
+	}
+
 	return plugin, nil
 }
 
@@ -302,6 +318,7 @@ func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
 		kubeletplugin.RegistrarDirectoryPath(registrarDir(cp.kubeletRootDir)),
 		kubeletplugin.PluginDataDirectoryPath(driverPluginPath),
 		kubeletplugin.EnableDeviceMetadata(true, []schema.GroupVersion{drametadatav1beta1.SchemeGroupVersion}),
+		kubeletplugin.HealthService(true),
 	}
 	d, err := kubeletplugin.Start(ctx, cp, kubeletOpts...)
 	if err != nil {
@@ -338,11 +355,19 @@ func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
 	// publish available resources
 	go cp.PublishResources(ctx)
 
+	// periodically (every healthResendInterval) resend device health so
+	// the kubelet's lease on it does not expire (see WatchHealthStatus in
+	// health.go)
+	cp.health.wg.Add(1)
+	go cp.healthResendLoop(ctx)
+
 	return asyncErr, nil
 }
 
 // Stop stops the CPUDriver.
 func (cp *CPUDriver) Stop() {
+	close(cp.health.stopCh)
+	cp.health.wg.Wait()
 	cp.nriPlugin.Stop()
 	cp.draPlugin.Stop()
 }

--- a/pkg/driver/health.go
+++ b/pkg/driver/health.go
@@ -1,0 +1,213 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/ctxlog"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+)
+
+// healthTracker owns the per-device health state and the set of active
+// WatchHealthStatus subscribers it is streamed to. mu protects devices,
+// clientsMu protects clients.
+type healthTracker struct {
+	mu        sync.RWMutex
+	devices   map[string]*deviceHealthEntry
+	clientsMu sync.RWMutex
+	clients   []chan kubeletplugin.DeviceHealthReport
+	stopCh    chan struct{}
+	wg        sync.WaitGroup
+}
+
+func newHealthTracker() healthTracker {
+	return healthTracker{
+		devices: make(map[string]*deviceHealthEntry),
+		stopCh:  make(chan struct{}),
+	}
+}
+
+// healthResendInterval is how often the driver resends the full device
+// health snapshot to the kubelet. It must be shorter than the kubelet's
+// default defaultKubeletHealthTimeout(30s), otherwise the kubelet will
+// treat devices as stale and report them as unknown between updates.
+var healthResendInterval = 10 * time.Second
+
+// updateDeviceHealth updates a device's health status. Returns true if it changed.
+func (h *healthTracker) updateDeviceHealth(deviceName string, status kubeletplugin.HealthStatus, message string) (changed bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.devices == nil {
+		return false
+	}
+	entry, known := h.devices[deviceName]
+	if !known {
+		return false
+	}
+	changed = entry.status != status || entry.message != message
+	entry.status = status
+	entry.message = message
+	return changed
+}
+
+// markDevicesHealth updates the health of every device in deviceNames and
+// notifies subscribers once for the whole batch. Unknown devices are ignored so a
+// caller passing through a claim's allocation results cannot populate the health
+// map with devices from a different driver/pool.
+func (cp *CPUDriver) markDevicesHealth(logger logr.Logger, deviceNames []string, status kubeletplugin.HealthStatus, message string) {
+	anyChanged := false
+	for _, name := range deviceNames {
+		if changed := cp.health.updateDeviceHealth(name, status, message); changed {
+			logger.V(2).Info("device health changed", "device", name, "health", status, "message", message)
+			anyChanged = true
+		}
+	}
+	if anyChanged {
+		cp.notifyHealthClients()
+	}
+}
+
+// buildHealthReport snapshots the health of every device this driver
+// manages. All devices are published under a single pool named after this
+// node (see PublishResources), so PoolName is always cp.nodeName.
+func (cp *CPUDriver) buildHealthReport() kubeletplugin.DeviceHealthReport {
+	h := &cp.health
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if h.devices == nil {
+		return kubeletplugin.DeviceHealthReport{Devices: []kubeletplugin.DeviceHealth{}}
+	}
+
+	devices := make([]kubeletplugin.DeviceHealth, 0, len(h.devices))
+	for name, entry := range h.devices {
+		devices = append(devices, kubeletplugin.DeviceHealth{
+			PoolName:           cp.nodeName,
+			DeviceName:         name,
+			Health:             entry.status,
+			LastUpdated:        time.Now(),
+			HealthCheckTimeout: 2 * healthResendInterval,
+			Message:            entry.message,
+		})
+	}
+	return kubeletplugin.DeviceHealthReport{Devices: devices}
+}
+
+// notifyHealthClients pushes the current health snapshot to every active
+// WatchHealthStatus subscriber. Sends are best-effort. A subscriber whose
+// channel is full will simply pick up the next periodic resend instead of
+// blocking the caller that triggered the change.
+func (cp *CPUDriver) notifyHealthClients() {
+	report := cp.buildHealthReport()
+
+	h := &cp.health
+	h.clientsMu.RLock()
+	defer h.clientsMu.RUnlock()
+	for _, ch := range h.clients {
+		select {
+		case ch <- report:
+		default:
+		}
+	}
+}
+
+// healthResendLoop periodically resends the full health snapshot so that
+// the kubelet's per-device lease (HealthCheckTimeout) never expires while
+// the driver is healthy and simply has nothing new to report. WatchHealthStatus
+// deliberately does not resend on its own: a wedged driver should decay to
+// Unknown instead of being kept alive artificially.
+func (cp *CPUDriver) healthResendLoop(ctx context.Context) {
+	defer cp.health.wg.Done()
+
+	ticker := time.NewTicker(healthResendInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-cp.health.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cp.notifyHealthClients()
+		}
+	}
+}
+
+// healthClientBufferSize buffers health reports per subscriber to absorb
+// short bursts without blocking. If full, newer reports are dropped.
+// It is an arbitrary small size.
+const healthClientBufferSize = 4
+
+// WatchHealthStatus implements kubeletplugin.DRAPlugin. The kubeletplugin
+// helper calls it whenever the kubelet subscribes to device health updates and
+// takes care of translating the reports produced here into DRAResourceHealth
+// gRPC API that the kubelet supports.
+func (cp *CPUDriver) WatchHealthStatus(ctx context.Context, reports chan<- kubeletplugin.DeviceHealthReport) error {
+	logger := ctxlog.FromContext(ctx)
+	logger.Info("started watching device health updates")
+	defer logger.Info("stopped watching device health updates")
+
+	// Buffered so a burst of markDevicesHealth calls doesn't block on a slow
+	// consumer. notifyHealthClients drops reports rather than blocking.
+	clientCh := make(chan kubeletplugin.DeviceHealthReport, healthClientBufferSize)
+	h := &cp.health
+	h.clientsMu.Lock()
+	h.clients = append(h.clients, clientCh)
+	h.clientsMu.Unlock()
+
+	defer func() {
+		h.clientsMu.Lock()
+		defer h.clientsMu.Unlock()
+		for i, ch := range h.clients {
+			if ch == clientCh {
+				h.clients = append(h.clients[:i], h.clients[i+1:]...)
+				break
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-h.stopCh:
+		return nil
+	case reports <- cp.buildHealthReport():
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-h.stopCh:
+			return nil
+		case report := <-clientCh:
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-h.stopCh:
+				return nil
+			case reports <- report:
+			}
+		}
+	}
+}

--- a/pkg/driver/health_test.go
+++ b/pkg/driver/health_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+)
+
+func newHealthTestDriver(deviceNames ...string) *CPUDriver {
+	cp := &CPUDriver{
+		driverName: testDriverName,
+		nodeName:   testNodeName,
+		health:     newHealthTracker(),
+	}
+	for _, name := range deviceNames {
+		cp.health.devices[name] = &deviceHealthEntry{status: kubeletplugin.HealthStatusHealthy, message: "device initialized"}
+	}
+	return cp
+}
+
+func TestMarkDevicesHealth(t *testing.T) {
+	logger := testr.New(t)
+
+	t.Run("unknown device is ignored", func(t *testing.T) {
+		cp := newHealthTestDriver("cpudev0")
+		cp.markDevicesHealth(logger, []string{"does-not-exist"}, kubeletplugin.HealthStatusUnhealthy, "boom")
+		_, ok := cp.health.devices["does-not-exist"]
+		assert.False(t, ok, "unknown device must not be added to the health map")
+	})
+
+	t.Run("known device is updated and change is reported", func(t *testing.T) {
+		cp := newHealthTestDriver("cpudev0")
+		clientCh := make(chan kubeletplugin.DeviceHealthReport, 1)
+		cp.health.clientsMu.Lock()
+		cp.health.clients = append(cp.health.clients, clientCh)
+		cp.health.clientsMu.Unlock()
+
+		cp.markDevicesHealth(logger, []string{"cpudev0"}, kubeletplugin.HealthStatusUnhealthy, "cdi write failed")
+
+		entry := cp.health.devices["cpudev0"]
+		require.Equal(t, kubeletplugin.HealthStatusUnhealthy, entry.status)
+		require.Equal(t, "cdi write failed", entry.message)
+
+		select {
+		case report := <-clientCh:
+			require.Len(t, report.Devices, 1)
+			assert.Equal(t, "cpudev0", report.Devices[0].DeviceName)
+			assert.Equal(t, testNodeName, report.Devices[0].PoolName)
+			assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health)
+			assert.Equal(t, "cdi write failed", report.Devices[0].Message)
+		default:
+			t.Fatal("expected a health report to be sent to the client channel")
+		}
+	})
+
+	t.Run("no-op update does not notify clients", func(t *testing.T) {
+		cp := newHealthTestDriver("cpudev0")
+		clientCh := make(chan kubeletplugin.DeviceHealthReport, 1)
+		cp.health.clientsMu.Lock()
+		cp.health.clients = append(cp.health.clients, clientCh)
+		cp.health.clientsMu.Unlock()
+
+		// Same status and message as the initial state set by newHealthTestDriver.
+		cp.markDevicesHealth(logger, []string{"cpudev0"}, kubeletplugin.HealthStatusHealthy, "device initialized")
+
+		select {
+		case <-clientCh:
+			t.Fatal("did not expect a health report for a no-op update")
+		default:
+		}
+	})
+}
+
+func TestBuildHealthReport(t *testing.T) {
+	cp := newHealthTestDriver("cpudev0", "cpudev1")
+	cp.markDevicesHealth(testr.New(t), []string{"cpudev1"}, kubeletplugin.HealthStatusUnhealthy, "broken")
+
+	report := cp.buildHealthReport()
+	require.Len(t, report.Devices, 2)
+
+	byName := map[string]kubeletplugin.DeviceHealth{}
+	for _, d := range report.Devices {
+		byName[d.DeviceName] = d
+	}
+
+	assert.Equal(t, kubeletplugin.HealthStatusHealthy, byName["cpudev0"].Health)
+	assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, byName["cpudev1"].Health)
+	assert.Equal(t, "broken", byName["cpudev1"].Message)
+	for _, d := range report.Devices {
+		assert.Equal(t, testNodeName, d.PoolName)
+	}
+}
+
+func TestWatchHealthStatus(t *testing.T) {
+	cp := newHealthTestDriver("cpudev0")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	reports := make(chan kubeletplugin.DeviceHealthReport)
+	var watchErr error
+	go func() {
+		defer wg.Done()
+		watchErr = cp.WatchHealthStatus(ctx, reports)
+	}()
+
+	// The first report sent must be a full snapshot of the initial state.
+	select {
+	case report := <-reports:
+		require.Len(t, report.Devices, 1)
+		assert.Equal(t, kubeletplugin.HealthStatusHealthy, report.Devices[0].Health)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the initial health report")
+	}
+
+	// A subsequent health change must be streamed too.
+	go cp.markDevicesHealth(testr.New(t), []string{"cpudev0"}, kubeletplugin.HealthStatusUnhealthy, "device fault")
+
+	select {
+	case report := <-reports:
+		require.Len(t, report.Devices, 1)
+		assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health)
+		assert.Equal(t, "device fault", report.Devices[0].Message)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the updated health report")
+	}
+
+	cp.health.clientsMu.RLock()
+	numClients := len(cp.health.clients)
+	cp.health.clientsMu.RUnlock()
+	require.Equal(t, 1, numClients, "expected exactly one registered health client while WatchHealthStatus is running")
+
+	cancel()
+	wg.Wait()
+	require.NoError(t, watchErr)
+
+	cp.health.clientsMu.RLock()
+	numClients = len(cp.health.clients)
+	cp.health.clientsMu.RUnlock()
+	assert.Equal(t, 0, numClients, "expected the health client to be unregistered after WatchHealthStatus returns")
+}
+
+func TestWatchHealthStatusStopsOnDriverStop(t *testing.T) {
+	cp := newHealthTestDriver("cpudev0")
+	reports := make(chan kubeletplugin.DeviceHealthReport)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cp.WatchHealthStatus(context.Background(), reports)
+	}()
+
+	// Drain the initial report so WatchHealthStatus reaches its main loop.
+	select {
+	case <-reports:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the initial health report")
+	}
+
+	close(cp.health.stopCh)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WatchHealthStatus did not return after stopHealthCh was closed")
+	}
+}
+
+func TestHealthResendLoop(t *testing.T) {
+	originalInterval := healthResendInterval
+	healthResendInterval = 10 * time.Millisecond
+	defer func() { healthResendInterval = originalInterval }()
+
+	cp := newHealthTestDriver("cpudev0")
+	clientCh := make(chan kubeletplugin.DeviceHealthReport, 1)
+	cp.health.clientsMu.Lock()
+	cp.health.clients = append(cp.health.clients, clientCh)
+	cp.health.clientsMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cp.health.wg.Add(1)
+	go cp.healthResendLoop(ctx)
+
+	select {
+	case report := <-clientCh:
+		require.Len(t, report.Devices, 1)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a periodic health resend")
+	}
+
+	cancel()
+	cp.health.wg.Wait()
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it
This implements device health reporting using the WatchHealthStatus kubelet plugin API added by
k/k [#139477](https://github.com/kubernetes/kubernetes/pull/139477). The idea (as described in #218) was to give users better visibility into failing devices without getting lost in the logs of driver.

#### Which issue(s) this PR is related to
Fixes: #218 

#### Special notes for reviewers

#### Release note
```release-note
Add per-device health reporting: the driver now reports device health (Healthy/Unknown) via the kubelet's WatchHealthStatus API, visible in`pod.status.containerStatuses[].allocatedResourcesStatus`. Unhealthy is not reported yet
```

#### Documentation updates
- README updates

