### PR TITLE
Validate grouped duplicate Prepare allocation equivalence

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -113,6 +113,11 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 
 	if existingCPUs, ok := cp.cpuAllocationStore.GetResourceClaimAllocation(claim.UID); ok {
 		logger.V(2).Info("claim already has allocated CPUs in store, reusing assignment", "cpus", existingCPUs.String())
+		if err := cp.validateGroupedAllocationForReuse(logger, claim, existingCPUs); err != nil {
+			return kubeletplugin.PrepareResult{
+				Err: fmt.Errorf("claim %s/%s is already prepared with CPUs %s which do not match the current allocation: %w", claim.Namespace, claim.Name, existingCPUs.String(), err),
+			}
+		}
 		// Even if the claim is already allocated in our in-memory store (which happens when a duplicate prepare
 		// call is invoked without an intermediate unprepare), we must call prepareDevices and return the result back to Kubelet.
 		// If the CDI file is already created on disk, the CDI manager will safely overwrite it with the same configuration.
@@ -194,6 +199,105 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 	cp.metricsRecorder().RecordClaimAllocatedCPUs(cpuAssignment.Size())
 	cp.refreshAllocationMetrics()
 	return result
+}
+
+func (cp *CPUDriver) validateGroupedAllocationForReuse(logger logr.Logger, claim *resourceapi.ResourceClaim, existingCPUs cpuset.CPUSet) error {
+	type boundaryAllocation struct {
+		name string
+		cpus cpuset.CPUSet
+	}
+
+	requestedByBoundary := make(map[int]int64)
+	boundaries := make(map[int]boundaryAllocation)
+	machineAssignment := cpuset.New()
+	driverAllocations := 0
+
+	for _, alloc := range claim.Status.Allocation.Devices.Results {
+		if alloc.Driver != cp.driverName {
+			continue
+		}
+		driverAllocations++
+
+		quantity, ok := alloc.ConsumedCapacity[device.CPUResourceQualifiedName]
+		if !ok {
+			return fmt.Errorf("allocation for device %q has no %q capacity", alloc.Device, device.CPUResourceQualifiedName)
+		}
+		if quantity.Sign() <= 0 {
+			return fmt.Errorf("CPU capacity for device %q must be positive, got %s", alloc.Device, quantity.String())
+		}
+		count := quantity.Value()
+		if quantity.CmpInt64(count) != 0 {
+			return fmt.Errorf("CPU capacity for device %q must be a whole number, got %s", alloc.Device, quantity.String())
+		}
+
+		switch cp.cpuDeviceGroupBy {
+		case device.GROUP_BY_SOCKET:
+			socketID, ok := cp.deviceNameToSocketID[alloc.Device]
+			if !ok {
+				return fmt.Errorf("no valid socket ID found for device %s", alloc.Device)
+			}
+			requestedByBoundary[socketID] += count
+			boundaries[socketID] = boundaryAllocation{
+				name: fmt.Sprintf("socket %d", socketID),
+				cpus: cp.cpuTopology.CPUDetails.CPUsInSockets(socketID),
+			}
+		case device.GROUP_BY_NUMA_NODE:
+			numaNodeID, ok := cp.deviceNameToNUMANodeID[alloc.Device]
+			if !ok {
+				return fmt.Errorf("no valid NUMA node ID found for device %s", alloc.Device)
+			}
+			requestedByBoundary[numaNodeID] += count
+			boundaries[numaNodeID] = boundaryAllocation{
+				name: fmt.Sprintf("NUMA node %d", numaNodeID),
+				cpus: cp.cpuTopology.CPUDetails.CPUsInNUMANodes(numaNodeID),
+			}
+		case device.GROUP_BY_MACHINE:
+			if alloc.Device != device.CPUDeviceMachineGrouped {
+				return fmt.Errorf("invalid machine device %q", alloc.Device)
+			}
+			opaqueCPUSet, ok, err := cp.getOpaqueCPUSet(logger, claim.Status.Allocation, alloc)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("no opaque cpuset configuration found for allocation request %q", alloc.Request)
+			}
+
+			otherClaimCPUs := cp.cpuAllocationStore.GetAllocatedCPUs().Difference(existingCPUs)
+			if err := cp.validateOpaqueCPUSetAgainstAllocations(opaqueCPUSet, cp.onlineCPUs, machineAssignment, count, otherClaimCPUs); err != nil {
+				return err
+			}
+			machineAssignment = machineAssignment.Union(opaqueCPUSet)
+		default:
+			return fmt.Errorf("unsupported CPU grouping %q", cp.cpuDeviceGroupBy)
+		}
+	}
+
+	if driverAllocations == 0 {
+		return fmt.Errorf("claim has no CPU allocations for driver %q", cp.driverName)
+	}
+
+	if cp.cpuDeviceGroupBy == device.GROUP_BY_MACHINE {
+		if !machineAssignment.Equals(existingCPUs) {
+			return fmt.Errorf("opaque cpuset %s does not match prepared CPUs %s", machineAssignment.String(), existingCPUs.String())
+		}
+		return nil
+	}
+
+	matchedCPUs := cpuset.New()
+	for boundaryID, requested := range requestedByBoundary {
+		boundary := boundaries[boundaryID]
+		actual := existingCPUs.Intersection(boundary.cpus)
+		if int64(actual.Size()) != requested {
+			return fmt.Errorf("%s allocation requests %d CPUs but prepared CPUs contain %d", boundary.name, requested, actual.Size())
+		}
+		matchedCPUs = matchedCPUs.Union(actual)
+	}
+	if !matchedCPUs.Equals(existingCPUs) {
+		return fmt.Errorf("prepared CPUs %s are outside the allocated topology boundaries", existingCPUs.Difference(matchedCPUs).String())
+	}
+
+	return nil
 }
 
 func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
@@ -411,6 +515,10 @@ func (cp *CPUDriver) getOpaqueCPUSet(logger logr.Logger, allocation *resourceapi
 }
 
 func (cp *CPUDriver) validateOpaqueCPUSet(opaqueCPUSet cpuset.CPUSet, onlineCPUs cpuset.CPUSet, cpuAssignment cpuset.CPUSet, claimCPUCount int64) error {
+	return cp.validateOpaqueCPUSetAgainstAllocations(opaqueCPUSet, onlineCPUs, cpuAssignment, claimCPUCount, cp.cpuAllocationStore.GetAllocatedCPUs())
+}
+
+func (cp *CPUDriver) validateOpaqueCPUSetAgainstAllocations(opaqueCPUSet cpuset.CPUSet, onlineCPUs cpuset.CPUSet, cpuAssignment cpuset.CPUSet, claimCPUCount int64, allocatedCPUs cpuset.CPUSet) error {
 	// Verify core count matches requested capacity
 	if int64(opaqueCPUSet.Size()) != claimCPUCount {
 		return fmt.Errorf("opaque config cpuset size %d does not match requested capacity %d", opaqueCPUSet.Size(), claimCPUCount)
@@ -436,8 +544,7 @@ func (cp *CPUDriver) validateOpaqueCPUSet(opaqueCPUSet cpuset.CPUSet, onlineCPUs
 	}
 
 	// Verify cores do not overlap with other active claims on this node
-	existingClaimCPUs := cp.cpuAllocationStore.GetAllocatedCPUs()
-	if opaqueCPUSet.Intersection(existingClaimCPUs).Size() > 0 {
+	if opaqueCPUSet.Intersection(allocatedCPUs).Size() > 0 {
 		return fmt.Errorf("requested CPUs %s from opaque config conflict with already allocated claims", opaqueCPUSet.String())
 	}
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -80,6 +80,7 @@ func (m *mockKubeletPlugin) Stop() {}
 
 type mockCdiMgr struct {
 	devices     map[string]string
+	addCalls    int
 	addError    error
 	removeError error
 }
@@ -91,6 +92,7 @@ func newMockCdiMgr() *mockCdiMgr {
 }
 
 func (m *mockCdiMgr) AddDevice(_ logr.Logger, deviceName, envVar string) error {
+	m.addCalls++
 	if m.addError != nil {
 		return m.addError
 	}
@@ -1368,6 +1370,24 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			cdiMgr:                 cdiMgr,
 		}, cpuStore, cdiMgr
 	}
+	makeMachineDriver := func(_ logr.Logger) (*CPUDriver, *store.CPUAllocation, *mockCdiMgr) {
+		cdiMgr := newMockCdiMgr()
+		driver := createCPUDriverForTest(t, devattr.GROUP_BY_MACHINE, mockCPUInfos_DualSocket_4CPUsPerSocket_HT, nil, cpuset.New(), cdiMgr)
+		return driver, driver.cpuAllocationStore, cdiMgr
+	}
+	claimWithQuantity := func(deviceName, quantity string) *resourceapi.ResourceClaim {
+		return testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+			{
+				Driver:  testDriverName,
+				Pool:    testNodeName,
+				Device:  deviceName,
+				Request: string(claimUID),
+				ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
+					devattr.CPUResourceQualifiedName: resource.MustParse(quantity),
+				},
+			},
+		})
+	}
 
 	testCases := []struct {
 		name           string
@@ -1376,6 +1396,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 		secondClaim    *resourceapi.ResourceClaim
 		expectedCPUSet cpuset.CPUSet
 		expectedShared cpuset.CPUSet
+		expectedError  string
 	}{
 		{
 			name:           "same socket repeated",
@@ -1392,6 +1413,59 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket1": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
 			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "socket 1 allocation requests 2 CPUs but prepared CPUs contain 0",
+		},
+		{
+			name:           "different socket capacity repeated",
+			makeDriver:     makeSocketDriver,
+			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
+			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 1}),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "socket 0 allocation requests 1 CPUs but prepared CPUs contain 2",
+		},
+		{
+			name:       "equivalent repeated results for same socket",
+			makeDriver: makeSocketDriver,
+			firstClaim: testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
+			secondClaim: testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+				{
+					Driver:           testDriverName,
+					Pool:             testNodeName,
+					Device:           "cpudevsocket0",
+					Request:          "req-0",
+					ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{devattr.CPUResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
+				},
+				{
+					Driver:           testDriverName,
+					Pool:             testNodeName,
+					Device:           "cpudevsocket0",
+					Request:          "req-1",
+					ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{devattr.CPUResourceQualifiedName: *resource.NewQuantity(1, resource.DecimalSI)},
+				},
+			}),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+		},
+		{
+			name:       "missing socket capacity repeated",
+			makeDriver: makeSocketDriver,
+			firstClaim: testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
+			secondClaim: testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+				{Driver: testDriverName, Pool: testNodeName, Device: "cpudevsocket0", Request: string(claimUID)},
+			}),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "has no \"dra.cpu/cpu\" capacity",
+		},
+		{
+			name:           "fractional socket capacity repeated",
+			makeDriver:     makeSocketDriver,
+			firstClaim:     testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevsocket0": 2}),
+			secondClaim:    claimWithQuantity("cpudevsocket0", "1500m"),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "must be a whole number",
 		},
 		{
 			name:           "same NUMA node repeated",
@@ -1408,6 +1482,42 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{"cpudevnuma1": 2}),
 			expectedCPUSet: cpuset.New(0, 4),
 			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "NUMA node 1 allocation requests 2 CPUs but prepared CPUs contain 0",
+		},
+		{
+			name:           "same machine opaque cpuset repeated",
+			makeDriver:     makeMachineDriver,
+			firstClaim:     testClaimWithOpaqueConfig(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}, "0,4"),
+			secondClaim:    testClaimWithOpaqueConfig(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}, "0,4"),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+		},
+		{
+			name:           "different machine opaque cpuset repeated",
+			makeDriver:     makeMachineDriver,
+			firstClaim:     testClaimWithOpaqueConfig(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}, "0,4"),
+			secondClaim:    testClaimWithOpaqueConfig(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}, "1,5"),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "opaque cpuset 1,5 does not match prepared CPUs 0,4",
+		},
+		{
+			name:           "machine opaque capacity mismatch repeated",
+			makeDriver:     makeMachineDriver,
+			firstClaim:     testClaimWithOpaqueConfig(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}, "0,4"),
+			secondClaim:    testClaimWithOpaqueConfig(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 1}, "0,4"),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "opaque config cpuset size 2 does not match requested capacity 1",
+		},
+		{
+			name:           "missing machine opaque config repeated",
+			makeDriver:     makeMachineDriver,
+			firstClaim:     testClaimWithOpaqueConfig(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}, "0,4"),
+			secondClaim:    testClaim(claimUID, testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}),
+			expectedCPUSet: cpuset.New(0, 4),
+			expectedShared: cpuset.New(1, 2, 3, 5, 6, 7),
+			expectedError:  "is targeted by 0 configurations",
 		},
 	}
 
@@ -1415,8 +1525,9 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			driver, cpuStore, cdiMgr := tc.makeDriver(logger)
 
-			_, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.firstClaim})
+			firstResults, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.firstClaim})
 			require.NoError(t, err)
+			require.NoError(t, firstResults[claimUID].Err)
 
 			gotCPUsAfterFirst, ok := cpuStore.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)
@@ -1425,7 +1536,13 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 
 			prepareResults, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{tc.secondClaim})
 			require.NoError(t, err)
-			require.NoError(t, prepareResults[claimUID].Err)
+			if tc.expectedError == "" {
+				require.NoError(t, prepareResults[claimUID].Err)
+				require.Equal(t, 2, cdiMgr.addCalls, "equivalent duplicate prepare must recreate CDI state")
+			} else {
+				require.ErrorContains(t, prepareResults[claimUID].Err, tc.expectedError)
+				require.Equal(t, 1, cdiMgr.addCalls, "mismatched duplicate prepare must not recreate CDI state")
+			}
 
 			gotCPUs, ok := cpuStore.GetResourceClaimAllocation(claimUID)
 			require.True(t, ok)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Grouped mode currently reuses the CPU assignment stored for a claim UID before validating the allocation in the duplicate `PrepareResourceClaims` request. A stale or malformed allocation can therefore succeed and regenerate CDI state for CPUs selected from an earlier allocation.

This PR validates the current grouped allocation before reusing stored CPUs:

- socket and NUMA grouping aggregate consumed CPU capacity per topology boundary and require the stored CPU set to match those boundaries exactly;
- machine grouping parses and validates each opaque cpuset, excludes the current claim from active-allocation conflict checks, and requires the reconstructed cpuset to equal the stored assignment;
- missing, fractional, non-positive, or otherwise malformed duplicate capacities fail closed;
- failed equivalence checks return before CDI state is rewritten and leave the CPU allocation store unchanged.

Equivalent duplicate Prepare calls remain idempotent and still recreate CDI state as before.

#### Which issue(s) this PR is related to

Fixes #250

#### Special notes for reviewers

Allocation equivalence is semantic rather than a byte-for-byte comparison of `AllocationResult`: repeated results for the same socket or NUMA device are equivalent when their aggregate capacity matches the stored CPUs in that boundary.

PR #247 adds the same positive whole-capacity checks to the initial grouped Prepare path. This PR keeps the duplicate-Prepare fix independently reviewable and applies those checks only while validating reuse; after #247 merges, the small shared validation can be consolidated during rebase if desired.

Validation performed:

- `make test-unit`
- `make lint`
- `make modernize`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make build`
- `uvx pre-commit run --all-files` (all hooks pass except the existing darwin `dracputester` no-main build-tag issue)
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 uvx pre-commit run go-build-mod --all-files`

#### Release note

```release-note
Reject mismatched grouped-mode duplicate Prepare calls instead of reusing stale CPU assignments.
```

#### Documentation updates

NONE
