### PR TITLE
codeorg: simplify futher CPUEnumerator

### DIFF
--- a/pkg/device/builder.go
+++ b/pkg/device/builder.go
@@ -38,63 +38,35 @@ const (
 	CPUDeviceMachineGrouped      = "cpudevmachine"
 )
 
-type CPUEnumerator struct {
-	topo           *cpuinfo.CPUTopology
-	pcieRootMapper *store.PCIeRootMapper
-	deviceInfos    []cpuDeviceInfo
-}
+// DeviceBuilderFunc produces DRA device objects and the device-name-to-device-id mapping.
+// The mapping is needed at claim preparation time to resolve internal devices.
+type DeviceBuilderFunc func(logger logr.Logger) ([]resourceapi.Device, map[string]int)
 
-func NewCPUEnumerator(topo *cpuinfo.CPUTopology, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) *CPUEnumerator {
-	return &CPUEnumerator{
-		topo:           topo,
-		pcieRootMapper: pcieRootMapper,
-		deviceInfos:    cpuDeviceInfos(topo, reservedCPUSet),
-	}
-}
-
-func (en *CPUEnumerator) MapDeviceNamesToIDs() map[string]int {
-	deviceNameToDeviceID := make(map[string]int)
-	for _, dev := range en.deviceInfos {
-		deviceNameToDeviceID[dev.name] = dev.cpu.CpuID
-	}
-	return deviceNameToDeviceID
-}
-
-func (en *CPUEnumerator) CreateDevices(_ logr.Logger) []resourceapi.Device {
-	return createCPUDeviceSlices(en.deviceInfos, en.pcieRootMapper, en.topo.SMTEnabled)
-}
-
-type GroupedEnumerator struct {
-	groupBy        string
-	topo           *cpuinfo.CPUTopology
-	pcieRootMapper *store.PCIeRootMapper
-	deviceInfos    []groupedCPUDeviceInfo
-}
-
-func NewGroupedEnumerator(groupBy string, topo *cpuinfo.CPUTopology, onlineCPUs, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) *GroupedEnumerator {
-	return &GroupedEnumerator{
-		groupBy:        groupBy,
-		topo:           topo,
-		pcieRootMapper: pcieRootMapper,
-		deviceInfos:    groupedCPUDeviceInfos(groupBy, topo, onlineCPUs, reservedCPUSet),
-	}
-}
-
-func (en *GroupedEnumerator) MapDeviceNamesToIDs() map[string]int {
-	deviceNameToDeviceID := make(map[string]int)
-	for _, dev := range en.deviceInfos {
-		switch en.groupBy {
-		case GROUP_BY_SOCKET:
-			deviceNameToDeviceID[dev.name] = dev.socketID
-		case GROUP_BY_NUMA_NODE:
-			deviceNameToDeviceID[dev.name] = dev.numaNodeID
+func NewDeviceBuilder(topo *cpuinfo.CPUTopology, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) DeviceBuilderFunc {
+	deviceInfos := cpuDeviceInfos(topo, reservedCPUSet)
+	return func(_ logr.Logger) ([]resourceapi.Device, map[string]int) {
+		nameToID := make(map[string]int)
+		for _, dev := range deviceInfos {
+			nameToID[dev.name] = dev.cpu.CpuID
 		}
+		return createCPUDeviceSlices(deviceInfos, pcieRootMapper, topo.SMTEnabled), nameToID
 	}
-	return deviceNameToDeviceID
 }
 
-func (en *GroupedEnumerator) CreateDevices(logger logr.Logger) []resourceapi.Device {
-	return createGroupedCPUDeviceSlices(logger, en.groupBy, en.deviceInfos, en.pcieRootMapper, en.topo.SMTEnabled)
+func NewGroupedDeviceBuilder(groupBy string, topo *cpuinfo.CPUTopology, onlineCPUs, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) DeviceBuilderFunc {
+	deviceInfos := groupedCPUDeviceInfos(groupBy, topo, onlineCPUs, reservedCPUSet)
+	return func(logger logr.Logger) ([]resourceapi.Device, map[string]int) {
+		nameToID := make(map[string]int)
+		for _, dev := range deviceInfos {
+			switch groupBy {
+			case GROUP_BY_SOCKET:
+				nameToID[dev.name] = dev.socketID
+			case GROUP_BY_NUMA_NODE:
+				nameToID[dev.name] = dev.numaNodeID
+			}
+		}
+		return createGroupedCPUDeviceSlices(logger, groupBy, deviceInfos, pcieRootMapper, topo.SMTEnabled), nameToID
+	}
 }
 
 type groupedCPUDeviceInfo struct {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -67,11 +67,6 @@ type CPUInfoProvider interface {
 	GetCPUTopology(logger logr.Logger) (*cpuinfo.CPUTopology, error)
 }
 
-type CPUEnumerator interface {
-	MapDeviceNamesToIDs() map[string]int
-	CreateDevices(logger logr.Logger) []resourceapi.Device
-}
-
 // CPUDriver is the structure that holds all the driver runtime information.
 type CPUDriver struct {
 	driverName              string
@@ -190,21 +185,25 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 	plugin.refreshAllocationMetrics()
 	plugin.podConfigStore = store.NewPodConfig()
 
-	var cpuEnum CPUEnumerator
+	var buildDevices device.DeviceBuilderFunc
 	if plugin.cpuDeviceMode == device.CPU_DEVICE_MODE_GROUPED {
-		cpuEnum = device.NewGroupedEnumerator(plugin.cpuDeviceGroupBy, plugin.cpuTopology, plugin.onlineCPUs, plugin.reservedCPUs, plugin.pcieRootMapper)
-		switch plugin.cpuDeviceGroupBy {
-		case device.GROUP_BY_SOCKET:
-			plugin.deviceNameToSocketID = cpuEnum.MapDeviceNamesToIDs()
-		case device.GROUP_BY_NUMA_NODE:
-			plugin.deviceNameToNUMANodeID = cpuEnum.MapDeviceNamesToIDs()
-		}
+		buildDevices = device.NewGroupedDeviceBuilder(plugin.cpuDeviceGroupBy, plugin.cpuTopology, plugin.onlineCPUs, plugin.reservedCPUs, plugin.pcieRootMapper)
 	} else {
-		cpuEnum = device.NewCPUEnumerator(plugin.cpuTopology, plugin.reservedCPUs, plugin.pcieRootMapper)
-		plugin.deviceNameToCPUID = cpuEnum.MapDeviceNamesToIDs()
+		buildDevices = device.NewDeviceBuilder(plugin.cpuTopology, plugin.reservedCPUs, plugin.pcieRootMapper)
 	}
 
-	devices := cpuEnum.CreateDevices(logger)
+	devices, nameToID := buildDevices(logger)
+
+	if plugin.cpuDeviceMode == device.CPU_DEVICE_MODE_GROUPED {
+		switch plugin.cpuDeviceGroupBy {
+		case device.GROUP_BY_SOCKET:
+			plugin.deviceNameToSocketID = nameToID
+		case device.GROUP_BY_NUMA_NODE:
+			plugin.deviceNameToNUMANodeID = nameToID
+		}
+	} else {
+		plugin.deviceNameToCPUID = nameToID
+	}
 
 	if len(devices) > 0 {
 		// Chunk devices into slices of at most devicesPerResourceSlice


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it

in commit be6a4d3f6cb472c769a2c1b9f9acd7ea4bd96a55 we introduced the cpuenumerator abstraction to split the CPUDriver god object. This entity was in charge of building the DRA devices.

At time, the attempt followed the natural seams and split a big object along the easiest fracture lines, but the abstraction was still clunky and kinda artificial.

The way we use this code is in the setup flow; this is a data transformation code with no real state - and its state we throw it away anyway. From this awkward split it also stemmed the hard-to-document `MapDeviceNamesToIDs` method.

The best and natural shape for this code is a function. In this commit we simplify the code further dropping the interface and temp objects; we just use closures and functions.

This further refactoring also couples the map and the devices, which is more natural; the code is now equally loosely coupled but more cohesive, better documented and yet with less pressing documentation needs.

#### Which issue(s) this PR is related to

N/A

#### Special notes for reviewers

N/A

#### Release note

```release-note
NONE
```

#### Documentation updates

N/A