### PR TITLE
chore: reduce driver CLI flags in favor of config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ one can be enabled at a time on any given node. See [Configuration](docs/user/co
 
 ## Key Features
 
-- **Topology-Aware CPU Discovery:** Discovers the node's full CPU topology by reading sysfs, including sockets, NUMA nodes, cores, SMT siblings, Last-Level Cache (LLC), core types (Performance/Efficiency), and optionally PCIe root locality.
-- **Exclusive CPU Allocation:** Pods requesting CPUs via a `ResourceClaim` are pinned to exclusive, guaranteed CPUs enforced through CDI and NRI.
-- **Shared Pool Management:** All other containers are dynamically confined to a shared pool made up of CPUs not exclusively assigned to any guaranteed container.
-- **Two Device Exposure Modes:** `individual` mode exposes each CPU as a selectable device for fine-grained placement; `grouped` mode exposes larger aggregates (NUMA node/socket) as consumable capacity for better scalability on large systems.
-- **CPU Manager Feature Parity:** Aims to match key kubelet CPUManager static policy options (e.g. `PreferAlignByUnCoreCache`, `StrictCPUReservation`) - see [Feature Support](docs/user/feature-support.md) for the full comparison.
-- **Stateful Restarts:** Synchronizes with existing pods on restart by inspecting CDI-injected environment variables, rebuilding its allocation state without disrupting running workloads.
+- Topology-Aware CPU Discovery: Discovers the node's full CPU topology by reading sysfs, including sockets, NUMA nodes, cores, SMT siblings, Last-Level Cache (LLC), core types (Performance/Efficiency), and optionally PCIe root locality.
+- Exclusive CPU Allocation: Pods requesting CPUs via a `ResourceClaim` are pinned to exclusive, guaranteed CPUs enforced through CDI and NRI.
+- Shared Pool Management: All other containers are dynamically confined to a shared pool made up of CPUs not exclusively assigned to any guaranteed container.
+- Two Device Exposure Modes: `individual` mode exposes each CPU as a selectable device for fine-grained placement; `grouped` mode exposes larger aggregates (NUMA node/socket) as consumable capacity for better scalability on large systems.
+- CPU Manager Feature Parity: Aims to match key kubelet CPUManager static policy options (e.g. `PreferAlignByUnCoreCache`, `StrictCPUReservation`) - see [Feature Support](docs/user/feature-support.md) for the full comparison.
+- Stateful Restarts: Synchronizes with existing pods on restart by inspecting CDI-injected environment variables, rebuilding its allocation state without disrupting running workloads.
 
 ## How It Works
 
 The driver runs as a single executable, deployed as a DaemonSet, that implements two core interfaces working together on each node:
 
-- The **DRA driver** control loop discovers CPU topology, publishes `ResourceSlice` objects to the API server, and handles `ResourceClaim` allocation requests, writing the result as a [CDI](https://github.com/cncf-tags/container-device-interface) spec.
-- An **NRI plugin** reads the CDI-injected cpuset for guaranteed containers and pins them via the cgroup cpuset controller, while dynamically managing the shared pool for everything else.
+- The DRA driver control loop discovers CPU topology, publishes `ResourceSlice` objects to the API server, and handles `ResourceClaim` allocation requests, writing the result as a [CDI](https://github.com/cncf-tags/container-device-interface) spec.
+- An NRI plugin reads the CDI-injected cpuset for guaranteed containers and pins them via the cgroup cpuset controller, while dynamically managing the shared pool for everything else.
 
 See [How it Works](docs/user/how-it-works.md) for the detailed architecture, and [Example ResourceSlices](docs/user/resourceslices-examples.md) for sample driver output.
 
@@ -46,8 +46,8 @@ when filing an issue — it collects the CPU topology and driver configuration n
 ### User Documentation
 
 - [Prerequisites](docs/user/prerequisites.md) - container runtime (NRI/CDI) requirements.
-- [Getting Started](docs/user/installation.md) - installation, migration from `install.yaml`, and example usage.
-- [Configuration](docs/user/configuration.md) - kubelet prerequisites, command-line flags, and the Helm `driverConfig` file schema.
+- [Getting Started](docs/user/installation.md) - installation, migration from install.yaml, and example usage.
+- [Configuration](docs/user/configuration.md) - the config file schema, command-line flags, and kubelet prerequisites.
 - [How it Works](docs/user/how-it-works.md) - driver architecture, CDI, and NRI integration.
 - [Feature Support](docs/user/feature-support.md) - supported/unsupported features and [CPU Manager Options mapping](docs/user/cpu-manager-mapping.md).
 - [Matching CPU Manager Options](docs/user/cpu-manager-mapping.md) - kubelet cpumanager policy options and their driver equivalents.

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -89,6 +89,7 @@ func main() {
 	ctxlog.AddFlags(flag.CommandLine)
 	flag.Parse()
 	logger := ctxlog.Setup()
+	driverconfig.WarnDeprecatedFlags(flag.CommandLine, logger)
 
 	if len(flag.Args()) > 0 {
 		if flag.NFlag() > 0 {

--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -35,13 +35,13 @@ helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driv
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for scheduling the DaemonSet pods |
-| args.cpuDeviceMode | string | `""` | CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); when empty, defers to `driverConfig.cpuDeviceMode` or the built-in default (`grouped`) |
+| args.cpuDeviceMode | string | `""` | **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.cpuDeviceMode` instead. CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); defaults to `grouped` when empty. |
 | args.exposePCIeRoots | bool | `false` | Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster. Not configurable via `driverConfig`; use this flag instead |
-| args.groupBy | string | `""` | Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; when empty, defers to `driverConfig.groupBy` or the built-in default (`numanode`) |
-| args.hostnameOverride | string | `""` | Override the node name the driver registers under; omitted when empty |
+| args.groupBy | string | `""` | **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.groupBy` instead. Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; defaults to `numanode` when empty. |
+| args.hostnameOverride | string | `""` | **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.hostnameOverride` instead. Overrides the node name the driver registers under. |
 | args.logLevel | int | `4` | Log verbosity level passed as `--v` |
-| args.reservedCPUs | string | `""` | CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty |
-| driverConfig | object | `{}` | Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. Fields in `args.*` that are non-empty always take priority over values set here. Example:   driverConfig:     cpuDeviceMode: individual     groupBy: socket     reservedCPUs: "0-3" |
+| args.reservedCPUs | string | `""` | **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.reservedCPUs` instead. CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`). |
+| driverConfig | object | `{}` | Driver config file contents. When non-empty, or when a deprecated `args.*` field below is set, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. `args.*` fields that mirror a deprecated CLI flag (`cpuDeviceMode`, `groupBy`, `reservedCPUs`, `hostnameOverride`) are folded into the generated config automatically and take priority over the same field set here. Example:   driverConfig:     cpuDeviceMode: individual     groupBy: socket     reservedCPUs: "0-3" |
 | extraArgs | list | `[]` | Extra command-line arguments appended to the driver arguments |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for the driver container |
 | extraVolumes | list | `[]` | Extra volumes for the DaemonSet pod |

--- a/deployment/helm/dra-driver-cpu/templates/_helpers.tpl
+++ b/deployment/helm/dra-driver-cpu/templates/_helpers.tpl
@@ -49,3 +49,25 @@ Selector labels
 app.kubernetes.io/name: {{ include "dra-driver-cpu.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Effective driverConfig: folds deprecated args.* fields (cpuDeviceMode,
+groupBy, reservedCPUs, hostnameOverride) into driverConfig, args.* wins on
+conflicts.
+*/}}
+{{- define "dra-driver-cpu.effectiveDriverConfig" -}}
+{{- $cfg := deepCopy (.Values.driverConfig | default dict) -}}
+{{- if .Values.args.cpuDeviceMode }}
+{{- $_ := set $cfg "cpuDeviceMode" .Values.args.cpuDeviceMode }}
+{{- end }}
+{{- if .Values.args.groupBy }}
+{{- $_ := set $cfg "groupBy" .Values.args.groupBy }}
+{{- end }}
+{{- if .Values.args.reservedCPUs }}
+{{- $_ := set $cfg "reservedCPUs" .Values.args.reservedCPUs }}
+{{- end }}
+{{- if .Values.args.hostnameOverride }}
+{{- $_ := set $cfg "hostnameOverride" .Values.args.hostnameOverride }}
+{{- end }}
+{{- toYaml $cfg -}}
+{{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/configmap.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/configmap.yaml
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- if .Values.driverConfig }}
+{{- $effectiveDriverConfig := include "dra-driver-cpu.effectiveDriverConfig" . | fromYaml }}
+{{- if $effectiveDriverConfig }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -22,5 +23,5 @@ metadata:
     {{- include "dra-driver-cpu.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- .Values.driverConfig | toYaml | nindent 4 }}
+    {{- $effectiveDriverConfig | toYaml | nindent 4 }}
 {{- end }}

--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- $effectiveDriverConfig := include "dra-driver-cpu.effectiveDriverConfig" . | fromYaml }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -35,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.driverConfig }}
+        {{- if $effectiveDriverConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -64,26 +65,14 @@ spec:
         args:
           - /dracpu
           - --v={{ .Values.args.logLevel }}
-          {{- if .Values.args.cpuDeviceMode }}
-          - --cpu-device-mode={{ .Values.args.cpuDeviceMode }}
-          {{- end }}
-          {{- if .Values.args.groupBy }}
-          - --group-by={{ .Values.args.groupBy }}
-          {{- end }}
           {{- if .Values.healthzPort }}
           - --bind-address=:{{ .Values.healthzPort }}
-          {{- end }}
-          {{- if .Values.args.reservedCPUs }}
-          - --reserved-cpus={{ .Values.args.reservedCPUs }}
-          {{- end }}
-          {{- if .Values.args.hostnameOverride }}
-          - --hostname-override={{ .Values.args.hostnameOverride }}
           {{- end }}
           - --expose-pcie-roots={{ .Values.args.exposePCIeRoots }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- if .Values.driverConfig }}
+          {{- if $effectiveDriverConfig }}
           - --config=/etc/dracpu/config.yaml
           {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
@@ -123,7 +112,7 @@ spec:
         {{- with .Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.driverConfig }}
+        {{- if $effectiveDriverConfig }}
         - name: driver-config
           mountPath: /etc/dracpu
           readOnly: true
@@ -145,7 +134,7 @@ spec:
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- if .Values.driverConfig }}
+      {{- if $effectiveDriverConfig }}
       - name: driver-config
         configMap:
           name: {{ include "dra-driver-cpu.fullname" . }}-config

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -15,7 +15,7 @@
       ],
       "properties": {
         "cpuDeviceMode": {
-          "description": "CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); when empty, defers to `driverConfig.cpuDeviceMode` or the built-in default (`grouped`)",
+          "description": "**Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.cpuDeviceMode` instead. CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); defaults to `grouped` when empty.",
           "type": "string",
           "enum": [
             "",
@@ -28,7 +28,7 @@
           "type": "boolean"
         },
         "groupBy": {
-          "description": "Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; when empty, defers to `driverConfig.groupBy` or the built-in default (`numanode`)",
+          "description": "**Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.groupBy` instead. Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; defaults to `numanode` when empty.",
           "type": "string",
           "enum": [
             "",
@@ -38,7 +38,7 @@
           ]
         },
         "hostnameOverride": {
-          "description": "Override the node name the driver registers under; omitted when empty",
+          "description": "**Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.hostnameOverride` instead. Overrides the node name the driver registers under.",
           "type": "string"
         },
         "logLevel": {
@@ -47,14 +47,14 @@
           "minimum": 0
         },
         "reservedCPUs": {
-          "description": "CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `\"0-1\"`); omitted when empty",
+          "description": "**Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.reservedCPUs` instead. CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `\"0-1\"`).",
           "type": "string"
         }
       },
       "additionalProperties": false
     },
     "driverConfig": {
-      "description": "Driver config file contents. When non-empty, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. Fields in `args.*` that are non-empty always take priority over values set here. Example: driverConfig: cpuDeviceMode: individual groupBy: socket reservedCPUs: \"0-3\"",
+      "description": "Driver config file contents. When non-empty, or when a deprecated `args.*` field below is set, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. `args.*` fields that mirror a deprecated CLI flag (`cpuDeviceMode`, `groupBy`, `reservedCPUs`, `hostnameOverride`) are folded into the generated config automatically and take priority over the same field set here. Example: driverConfig: cpuDeviceMode: individual groupBy: socket reservedCPUs: \"0-3\"",
       "$ref": "driverconfig.schema.json",
       "type": "object"
     },

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -78,13 +78,13 @@ affinity: {}
 args:
   # -- Log verbosity level passed as `--v`
   logLevel: 4 # @schema type:integer;minimum:0;required:true
-  # -- CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); when empty, defers to `driverConfig.cpuDeviceMode` or the built-in default (`grouped`)
+  # -- **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.cpuDeviceMode` instead. CPU exposure mode: `grouped` (expose NUMA nodes or sockets as devices) or `individual` (expose each CPU as a device); defaults to `grouped` when empty.
   cpuDeviceMode: "" # @schema enum:["",grouped,individual];required:true
-  # -- Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; when empty, defers to `driverConfig.groupBy` or the built-in default (`numanode`)
+  # -- **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.groupBy` instead. Grouping criteria when `cpuDeviceMode=grouped`: `numanode`, `socket` or `machine`; defaults to `numanode` when empty.
   groupBy: "" # @schema enum:["",numanode,socket,machine];required:true
-  # -- CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`); omitted when empty
+  # -- **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.reservedCPUs` instead. CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`).
   reservedCPUs: ""
-  # -- Override the node name the driver registers under; omitted when empty
+  # -- **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.hostnameOverride` instead. Overrides the node name the driver registers under.
   hostnameOverride: ""
   # -- Discover and expose PCIe roots as device attributes. Requires the `DRAListTypeAttributes=true` feature gate in the cluster. Not configurable via `driverConfig`; use this flag instead
   exposePCIeRoots: false # @schema type:boolean
@@ -94,9 +94,12 @@ healthzPath: /healthz
 # -- Port the HTTP server binds to; used for the container port and probes
 healthzPort: 8080 # @schema type:integer;minimum:1;maximum:65535
 
-# -- Driver config file contents. When non-empty, a ConfigMap is created and
-# mounted into the driver container as /etc/dracpu/config.yaml. Fields in
-# `args.*` that are non-empty always take priority over values set here.
+# -- Driver config file contents. When non-empty, or when a deprecated
+# `args.*` field below is set, a ConfigMap is created and mounted into the
+# driver container as /etc/dracpu/config.yaml. `args.*` fields that mirror a
+# deprecated CLI flag (`cpuDeviceMode`, `groupBy`, `reservedCPUs`,
+# `hostnameOverride`) are folded into the generated config automatically and
+# take priority over the same field set here.
 # Example:
 #   driverConfig:
 #     cpuDeviceMode: individual

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -1,53 +1,105 @@
 # Configuration
 
-**IMPORTANT:** The kubelet's CPUManager implements assignment of exclusive CPUs to workloads. The CPUManager and this DRA driver are mutually incompatible and only
-one can be enabled at a time on any given node.
-
-## Kubelet configuration prerequisites
-
-You need to disable the CPUManager on the nodes you wish to run this DRA driver.
-
-1. The default settings of the kubelet are compatible with this DRA driver. If you never fine-tuned the kubelet, you are probably fine.
-1. Make sure `cpuManagerPolicy: "none"` is set in the kubelet [configuration file](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/).
-1. If you changed the kubelet configuration, restart the kubelet to take effect. **NOTE:** you may need to [delete the CPUManager state file](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#changing-the-cpu-manager-policy).
-1. You may now proceed with deploying and configuring this DRA driver.
+This page covers configuring the driver itself, the kubelet prerequisites required to run it,
+and the command-line flags currently being deprecated in favour of the configuration file.
 
 ## Driver configuration
 
-**The configuration file is the preferred configuration mechanism.** Command-line flags are
-still supported, but they are kept mainly for backward compatibility and are expected to be
-phased out in favour of the configuration file over time (see
-[Versioning and backward compatibility](#versioning-and-backward-compatibility) below). If a
-field is set both ways, the flag wins, so avoid mixing the two for the same field and configure
-new deployments via `driverConfig` / the config file alone.
+The driver supports two configuration mechanisms:
+
+- The config file - the main, preferred way to configure the driver.
+- Command-line flags — kept for a small set of important, mostly behavior altering settings and for backward compatibility. Some flags are being deprecated in favor of their config file equivalent (see [Helm: deprecated args values vs driverConfig](#helm-deprecated-args-values-vs-driverconfig) below).
+
+If the same setting is provided both ways, the explicit command-line flag wins, so avoid mixing
+the two for the same field.
 
 ### Configuration file
 
-When deploying with Helm, set `driverConfig` in your values file. The chart serializes the
-map to YAML, stores it in a ConfigMap, mounts it as `/etc/dracpu/config.yaml` inside the
-driver container, and passes `--config` automatically.
+The config file is a YAML file passed to the driver via `--config <path>`.
 
-#### Schema
+When deploying with Helm, you don't write this file yourself: set the `driverConfig` value in
+your values file and the chart serializes it to YAML, stores it in a ConfigMap, mounts it as
+`/etc/dracpu/config.yaml` inside the driver container and passes `--config` automatically. For
+example, with a `values.yaml` containing:
 
-The config file is a **flat** YAML map - there are no nested groups. All fields are optional
+```yaml
+# values.yaml
+# Driver configuration
+driverConfig:
+  cpuDeviceMode: individual
+  reservedCPUs: "0-1"
+# Other tuning knobs of Helm chart
+image:
+  tag: v0.2.0
+resources:
+  requests:
+    cpu: "200m"
+    memory: "100Mi"
+nodeSelector:
+  kubernetes.io/os: linux
+```
+
+```console
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu -f values.yaml
+```
+
+Individual fields can also be tuned with `--set` instead of a values file, e.g. to switch
+`cpuDeviceMode` to `individual` and reserve CPUs `0-1`:
+
+```shell
+helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driver-cpu \
+    --set driverConfig.cpuDeviceMode=individual \
+    --set driverConfig.reservedCPUs="0-1"
+```
+
+#### driverConfig sub-fields
+
+The config file is a flat YAML map - there are no nested groups. All fields are optional
 except where noted. Unknown fields are rejected at startup to catch typos early.
 
-| Field              | Type   | Default     | Description                                                                              |
-| ------------------ | ------ | ----------- | ---------------------------------------------------------------------------------------- |
-| `apiVersion`       | string | *(omitted)* | When present, must be `v1alpha1`. Rejected otherwise.                                    |
-| `cpuDeviceMode`    | string | `grouped`   | CPU exposure mode: `individual` or `grouped`.                                            |
-| `groupBy`          | string | `numanode`  | Grouping strategy when `cpuDeviceMode` is `grouped`: `numanode`, `socket`, or `machine`. |
-| `reservedCPUs`     | string | *(none)*    | CPUs excluded from allocation, e.g. `"0-1"`.                                             |
-| `hostnameOverride` | string | *(none)*    | Override the node hostname the driver registers under.                                   |
-| `exposePCIeRoots`  | bool   | `false`     | Add PCIe root attributes to CPU devices (requires `DRAListTypeAttributes` feature gate). |
-| `kubeconfig`       | string | *(none)*    | Path to a kubeconfig file (for out-of-cluster use).                                      |
+These fields only affect the driver's own behavior (CPU allocation, hostname, sysfs path,
+etc.). Anything about the driver's Pod itself - image, resources, node placement, and so
+on - is configured through other Helm values, not through this file.
 
-#### Versioning and backward compatibility
+`apiVersion` (string)
 
-The schema is versioned via the optional `apiVersion` field (currently `v1alpha1`). The layout
-is intentionally flat for now. If a nested hierarchy is introduced in the future, the
-`apiVersion` field will be bumped so that older config files continue to be accepted or produce a
-an error.
+- When present, must be `v1alpha1`. Rejected otherwise.
+
+`cpuDeviceMode` (string, default: `grouped`)
+
+- `individual`: exposes each allocatable CPU as a separate device in the `ResourceSlice`.
+  This mode provides fine-grained control, as it exposes granular information specific
+  to each CPU as device attributes.
+- `grouped`: exposes a single device representing a group of CPUs. This mode treats CPUs
+  as a [consumable capacity](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5075-dra-consumable-capacity/README.md)
+  within the group, improving scalability by reducing the number of API objects.
+
+`groupBy` (string, default: `numanode`)
+
+- Grouping strategy used when `cpuDeviceMode` is `grouped`.
+- `numanode`: groups CPUs by NUMA node.
+- `socket`: groups CPUs by socket.
+- `machine`: groups all allocatable node CPUs into a single machine-wide capacity device.
+  NOTE: this mode requires an external scheduler to supply core assignments. See
+  [Custom Opaque CPUSet Allocation Overrides](opaque-cpuset-overrides.md).
+
+`reservedCPUs` (string)
+
+- CPUs excluded from allocation and from the `ResourceSlice`, given as a cpuset, e.g.
+  `"0-1"`. This has the same semantics as the kubelet's `static` CPU Manager policy with
+  [`strict-cpu-reservation`](https://kubernetes.io/blog/2024/12/16/cpumanager-strict-cpu-reservation/)
+  enabled and [`reservedSystemCPUs`](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list)
+  set. For correct CPU accounting, the number of CPUs reserved here should match the sum
+  of the kubelet's `kubeReserved` and `systemReserved` settings, so that the kubelet
+  subtracts the right number of CPUs from `Node.Status.Allocatable`.
+
+`hostnameOverride` (string)
+
+- Override the node hostname the driver registers under.
+
+`kubeconfig` (string)
+
+- Path to a kubeconfig file (for out-of-cluster use).
 
 #### Example
 
@@ -60,30 +112,65 @@ driverConfig:
   reservedCPUs: "0-3"
 ```
 
-The `apiVersion` field is optional. When present it must equal `v1alpha1` (the current version); any other value is rejected at startup.
+#### Versioning and backward compatibility
 
-`driverConfig` is a single map covering all driver settings — there is no separate Helm value
-per field. `args.*` on the other hand exposes individual fields as explicit Helm values and
-translates them to CLI flags. Both reach the same driver settings; `args.*` takes priority when
-both are set for the same field.
+The schema is versioned via the optional `apiVersion` field (currently `v1alpha1`). The layout
+is intentionally flat for now. If a nested hierarchy is introduced in the future, the
+`apiVersion` field will be bumped so that older config files continue to be accepted or produce
+an error.
 
-Both `args.*` and `driverConfig` exist during a transition period. The intent is to eventually
-deprecate `args.*` in favour of `driverConfig` as the single configuration mechanism. The driver
-logs the effective configuration at startup so you can verify which values are active.
+### Helm: deprecated args values vs driverConfig
+
+`driverConfig` is the Helm value that generates the config file described above (a single map
+covering all driver settings — there is no separate Helm value per field). `args.*` on the other
+hand exposes individual fields as explicit Helm values.
+
+- `args.cpuDeviceMode`, `args.groupBy`, `args.reservedCPUs`, and `args.hostnameOverride` are
+  deprecated: instead of being emitted as CLI flags, they are now folded into the generated
+  `driverConfig` ConfigMap.
+- Both reach the same driver settings; `args.*` takes priority when both are set for the same
+  field.
+- The intent is to eventually deprecate `args.*` entirely in favour of `driverConfig` as the
+  single configuration mechanism. The driver logs the effective configuration at startup so you
+  can verify which values are active.
 
 ### Command-line flags
 
 **NOTE:** Command-line flags are kept mainly for backward compatibility. Prefer the
 [configuration file](#configuration-file) above for new deployments.
 
-The driver can be configured with the following command-line flags:
+`--cpu-device-mode`, `--group-by`, `--reserved-cpus`, `--hostname-override`, `--sysfs-overlay`
+are deprecated in favour of their config file equivalents and will be removed in a future
+release ([issue #245](https://github.com/kubernetes-sigs/dra-driver-cpu/issues/245)). Each is
+marked as deprecated in `--help`, and passing one explicitly logs a startup warning.
 
-- `--cpu-device-mode`: Sets the mode for exposing CPU devices.
-  - `"individual"`: Exposes each allocatable CPU as a separate device in the `ResourceSlice`. This mode provides fine-grained control as it exposes granular information specific to each CPU as device attributes in the `ResourceSlice`.
-  - `"grouped" (default)`: Exposes a single device representing a group of CPUs. This mode treats CPUs as a [consumable capacity](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5075-dra-consumable-capacity/README.md) within the group, improving scalability by reducing the number of API objects.
-- `--group-by`: When `--cpu-device-mode` is set to `"grouped"`, this flag determines the grouping strategy.
-  - `"numanode"` (default): Groups CPUs by NUMA node.
-  - `"socket"`: Groups CPUs by socket.
-  - `"machine"`: Groups all allocatable node CPUs into a single machine-wide capacity device. **NOTE**: This mode requires an external scheduler to supply core assignments. See [Custom Opaque CPUSet Allocation Overrides](opaque-cpuset-overrides.md).
-- `--reserved-cpus`: Specifies a set of CPUs to be reserved for system and kubelet processes. These CPUs will not be allocatable by the DRA driver and would be excluded from the `ResourceSlice`. The value is a cpuset, e.g., `0-1`. This semantic is the same as the one the kubelet applies with its `static` CPU Manager policy and enabling [`strict-cpu-reservation`](https://kubernetes.io/blog/2024/12/16/cpumanager-strict-cpu-reservation/) flag and specifying the CPUs with the [`reservedSystemCPUs`](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#explicitly-reserved-cpu-list) to be reserved for system daemons. For correct CPU accounting, the number of CPUs reserved with this flag should match the sum of the kubelet's `kubeReserved` and `systemReserved` settings. This ensures the kubelet subtracts the correct number of CPUs from `Node.Status.Allocatable`.
-- `--expose-pcie-roots`: If enabled, adds the "resource.kubernetes.io/pcieRoot" standard value to CPU devices, to report the PCIe roots close to each device. Since it always reports values as list, this option requires the cluster Feature Gate `DRAListTypeAttributes` (see KEP 5491) to be enabled. The driver has no way to introspect the cluster Feature Gate, so care must be taken to enable first the Feature Gate then this option.
+- `--cpu-device-mode` → `cpuDeviceMode`
+- `--group-by` → `groupBy`
+- `--reserved-cpus` → `reservedCPUs`
+- `--hostname-override` → `hostnameOverride`
+- `--sysfs-overlay` → `sysfsOverlay`
+
+The remaining flags aren't part of that deprecation:
+
+- `--config`: path to the config file described above.
+- `--kubeconfig`: path to a kubeconfig file, for out-of-cluster use. Also settable via the `kubeconfig` config field.
+- `--bind-address`: address the metrics server listens on.
+- `--show-metrics`: print the metrics endpoint and exit.
+- `--expose-pcie-roots`: adds the `resource.kubernetes.io/pcieRoot` standard value to CPU
+  devices, reporting the PCIe roots close to each device. Since it always reports values
+  as a list, this option requires the cluster feature gate `DRAListTypeAttributes` (see
+  KEP 5491) to be enabled. The driver cannot introspect the cluster feature gate, so
+  enable the feature gate first and this option second. Unlike the flags above, it is not
+  deprecated and has no config file equivalent — it is intentionally excluded from the
+  config file (see [driverConfig sub-fields](#driverconfig-sub-fields) above) and stays a
+  standalone flag (or Helm `args.exposePCIeRoots`).
+
+## Kubelet configuration prerequisites
+
+**IMPORTANT:** The kubelet's CPUManager implements assignment of exclusive CPUs to workloads. The CPUManager and this DRA driver are mutually incompatible and only
+one can be enabled at a time on any given node. You need to disable the CPUManager on the nodes you wish to run this DRA driver.
+
+1. The default settings of the kubelet are compatible with this DRA driver. If you never fine-tuned the kubelet, you are probably fine.
+1. Make sure `cpuManagerPolicy: "none"` is set in the kubelet [configuration file](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/).
+1. If you changed the kubelet configuration, restart the kubelet to take effect. **NOTE:** you may need to [delete the CPUManager state file](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#changing-the-cpu-manager-policy).
+1. You may now proceed with deploying and configuring this DRA driver.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -18,7 +18,7 @@ helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driv
 
 See the [Helm chart README](../../deployment/helm/dra-driver-cpu/README.md) for the full list of configuration options.
 
-For environments with incomplete or synthetic sysfs topology, e.g. Docker Desktop for macOS see the [sysfs overlay example](../../hack/examples/sysfs-overlay/README.md). It demonstrates how to supply an overlay through the chart's generic extra arguments, volume mounts, and volumes.
+For environments with incomplete or synthetic sysfs topology, e.g. Docker Desktop for macOS see the [sysfs overlay example](../../hack/examples/sysfs-overlay/README.md). It demonstrates how to supply an overlay through `driverConfig.sysfsOverlay`, volume mounts, and volumes.
 
 ## Example Usage
 

--- a/hack/examples/sysfs-overlay/README.md
+++ b/hack/examples/sysfs-overlay/README.md
@@ -1,6 +1,6 @@
 # Sysfs overlay example
 
-This example supplies a synthetic four-CPU topology. The ConfigMap owns the overlay data, while the values file uses the chart's generic extra arguments, volume mounts, and volumes.
+This example supplies a synthetic four-CPU topology. The ConfigMap owns the overlay data, while the values file uses `driverConfig.sysfsOverlay` plus the chart's generic extra volume mounts and volumes.
 
 One environment where this is useful is a Kind cluster running in Docker Desktop for macOS, where the container-visible sysfs may not expose complete NUMA topology. The CPU and NUMA portions of this example work on Apple Silicon; PCIe-root discovery is currently limited to AMD64.
 

--- a/hack/examples/sysfs-overlay/values.yaml
+++ b/hack/examples/sysfs-overlay/values.yaml
@@ -1,8 +1,8 @@
 args:
   exposePCIeRoots: true
 
-extraArgs:
-  - --sysfs-overlay=/etc/dra-driver-cpu/sysfs-overlay.yaml
+driverConfig:
+  sysfsOverlay: /etc/dra-driver-cpu/sysfs-overlay.yaml
 
 extraVolumeMounts:
   - name: sysfs-overlay

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // newFlagSet creates a FlagSet with cfg registered and args parsed.
@@ -194,6 +195,79 @@ reservedCPUs: "0-3"
 
 	require.NoError(t, err)
 	assert.Contains(t, logs.String(), "unmapped-flag")
+}
+
+// TestWarnDeprecatedFlags_LogsWarning: a deprecated flag logs a warning naming its driverConfig replacement.
+func TestWarnDeprecatedFlags_LogsWarning(t *testing.T) {
+	for _, tc := range []struct {
+		flag              string
+		driverConfigField string
+	}{
+		{flag: "cpu-device-mode=individual", driverConfigField: "cpuDeviceMode"},
+		{flag: "group-by=socket", driverConfigField: "groupBy"},
+		{flag: "reserved-cpus=0-1", driverConfigField: "reservedCPUs"},
+		{flag: "hostname-override=node1", driverConfigField: "hostnameOverride"},
+		{flag: "sysfs-overlay=/tmp/overlay.yaml", driverConfigField: "sysfsOverlay"},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			cfg := driverconfig.Default()
+			fs := newFlagSet(t, &cfg, []string{"--" + tc.flag})
+
+			var logs strings.Builder
+			logger := funcr.New(func(prefix, args string) {
+				logs.WriteString(prefix + " " + args + "\n")
+			}, funcr.Options{})
+
+			driverconfig.WarnDeprecatedFlags(fs, logger)
+
+			assert.Contains(t, logs.String(), "deprecated")
+			assert.Contains(t, logs.String(), tc.driverConfigField)
+		})
+	}
+}
+
+// TestWarnDeprecatedFlags_NonDeprecatedFlagNoWarning: non-deprecated flags don't trigger the deprecation warning.
+func TestWarnDeprecatedFlags_NonDeprecatedFlagNoWarning(t *testing.T) {
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, []string{"--bind-address=:9090"})
+
+	var logs strings.Builder
+	logger := funcr.New(func(prefix, args string) {
+		logs.WriteString(prefix + " " + args + "\n")
+	}, funcr.Options{})
+
+	driverconfig.WarnDeprecatedFlags(fs, logger)
+
+	assert.NotContains(t, logs.String(), "deprecated")
+}
+
+// deprecatedFlagNames is the hardcoded set of flags expected to be marked
+// as deprecated in --help. Update it whenever a flag's deprecation status changes.
+var deprecatedFlagNames = sets.New(
+	"cpu-device-mode",
+	"group-by",
+	"reserved-cpus",
+	"hostname-override",
+	"sysfs-overlay",
+)
+
+// TestDeprecatedFlags_HelpTextSuffix: exactly the flags in deprecatedFlagNames
+// carry a "(DEPRECATED: ...)" suffix in --help - none missing, none extra.
+func TestDeprecatedFlags_HelpTextSuffix(t *testing.T) {
+	cfg := driverconfig.Config{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.AddFlags(fs)
+
+	fs.VisitAll(func(f *flag.Flag) {
+		wantDeprecated := deprecatedFlagNames.Has(f.Name)
+		isMarkedDeprecated := strings.Contains(f.Usage, "(DEPRECATED:")
+		switch {
+		case wantDeprecated && !isMarkedDeprecated:
+			t.Errorf("flag %q is expected to be deprecated but its --help text has no DEPRECATED suffix: %q", f.Name, f.Usage)
+		case !wantDeprecated && isMarkedDeprecated:
+			t.Errorf("flag %q has a DEPRECATED --help suffix but isn't expected to be deprecated: %q", f.Name, f.Usage)
+		}
+	})
 }
 
 // TestDefault pins the built-in default values.

--- a/internal/driverconfig/flags.go
+++ b/internal/driverconfig/flags.go
@@ -28,13 +28,22 @@ func (c *Config) AddFlags(fs *flag.FlagSet) {
 	c.applyDefaults()
 
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", c.Kubeconfig, "absolute path to the kubeconfig file")
-	fs.StringVar(&c.HostnameOverride, "hostname-override", c.HostnameOverride, "If non-empty, will be used as the name of the Node that kube-network-policies is running on. If unset, the node name is assumed to be the same as the node's hostname.")
 	fs.StringVar(&c.BindAddress, "bind-address", c.BindAddress, "The address to bind the HTTP server for /healthz and /metrics endpoints")
-	fs.StringVar(&c.ReservedCPUs, "reserved-cpus", c.ReservedCPUs, "cpuset of CPUs to be excluded from ResourceSlice.")
-	fs.Var(newCPUDeviceModeValue(&c.CPUDeviceMode, c.CPUDeviceMode), "cpu-device-mode", "Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device.")
-	fs.Var(newGroupByValue(&c.GroupBy, c.GroupBy), "group-by", "When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket', 'numanode', or 'machine' (machine mode requires an external scheduler to include cpuset configuration in claim allocation results).")
 	fs.BoolVar(&c.ExposePCIeRoots, "expose-pcie-roots", c.ExposePCIeRoots, "Discover and expose PCIe roots as device attributes. Requires the DRAListTypeAttributes=true Feature Gate in the cluster.")
-	fs.StringVar(&c.SysFSOverlay, "sysfs-overlay", c.SysFSOverlay, "Path to a YAML file containing sysfs file overlays.")
+	fs.Var(newCPUDeviceModeValue(&c.CPUDeviceMode, c.CPUDeviceMode), "cpu-device-mode", deprecatedUsage("cpuDeviceMode",
+		"Sets the mode for exposing CPU devices. 'grouped' exposes a single device per socket or numa node (based on --group-by). 'individual' exposes each CPU as a separate device."))
+	fs.Var(newGroupByValue(&c.GroupBy, c.GroupBy), "group-by", deprecatedUsage("groupBy",
+		"When --cpu-device-mode=grouped, sets the criteria for grouping CPUs. Can be set to 'socket', 'numanode', or 'machine' (machine mode requires an external scheduler to include cpuset configuration in claim allocation results)."))
+	fs.StringVar(&c.ReservedCPUs, "reserved-cpus", c.ReservedCPUs, deprecatedUsage("reservedCPUs",
+		"cpuset of CPUs to be excluded from ResourceSlice."))
+	fs.StringVar(&c.HostnameOverride, "hostname-override", c.HostnameOverride, deprecatedUsage("hostnameOverride",
+		"If non-empty, will be used as the name of the Node that kube-network-policies is running on. If unset, the node name is assumed to be the same as the node's hostname."))
+	fs.StringVar(&c.SysFSOverlay, "sysfs-overlay", c.SysFSOverlay, deprecatedUsage("sysfsOverlay",
+		"Path to a YAML file containing sysfs file overlays."))
+}
+
+func deprecatedUsage(driverConfigField, usage string) string {
+	return fmt.Sprintf("%s (DEPRECATED: prefer driverConfig field %q; this flag will be removed in a future release)", usage, driverConfigField)
 }
 
 func (c *Config) applyDefaults() {

--- a/internal/driverconfig/load.go
+++ b/internal/driverconfig/load.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // flagToJSONKey maps CLI flag names to their Config JSON keys.
@@ -34,6 +35,29 @@ var flagToJSONKey = map[string]string{
 	"group-by":          "groupBy",
 	"expose-pcie-roots": "exposePCIeRoots",
 	"sysfs-overlay":     "sysfsOverlay",
+}
+
+// deprecatedFlags is the set of standalone CLI flags being phased out in
+// favour of the same-named driverConfig field (issue #245).
+var deprecatedFlags = sets.New(
+	"cpu-device-mode",
+	"group-by",
+	"reserved-cpus",
+	"hostname-override",
+	"sysfs-overlay",
+)
+
+// WarnDeprecatedFlags logs a warning for each deprecated flag explicitly set
+// on the command line. Not called by Load. gatherinfo also calls Load, but
+// on other processes' flags, where a warning wouldn't make sense.
+func WarnDeprecatedFlags(fs *flag.FlagSet, logger logr.Logger) {
+	fs.Visit(func(f *flag.Flag) {
+		if !deprecatedFlags.Has(f.Name) {
+			return
+		}
+		logger.Info("flag is deprecated and will be removed in a future release; prefer the equivalent driverConfig field instead",
+			"flag", f.Name, "driverConfigField", flagToJSONKey[f.Name])
+	})
 }
 
 // Load merges the config file at filePath into base, giving CLI flags that were

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -95,18 +95,15 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 		daemonSet, err := rootFxt.K8SClientset.AppsV1().DaemonSets("kube-system").Get(ctx, "dracpu", metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
 		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
+		cfgValues, err := getDriverConfigValues(ctx, rootFxt.K8SClientset, "kube-system", daemonSet)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot read dracpu driver config values")
 		var dsReservedCPUs cpuset.CPUSet
-		cnt := &daemonSet.Spec.Template.Spec.Containers[0]
-		if val, ok := findArgInContainer(cnt, argReservedCPUs); ok {
-			dsReservedCPUs, err = cpuset.Parse(val)
+		if len(cfgValues.ReservedCPUs) > 0 {
+			dsReservedCPUs, err = cpuset.Parse(cfgValues.ReservedCPUs)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse daemonset reserved cpus: %v", err)
 		}
-		if val, ok := findArgInContainer(cnt, argCPUDeviceMode); ok {
-			cpuDeviceMode = val
-		}
-		if val, ok := findArgInContainer(cnt, argGroupBy); ok {
-			groupBy = val
-		}
+		cpuDeviceMode = cfgValues.CPUDeviceMode
+		groupBy = cfgValues.GroupBy
 		rootFxt.Log.Info("daemonset --reserved-cpus configuration", "cpus", dsReservedCPUs.String())
 		gomega.Expect(dsReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
 		rootFxt.Log.Info("daemonset --cpu-device-mode configuration", "mode", cpuDeviceMode, "groupBy", groupBy)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -31,6 +31,7 @@ import (
 	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -39,6 +40,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
+	"sigs.k8s.io/yaml"
 )
 
 func TestE2E(t *testing.T) {
@@ -225,6 +227,40 @@ func findArgInContainer(container *v1.Container, prefix string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// driverConfigValues holds cpuDeviceMode/groupBy/reservedCPUs read back from a daemonset.
+type driverConfigValues struct {
+	CPUDeviceMode string `json:"cpuDeviceMode,omitempty"`
+	GroupBy       string `json:"groupBy,omitempty"`
+	ReservedCPUs  string `json:"reservedCPUs,omitempty"`
+}
+
+// getDriverConfigValues reads the ConfigMap if the daemonset uses --config=, else falls back to
+// the deprecated CLI flags.
+func getDriverConfigValues(ctx context.Context, client kubernetes.Interface, namespace string, ds *appsv1.DaemonSet) (driverConfigValues, error) {
+	var values driverConfigValues
+	cnt := &ds.Spec.Template.Spec.Containers[0]
+	if _, ok := findArgInContainer(cnt, "--config="); ok {
+		cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, ds.Name+"-config", metav1.GetOptions{})
+		if err != nil {
+			return values, fmt.Errorf("getting driver config configmap for daemonset %s: %w", ds.Name, err)
+		}
+		if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &values); err != nil {
+			return values, fmt.Errorf("parsing driver config configmap for daemonset %s: %w", ds.Name, err)
+		}
+		return values, nil
+	}
+	if val, ok := findArgInContainer(cnt, argCPUDeviceMode); ok {
+		values.CPUDeviceMode = val
+	}
+	if val, ok := findArgInContainer(cnt, argGroupBy); ok {
+		values.GroupBy = val
+	}
+	if val, ok := findArgInContainer(cnt, argReservedCPUs); ok {
+		values.ReservedCPUs = val
+	}
+	return values, nil
 }
 
 func makeTesterPodWithNamedClaim(ns, image, claimName string, nodeName string) *v1.Pod {

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -93,15 +93,18 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Serial, func() {
 		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
 		orgDaemonSet := daemonSet.DeepCopy()
 
-		container := &daemonSet.Spec.Template.Spec.Containers[0]
-		cpuDeviceMode, _ := findArgInContainer(container, argCPUDeviceMode)
-		groupBy, _ := findArgInContainer(container, argGroupBy)
+		cfgValues, err := getDriverConfigValues(ctx, rootFxt.K8SClientset, daemonSetNamespace, daemonSet)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot read dracpu driver config values")
+		cpuDeviceMode := cfgValues.CPUDeviceMode
+		groupBy := cfgValues.GroupBy
 
 		var claimSpec resourcev1.ResourceClaimSpec
 		if cpuDeviceMode == "grouped" && groupBy == "machine" {
-			reservedCPUs, err := reservedCPUsFromContainer(container)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
+			var reservedCPUs cpuset.CPUSet
+			if len(cfgValues.ReservedCPUs) > 0 {
+				reservedCPUs, err = cpuset.Parse(cfgValues.ReservedCPUs)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}
 			availableCPUs, err := discoverAvailableCPUs(ctx, metricsFxt, targetNode.Name, dracpuTesterImage, reservedCPUs)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			if availableCPUs.Size() == 0 {
@@ -182,14 +185,6 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Serial, func() {
 		}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
 	})
 })
-
-func reservedCPUsFromContainer(container *v1.Container) (cpuset.CPUSet, error) {
-	value, ok := findArgInContainer(container, argReservedCPUs)
-	if !ok {
-		return cpuset.New(), nil
-	}
-	return cpuset.Parse(value)
-}
 
 func discoverAvailableCPUs(ctx context.Context, fxt *fixture.Fixture, nodeName, image string, reservedCPUs cpuset.CPUSet) (cpuset.CPUSet, error) {
 	infoPod := discovery.MakePod(fxt.Namespace.Name, image)

--- a/test/e2e/nri_reconciliation_test.go
+++ b/test/e2e/nri_reconciliation_test.go
@@ -79,12 +79,10 @@ var _ = ginkgo.Describe("NRI Reconciliation on Restart", ginkgo.Serial, ginkgo.O
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
 		gomega.Expect(orgDaemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
 
-		if val, ok := findArgInContainer(&orgDaemonSet.Spec.Template.Spec.Containers[0], argCPUDeviceMode); ok {
-			cpuDeviceMode = val
-		}
-		if val, ok := findArgInContainer(&orgDaemonSet.Spec.Template.Spec.Containers[0], argGroupBy); ok {
-			groupBy = val
-		}
+		cfgValues, err := getDriverConfigValues(ctx, rootFxt.K8SClientset, daemonSetNamespaceRule, orgDaemonSet)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot read dracpu driver config values")
+		cpuDeviceMode = cfgValues.CPUDeviceMode
+		groupBy = cfgValues.GroupBy
 
 		// Find target node
 		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)

--- a/test/e2e/resource_slice_test.go
+++ b/test/e2e/resource_slice_test.go
@@ -46,13 +46,10 @@ var _ = ginkgo.Describe("Resource Attributes", ginkgo.Ordered, ginkgo.ContinueOn
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
 		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty())
 
-		cnt := &daemonSet.Spec.Template.Spec.Containers[0]
-		if val, ok := findArgInContainer(cnt, argCPUDeviceMode); ok {
-			cpuDeviceMode = val
-		}
-		if val, ok := findArgInContainer(cnt, argGroupBy); ok {
-			groupBy = val
-		}
+		cfgValues, err := getDriverConfigValues(ctx, fxt.K8SClientset, daemonSetNamespace, daemonSet)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot read dracpu driver config values")
+		cpuDeviceMode = cfgValues.CPUDeviceMode
+		groupBy = cfgValues.GroupBy
 		fxt.Log.Info("daemonset configuration", "cpuDeviceMode", cpuDeviceMode, "groupBy", groupBy)
 
 		ginkgo.By("listing ResourceSlices for driver " + driverName)

--- a/test/e2e/sharing_test.go
+++ b/test/e2e/sharing_test.go
@@ -71,18 +71,15 @@ var _ = ginkgo.Describe("Claim sharing", ginkgo.Serial, ginkgo.Ordered, ginkgo.C
 		daemonSet, err := rootFxt.K8SClientset.AppsV1().DaemonSets("kube-system").Get(ctx, "dracpu", metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
 		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
+		cfgValues, err := getDriverConfigValues(ctx, rootFxt.K8SClientset, "kube-system", daemonSet)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot read dracpu driver config values")
 		var dsReservedCPUs cpuset.CPUSet
-		cnt := &daemonSet.Spec.Template.Spec.Containers[0]
-		if val, ok := findArgInContainer(cnt, argReservedCPUs); ok {
-			dsReservedCPUs, err = cpuset.Parse(val)
+		if len(cfgValues.ReservedCPUs) > 0 {
+			dsReservedCPUs, err = cpuset.Parse(cfgValues.ReservedCPUs)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse daemonset reserved cpus: %v", err)
 		}
-		if val, ok := findArgInContainer(cnt, argCPUDeviceMode); ok {
-			cpuDeviceMode = val
-		}
-		if val, ok := findArgInContainer(cnt, argGroupBy); ok {
-			groupBy = val
-		}
+		cpuDeviceMode = cfgValues.CPUDeviceMode
+		groupBy = cfgValues.GroupBy
 		gomega.Expect(dsReservedCPUs).To(cpusetmatchers.Equal(reservedCPUs), "daemonset reserved cpus do not match test reserved cpus")
 
 		rootFxt.Log.Info("daemonset configuration", "reservedCPUs", dsReservedCPUs.String(), "deviceMode", cpuDeviceMode, "groupBy", groupBy)


### PR DESCRIPTION
#### What type of PR is this?
/kind deprecation

#### What this PR does / why we need it
As a follow up to the migration to the config file. 
Current behavior, cpuDeviceMode, groupBy, hostnameOverride and reservedCPUs end up as args.
```sh
helm install dra-driver-cpu deployment/helm/dra-driver-cpu/ \
--set args.logLevel=6 \
--set args.cpuDeviceMode=individual \
--set args.groupBy=socket \
--set args.reservedCPUs=0-1 \
--set args.hostnameOverride=dra-driver-cpu-worker \
--set args.exposePCIeRoots=true \
--set image.repository=ttl.sh/cpu \
--set image.tag=v1 \
--set fullnameOverride=dracpu-b
```
```
kubectl get ds dracpu-b -o json | jq '.spec.template.spec.containers[0].args'
```
```JSON
[
  "/dracpu",
  "--v=6",
  "--cpu-device-mode=individual",
  "--group-by=socket",
  "--bind-address=:8080",
  "--reserved-cpus=0-1",
  "--hostname-override=dra-driver-cpu-worker",
  "--expose-pcie-roots=true"
] 
```

With this change (using `driverConfig`)
```
helm install dra-driver-cpu deployment/helm/dra-driver-cpu/ \
....
--set driverConfig.cpuDeviceMode=individual \
--set driverConfig.groupBy=socket \
--set driverConfig.reservedCPUs=0-1 \
--set driverConfig.hostnameOverride=dra-driver-cpu-worker \
....
```
or using `args`
```
helm install dra-driver-cpu deployment/helm/dra-driver-cpu \
...
--set args.cpuDeviceMode=individual \
--set args.groupBy=socket \
--set args.reservedCPUs=0-1 \
--set args.hostnameOverride=dra-driver-cpu-worker \
...
```
will result in 

```
kubectl get ds dracpu-b2 -o json | jq '.spec.template.spec.containers[0].args'
```
```JSON
[
  "/dracpu",
  "--v=4",
  "--bind-address=:8080",
  "--expose-pcie-roots=false",
  "--config=/etc/dracpu/config.yaml"
]
```
and those driver configuration options end up as a configMap (config) settings

```YAML
kubectl get configmap dracpu-a-config -o yaml
apiVersion: v1
data:
  config.yaml: |
    cpuDeviceMode: individual
    groupBy: socket
    hostnameOverride: dra-driver-cpu-worker
    reservedCPUs: 0-1
kind: ConfigMap
...
```

#### Which issue(s) this PR is related to
Fixes: https://github.com/kubernetes-sigs/dra-driver-cpu/issues/245

#### Special notes for reviewers
As you will notice during the review, we are not dropping any flags yet and we should probably come to some consensus on the release timeline for finally removing these flags. This patch is more of a signal to the user that are moving away from the flags. 

We print warning in the logs only when flags are explicitly passed on the command line regardless of the value given, even if it matches the built-in default.  The warning is tied to flag usage, not to the resolved config value. Values reaching the driver via `driverConfig` (a mounted config file, whether written directly or Helm folded from `args.*`) never trigger this warning, since no deprecated flag is present on the CLI in that case. This is intentional since it's the migration path we want to encourage.

In other words, warnnig is visible for example when driver is configured via `extraArgs`

```
helm install dra-driver-cpu deployment/helm/dra-driver-cpu \
--set fullnameOverride=dracpu-warn \
--set-string extraArgs[0]=--cpu-device-mode=individual \
--set image.repository=ttl.sh/cpu \
--set image.tag=v2
```

```
kubectl logs dracpu-warn-6jbz9 | grep -i "deprecated\|Warning"
I0728 08:28:52.016591       1 load.go:67] "flag is deprecated and will be removed in a future release; prefer the equivalent driverConfig field instead" flag="cpu-device-mode" driverConfigField="cpuDeviceMode"
Warning: Flag --cpu-device-mode has been deprecated, prefer driverConfig field "cpuDeviceMode"; this flag will be removed in a future release

```

#### Release note
```release-note
Deprecated: the CLI flags `--cpu-device-mode`, `--group-by`, `--reserved-cpus`, `--hostname-override`, `--sysfs-overlay` in favor of `driverConfig`. Deprecated flags now show a deprecation notice in `--help` and log a startup warning when used. The Helm chart automatically migrates equivalent `args.*` values into the generated `driverConfig` ConfigMap, with no behavior change for existing users.
```

#### Documentation updates
- README updates
- Helm chart docs
