### PR TITLE
Handle SIGTERM for graceful shutdown

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -180,17 +180,11 @@ func run(logger logr.Logger, cfg driverconfig.Config) error {
 		return fmt.Errorf("can not obtain the node name, use the hostname-override flag if you want to set it to a specific value: %w", err)
 	}
 
-	// trap Ctrl+C and call cancel on the context
+	// Cancel the context on interactive interruption (SIGINT) or the default Pod
+	// stop signal (SIGTERM), so a normal termination runs the graceful shutdown.
 	ctx := ctxlog.NewContext(context.Background(), logger)
-	ctx, cancel := context.WithCancel(ctx)
-
-	// Enable signal handler
-	signalCh := make(chan os.Signal, 2)
-	defer func() {
-		close(signalCh)
-		cancel()
-	}()
-	signal.Notify(signalCh, os.Interrupt, unix.SIGINT)
+	ctx, stop := signal.NotifyContext(ctx, unix.SIGINT, unix.SIGTERM)
+	defer stop()
 
 	driverConfig := driver.Config{
 		DriverName:       driverName,
@@ -220,13 +214,13 @@ func run(logger logr.Logger, cfg driverconfig.Config) error {
 	var fatalErr error
 
 	select {
-	case <-signalCh:
-		logger.Info("exiting", "reason", "received signal")
-		cancel()
 	case <-ctx.Done():
-		logger.Info("exiting", "reason", "context cancelled")
+		// Restore the default signal behavior as soon as we start exiting, so a
+		// second signal can force termination if graceful cleanup gets stuck.
+		stop()
+		logger.Info("exiting", "reason", "received signal")
 	case err := <-asyncErr:
-		cancel()
+		stop()
 		fatalErr = fmt.Errorf("NRI driver error: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #253.

The driver registered `signal.Notify(signalCh, os.Interrupt, unix.SIGINT)`; on Unix both arguments denote SIGINT, so SIGTERM was never handled. SIGTERM is the default stop signal for a normal Pod termination (rollout, drain, delete) when no custom stop signal is configured, so the process was killed by the default disposition before the graceful shutdown ran — the DRA plugin stop, its socket cleanup, and the HTTP server shutdown.

This switches to `signal.NotifyContext(ctx, unix.SIGINT, unix.SIGTERM)`, covering interactive interruption and the default Pod stop signal. After either the signal or the async-error path wakes the main loop, the default signal behavior is restored (`stop()`) before graceful cleanup, so a second signal can still force termination if cleanup gets stuck. It also drops the manual signal channel, which was closed without a preceding `signal.Stop`.

Following @ffromani's note in #253 (register SIGINT once, add SIGTERM, move to `NotifyContext`).

#### Special notes for reviewers

No behavior change on SIGINT (Ctrl+C) or on the NRI async-error path: both still cancel the context and run the graceful shutdown. The startup window before the handler is installed is unchanged and out of scope here.

#### Release note

```release-note
dra-driver-cpu: handle SIGTERM so a normal Pod termination runs the driver's graceful shutdown instead of killing the process abruptly.
```
