### PR TITLE
codeorg: device: builder: remove closure

### DIFF
--- a/pkg/device/builder.go
+++ b/pkg/device/builder.go
@@ -38,35 +38,27 @@ const (
 	CPUDeviceMachineGrouped      = "cpudevmachine"
 )
 
-// DeviceBuilderFunc produces DRA device objects and the device-name-to-device-id mapping.
-// The mapping is needed at claim preparation time to resolve internal devices.
-type DeviceBuilderFunc func(logger logr.Logger) ([]resourceapi.Device, map[string]int)
-
-func NewDeviceBuilder(topo *cpuinfo.CPUTopology, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) DeviceBuilderFunc {
+func Build(topo *cpuinfo.CPUTopology, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) ([]resourceapi.Device, map[string]int) {
 	deviceInfos := cpuDeviceInfos(topo, reservedCPUSet)
-	return func(_ logr.Logger) ([]resourceapi.Device, map[string]int) {
-		nameToID := make(map[string]int)
-		for _, dev := range deviceInfos {
-			nameToID[dev.name] = dev.cpu.CpuID
-		}
-		return createCPUDeviceSlices(deviceInfos, pcieRootMapper, topo.SMTEnabled), nameToID
+	nameToID := make(map[string]int)
+	for _, dev := range deviceInfos {
+		nameToID[dev.name] = dev.cpu.CpuID
 	}
+	return createCPUDeviceSlices(deviceInfos, pcieRootMapper, topo.SMTEnabled), nameToID
 }
 
-func NewGroupedDeviceBuilder(groupBy string, topo *cpuinfo.CPUTopology, onlineCPUs, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) DeviceBuilderFunc {
+func BuildGrouped(logger logr.Logger, groupBy string, topo *cpuinfo.CPUTopology, onlineCPUs, reservedCPUSet cpuset.CPUSet, pcieRootMapper *store.PCIeRootMapper) ([]resourceapi.Device, map[string]int) {
 	deviceInfos := groupedCPUDeviceInfos(groupBy, topo, onlineCPUs, reservedCPUSet)
-	return func(logger logr.Logger) ([]resourceapi.Device, map[string]int) {
-		nameToID := make(map[string]int)
-		for _, dev := range deviceInfos {
-			switch groupBy {
-			case GROUP_BY_SOCKET:
-				nameToID[dev.name] = dev.socketID
-			case GROUP_BY_NUMA_NODE:
-				nameToID[dev.name] = dev.numaNodeID
-			}
+	nameToID := make(map[string]int)
+	for _, dev := range deviceInfos {
+		switch groupBy {
+		case GROUP_BY_SOCKET:
+			nameToID[dev.name] = dev.socketID
+		case GROUP_BY_NUMA_NODE:
+			nameToID[dev.name] = dev.numaNodeID
 		}
-		return createGroupedCPUDeviceSlices(logger, groupBy, deviceInfos, pcieRootMapper, topo.SMTEnabled), nameToID
 	}
+	return createGroupedCPUDeviceSlices(logger, groupBy, deviceInfos, pcieRootMapper, topo.SMTEnabled), nameToID
 }
 
 type groupedCPUDeviceInfo struct {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -185,16 +185,11 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 	plugin.refreshAllocationMetrics()
 	plugin.podConfigStore = store.NewPodConfig()
 
-	var buildDevices device.DeviceBuilderFunc
-	if plugin.cpuDeviceMode == device.CPU_DEVICE_MODE_GROUPED {
-		buildDevices = device.NewGroupedDeviceBuilder(plugin.cpuDeviceGroupBy, plugin.cpuTopology, plugin.onlineCPUs, plugin.reservedCPUs, plugin.pcieRootMapper)
-	} else {
-		buildDevices = device.NewDeviceBuilder(plugin.cpuTopology, plugin.reservedCPUs, plugin.pcieRootMapper)
-	}
-
-	devices, nameToID := buildDevices(logger)
+	var devices []resourceapi.Device
 
 	if plugin.cpuDeviceMode == device.CPU_DEVICE_MODE_GROUPED {
+		var nameToID map[string]int
+		devices, nameToID = device.BuildGrouped(logger, plugin.cpuDeviceGroupBy, plugin.cpuTopology, plugin.onlineCPUs, plugin.reservedCPUs, plugin.pcieRootMapper)
 		switch plugin.cpuDeviceGroupBy {
 		case device.GROUP_BY_SOCKET:
 			plugin.deviceNameToSocketID = nameToID
@@ -202,7 +197,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 			plugin.deviceNameToNUMANodeID = nameToID
 		}
 	} else {
-		plugin.deviceNameToCPUID = nameToID
+		devices, plugin.deviceNameToCPUID = device.Build(plugin.cpuTopology, plugin.reservedCPUs, plugin.pcieRootMapper)
 	}
 
 	if len(devices) > 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it
Following up 2d9e2e3 we use a closure immediately; we can therefore remove an indirection layer, and a type as we don't need to carry context.

There's further refactoring potential down the road: we can probably unify the device->id map instead of having 3 mutually exclusive variants, and the relevant number of parameters of device builders suggest we are operating at the wrong abstraction layer - topology, reserved, online cpu and the pcie root mapper probably belong together on a system hw view. This API shape hasn't clearly emerged yet, so we abstain from further cleanup yet.

#### Which issue(s) this PR is related to
N/A

#### Special notes for reviewers
Suggested in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/252#issuecomment-5104513350
