### PR TITLE
WIP: RFC: add Introspect config mode

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -77,7 +77,16 @@ func printRootUsage(fs *flag.FlagSet) {
 		commandName = "dracpu"
 	}
 
-	fmt.Fprintf(fs.Output(), "Usage:\n  %s [flags]\n  %s gatherinfo [flags]\n  %s introspect metrics\n\nCompatibility paths:\n  dracpu-gatherinfo [flags]\n\nFlags:\n", commandName, commandName, commandName)
+	fmt.Fprintf(fs.Output(), `Usage:
+%s [flags]
+%s gatherinfo [flags]
+%s introspect metrics
+
+Compatibility paths:
+dracpu-gatherinfo [flags]
+
+Flags:
+`, commandName, commandName, commandName)
 	fs.PrintDefaults()
 }
 

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -80,7 +80,7 @@ func printRootUsage(fs *flag.FlagSet) {
 	fmt.Fprintf(fs.Output(), `Usage:
 %s [flags]
 %s gatherinfo [flags]
-%s introspect metrics
+%s introspect [metrics|config]
 
 Compatibility paths:
 dracpu-gatherinfo [flags]

--- a/internal/driverconfig/config.go
+++ b/internal/driverconfig/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driverconfig
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"sigs.k8s.io/yaml"
@@ -76,4 +77,28 @@ func (c Config) Dump() string {
 		return fmt.Sprintf("<!!! FAILED TO MARSHAL Config: %v !!!>", err)
 	}
 	return string(out)
+}
+
+// DumpFile renders the Config as YAML accepted back by as configuration file.
+// Add versioning, hardcoding the most recent, and removes fields which
+// the configuration file is not allowed to set.
+func (c Config) DumpAsFile() (string, error) {
+	data, err := json.Marshal(dumpConfig(c))
+	if err != nil {
+		return "", err
+	}
+	fields := map[string]any{}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return "", err
+	}
+	for excluded := range schemaExcludedFields {
+		delete(fields, excluded)
+	}
+	fields["apiVersion"] = ConfigAPIVersion
+
+	out, err := yaml.Marshal(fields)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -681,6 +681,40 @@ func TestResolve_KubeletRootDirWithAConfigFile(t *testing.T) {
 	}
 }
 
+// TestDumpFile_RoundTrips feeds DumpFile's own output back through FromFile:
+// it must be accepted (none of the excluded fields leak in) and reproduce the
+// non-excluded fields unchanged.
+func TestDumpFile_RoundTrips(t *testing.T) {
+	cfg := driverconfig.Default()
+	cfg.ReservedCPUs = "0-3"
+	cfg.CPUDeviceMode = "individual"
+	cfg.BindAddress = ":9999"           // excluded: must not round-trip
+	cfg.ExposePCIeRoots = true          // excluded: must not round-trip
+	cfg.KubeletRootDir = "/mnt/kubelet" // excluded: must not round-trip
+
+	dir := t.TempDir()
+	out, err := cfg.DumpAsFile()
+	require.NoError(t, err)
+	cfgFile := writeFile(t, dir, "config.yaml", out)
+
+	result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, cfg.ReservedCPUs, result.ReservedCPUs)
+	assert.Equal(t, cfg.CPUDeviceMode, result.CPUDeviceMode)
+	assert.Equal(t, cfg.GroupBy, result.GroupBy)
+	assert.Equal(t, cfg.Kubeconfig, result.Kubeconfig)
+	assert.Equal(t, cfg.HostnameOverride, result.HostnameOverride)
+	assert.Equal(t, cfg.SysFSOverlay, result.SysFSOverlay)
+	// Excluded fields come back from Default(), not from cfg, since DumpFile
+	// must have dropped them from the file.
+	assert.Equal(t, driverconfig.Default().BindAddress, result.BindAddress)
+	assert.Equal(t, driverconfig.Default().ExposePCIeRoots, result.ExposePCIeRoots)
+	assert.Equal(t, driverconfig.Default().KubeletRootDir, result.KubeletRootDir)
+}
+
 // TestResolve_BoolFlagWinsOverFile: a bool CLI flag correctly overrides via the JSON round-trip.
 func TestResolve_BoolFlagWinsOverFile(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/subcommands/subcommands.go
+++ b/internal/subcommands/subcommands.go
@@ -57,7 +57,11 @@ func runIntrospect(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("dracpu introspect", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "Usage: %s <subcommand>\n\nAvailable subcommands:\n  metrics\tPrint JSON metadata for custom dra_cpu_* metrics.\n", fs.Name())
+		fmt.Fprintf(fs.Output(), `Usage: %s <subcommand>
+
+Available subcommands:
+metrics\tPrint JSON metadata for custom dra_cpu_* metrics.
+`, fs.Name())
 	}
 
 	if err := fs.Parse(args); err != nil {

--- a/internal/subcommands/subcommands.go
+++ b/internal/subcommands/subcommands.go
@@ -31,10 +31,9 @@ import (
 
 // Options configures subcommand execution.
 type Options struct {
-	DriverConfig driverconfig.Config
-	Logger       logr.Logger
-	Stdout       io.Writer
-	Stderr       io.Writer
+	Logger logr.Logger
+	Stdout io.Writer
+	Stderr io.Writer
 }
 
 // Run dispatches a dracpu subcommand.
@@ -47,20 +46,21 @@ func Run(args []string, opts Options) error {
 	case "gatherinfo":
 		return gatherinfo.Run(args[1:], gatherinfo.Options{}, opts.Logger)
 	case "introspect":
-		return runIntrospect(args[1:], opts.Stdout, opts.Stderr)
+		return runIntrospect(args[1:], opts)
 	default:
 		return fmt.Errorf("unknown subcommand %q; supported subcommands: gatherinfo, introspect", args[0])
 	}
 }
 
-func runIntrospect(args []string, stdout, stderr io.Writer) error {
+func runIntrospect(args []string, opts Options) error {
 	fs := flag.NewFlagSet("dracpu introspect", flag.ContinueOnError)
-	fs.SetOutput(stderr)
+	fs.SetOutput(opts.Stderr)
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), `Usage: %s <subcommand>
 
 Available subcommands:
 metrics\tPrint JSON metadata for custom dra_cpu_* metrics.
+config \tPrint YAML configuration from the supported sources.
 `, fs.Name())
 	}
 
@@ -71,14 +71,16 @@ metrics\tPrint JSON metadata for custom dra_cpu_* metrics.
 		return err
 	}
 	if fs.NArg() == 0 {
-		return fmt.Errorf("introspect requires a subcommand; supported subcommands: metrics")
+		return fmt.Errorf("introspect requires a subcommand; supported subcommands: metrics|config")
 	}
 
 	switch fs.Arg(0) {
 	case "metrics":
-		return runMetrics(fs.Args()[1:], stdout, stderr)
+		return runMetrics(fs.Args()[1:], opts.Stdout, opts.Stderr)
+	case "config":
+		return runConfig(fs.Args()[1:], opts.Logger, opts.Stdout, opts.Stderr)
 	default:
-		return fmt.Errorf("unknown introspect subcommand %q; supported subcommands: metrics", fs.Arg(0))
+		return fmt.Errorf("unknown introspect subcommand %q; supported subcommands: metrics|config", fs.Arg(0))
 	}
 }
 
@@ -100,4 +102,46 @@ func runMetrics(args []string, stdout, stderr io.Writer) error {
 	}
 
 	return cpumetrics.WriteJSON(stdout)
+}
+
+func runConfig(args []string, logger logr.Logger, stdout, stderr io.Writer) error {
+	rawMode := false
+	configFile := ""
+	fs := flag.NewFlagSet("dracpu introspect config", flag.ContinueOnError)
+	fs.BoolVar(&rawMode, "raw", rawMode, "if set, emit the full set of tunables as non-roundtrippable content.")
+	fs.StringVar(&configFile, "from-file", configFile, "configuration file to load (\"\" to disable)")
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: %s\n", fs.Name())
+	}
+
+	err := fs.Parse(args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("config does not accept positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	cfg, err := driverconfig.Resolve(logger, []driverconfig.Source{
+		// NOTE: must ensure the same ordering as the main app.go
+		driverconfig.FromFile(configFile),
+	})
+	if err != nil {
+		return err
+	}
+	var out string
+	if rawMode {
+		out = cfg.Dump()
+	} else {
+		out, err = cfg.DumpAsFile()
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Fprint(stdout, out)
+	return nil
 }

--- a/internal/subcommands/subcommands_test.go
+++ b/internal/subcommands/subcommands_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 )
 
@@ -50,7 +51,11 @@ func TestRunIntrospectMetrics(t *testing.T) {
 }
 
 func TestRunIntrospectRequiresNestedSubcommand(t *testing.T) {
-	err := runIntrospect(nil, io.Discard, io.Discard)
+	err := runIntrospect(nil, Options{
+		Logger: logr.Discard(),
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
 	if err == nil {
 		t.Fatal("runIntrospect() succeeded, want error")
 	}

--- a/test/e2e_local/config_test.go
+++ b/test/e2e_local/config_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_local
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/internal/driverconfig"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = ginkgo.Describe("[Local] dracpu introspect config", func() {
+	ginkgo.It("should output defaults matching compiled-in defaults", func() {
+		out := runCommand(binPath, "introspect", "config")
+
+		expected := driverconfig.Default()
+		got := driverconfig.Config{}
+		gomega.Expect(yaml.Unmarshal(out, &got)).To(gomega.Succeed())
+		gomega.Expect(got).To(gomega.Equal(expected))
+	})
+
+	ginkgo.It("should merge file values with defaults", func() {
+		tmpDir := ginkgo.GinkgoT().TempDir()
+		cfgPath := filepath.Join(tmpDir, "config.yaml")
+
+		expected := driverconfig.Default()
+		expected.ReservedCPUs = "0-3"
+		expected.CPUDeviceMode = "individual"
+
+		cfgContent := []byte(`
+reservedCPUs: "0-3"
+cpuDeviceMode: individual
+`)
+		gomega.Expect(os.WriteFile(cfgPath, cfgContent, 0600)).To(gomega.Succeed())
+
+		out := runCommand(binPath, "introspect", "config", "-file", cfgPath)
+
+		var got driverconfig.Config
+		gomega.Expect(yaml.Unmarshal(out, &got)).To(gomega.Succeed())
+		gomega.Expect(got).To(gomega.Equal(expected))
+	})
+
+	ginkgo.It("should fail when config file does not exist", func() {
+		cmdline := []string{binPath, "introspect", "config", "/does/not/exist.yaml"}
+		fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+		// #nosec G204 -- the command and arguments are fixed above.
+		out, err := exec.Command(cmdline[0], cmdline[1:]...).CombinedOutput()
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		fmt.Fprintf(ginkgo.GinkgoWriter, "output:\n%s\n", string(out))
+	})
+
+	ginkgo.It("should succeed with --help", func() {
+		cmdline := []string{binPath, "introspect", "config", "--help"}
+		fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+		cmd := exec.Command(cmdline[0], cmdline[1:]...)
+		cmd.Stderr = ginkgo.GinkgoWriter
+
+		err := cmd.Run()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should reject extra positional arguments", func() {
+		cmdline := []string{binPath, "introspect", "config", "a"}
+		fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
+
+		// #nosec G204 -- the command and arguments are fixed above.
+		out, err := exec.Command(cmdline[0], cmdline[1:]...).CombinedOutput()
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(string(out)).To(gomega.ContainSubstring("config does not accept positional arguments"))
+	})
+})

--- a/test/e2e_local/e2e_local_suite_test.go
+++ b/test/e2e_local/e2e_local_suite_test.go
@@ -19,6 +19,7 @@ package e2e_local
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -46,3 +47,17 @@ var _ = ginkgo.BeforeSuite(func() {
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(),
 		"binary not found at %q; run 'make build-dracpu' first", binPath)
 })
+
+func runCommand(args ...string) []byte {
+	ginkgo.GinkgoHelper()
+	fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", args)
+
+	// #nosec G204 -- the command and arguments are fixed from test code.
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stderr = ginkgo.GinkgoWriter
+
+	out, err := cmd.Output()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	fmt.Fprintf(ginkgo.GinkgoWriter, "output:\n%s\n", string(out))
+	return out
+}

--- a/test/e2e_local/metrics_test.go
+++ b/test/e2e_local/metrics_test.go
@@ -29,14 +29,7 @@ import (
 
 var _ = ginkgo.Describe("[Local] dracpu introspect metrics", func() {
 	ginkgo.It("should output valid JSON with custom metric descriptors", func() {
-		cmdline := []string{binPath, "introspect", "metrics"}
-		fmt.Fprintf(ginkgo.GinkgoWriter, "running: %v\n", cmdline)
-
-		cmd := exec.Command(cmdline[0], cmdline[1:]...)
-		cmd.Stderr = ginkgo.GinkgoWriter
-
-		out, err := cmd.Output()
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		out := runCommand(binPath, "introspect", "metrics")
 
 		// TODO: undecided: this import allows us clean validation, but
 		// we have now a build dep and the tests are no longer truly blackbox.
@@ -65,7 +58,7 @@ var _ = ginkgo.Describe("[Local] dracpu root usage", func() {
 
 		usage := string(out)
 		gomega.Expect(usage).To(gomega.ContainSubstring("dracpu gatherinfo [flags]"))
-		gomega.Expect(usage).To(gomega.ContainSubstring("dracpu introspect metrics"))
+		gomega.Expect(usage).To(gomega.ContainSubstring("dracpu introspect [metrics|config]"))
 		gomega.Expect(usage).To(gomega.ContainSubstring("dracpu-gatherinfo [flags]"))
 		gomega.Expect(usage).ToNot(gomega.ContainSubstring("--show-metrics"))
 	})


### PR DESCRIPTION
#### What type of PR is this?


/kind feature
/kind cleanup


#### What this PR does / why we need it
Add `dracpu introspect config`, enabling users to check which configuration the driver is using, or to create configuration templates

#### Which issue(s) this PR is related to
N/A

#### Special notes for reviewers
I believe this small feature has merit, but it seems unavoidable to load the config in its own path, which works but opens the gate for subtle drifts and subtle bugs. Exposing something different from reality defies the very point of this feature. Do we still deem it worthy?

I'm using AI assistance for the mechanical work of porting the tests (not for the core logic changes) and for self-review.

#### Release note
```release-note
NONE
```

#### Documentation updates

N/A