### PR TITLE
feat: publish device attributes as KEP-5304 metadata

### DIFF
--- a/pkg/device/attributes.go
+++ b/pkg/device/attributes.go
@@ -45,6 +45,10 @@ const (
 	AttributeCoreID     resourceapi.QualifiedName = "dra.cpu/coreID"
 	AttributeCPUID      resourceapi.QualifiedName = "dra.cpu/cpuID"
 	AttributeNumCPUs    resourceapi.QualifiedName = "dra.cpu/numCPUs"
+	// AttributeAllocatedNumCPUs is a metadata-only attribute (not published in
+	// ResourceSlice) that indicates how many CPUs were allocated to a specific
+	// claim from a grouped device's capacity.
+	AttributeAllocatedNumCPUs resourceapi.QualifiedName = "dra.cpu/allocatedNumCPUs"
 )
 
 // SetCompatibilityAttributes add attributes to enable compatibility (e.g. alignment) with other

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -283,7 +283,7 @@ func (cp *CPUDriver) prepareDevices(logger logr.Logger, claim *resourceapi.Resou
 		if allocResult.Request != "" {
 			preparedDevice.Requests = []string{allocResult.Request}
 		}
-		if attrs, ok := cp.getDeviceAttributes(allocResult.Device); ok && len(attrs) > 0 {
+		if attrs, ok := getDeviceAttributes(cp.topology.deviceSlices, allocResult.Device); ok && len(attrs) > 0 {
 			metadataAttrs := make(map[string]resourceapi.DeviceAttribute, len(attrs))
 			for k, v := range attrs {
 				metadataAttrs[string(k)] = v

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -283,6 +283,16 @@ func (cp *CPUDriver) prepareDevices(logger logr.Logger, claim *resourceapi.Resou
 		if allocResult.Request != "" {
 			preparedDevice.Requests = []string{allocResult.Request}
 		}
+		if attrs, ok := cp.getDeviceAttributes(allocResult.Device); ok && len(attrs) > 0 {
+			metadataAttrs := make(map[string]resourceapi.DeviceAttribute, len(attrs))
+			for k, v := range attrs {
+				metadataAttrs[string(k)] = v
+			}
+			preparedDevice.Metadata = &kubeletplugin.DeviceMetadata{
+				Attributes: metadataAttrs,
+			}
+			logger.V(6).Info("added device metadata", "device", allocResult.Device, "numAttrs", len(metadataAttrs))
+		}
 		preparedDevices = append(preparedDevices, preparedDevice)
 	}
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -288,6 +288,12 @@ func (cp *CPUDriver) prepareDevices(logger logr.Logger, claim *resourceapi.Resou
 			for k, v := range attrs {
 				metadataAttrs[string(k)] = v
 			}
+			if quantity, ok := allocResult.ConsumedCapacity[device.CPUResourceQualifiedName]; ok {
+				allocatedCount := quantity.Value()
+				metadataAttrs[string(device.AttributeAllocatedNumCPUs)] = resourceapi.DeviceAttribute{
+					IntValue: &allocatedCount,
+				}
+			}
 			preparedDevice.Metadata = &kubeletplugin.DeviceMetadata{
 				Attributes: metadataAttrs,
 			}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -643,8 +643,10 @@ func TestPrepareResourceClaims(t *testing.T) {
 			expectedCdiDevice:       cdiDeviceName,
 			expectedCdiEnvVar:       fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, "0-1"),
 			expectedPreparedDevices: []kubeletplugin.Device{
-				{PoolName: testNodeName, DeviceName: "cpudev000", CDIDeviceIDs: []string{cdiQualifiedName}},
-				{PoolName: testNodeName, DeviceName: "cpudev002", CDIDeviceIDs: []string{cdiQualifiedName}},
+				{PoolName: testNodeName, DeviceName: "cpudev000", CDIDeviceIDs: []string{cdiQualifiedName},
+					Metadata: metadataFromCPUInfo(cpuinfo.CPUInfo{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance}, false)},
+				{PoolName: testNodeName, DeviceName: "cpudev002", CDIDeviceIDs: []string{cdiQualifiedName},
+					Metadata: metadataFromCPUInfo(cpuinfo.CPUInfo{CpuID: 1, CoreID: 1, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance}, false)},
 			},
 		},
 		{
@@ -747,7 +749,8 @@ func TestPrepareResourceClaims(t *testing.T) {
 			expectedCdiDevice:       cdiDeviceName,
 			expectedCdiEnvVar:       fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, "0"),
 			expectedPreparedDevices: []kubeletplugin.Device{
-				{PoolName: testNodeName, DeviceName: "cpudev000", CDIDeviceIDs: []string{cdiQualifiedName}},
+				{PoolName: testNodeName, DeviceName: "cpudev000", CDIDeviceIDs: []string{cdiQualifiedName},
+					Metadata: metadataFromCPUInfo(cpuinfo.CPUInfo{CpuID: 0, CoreID: 0, SocketID: 0, NUMANodeID: 0, CoreType: cpuinfo.CoreTypePerformance}, false)},
 			},
 		},
 		{
@@ -798,11 +801,7 @@ func TestPrepareResourceClaims(t *testing.T) {
 					require.Empty(t, result.Devices)
 				} else {
 					require.NoError(t, result.Err)
-					expected := tc.expectedPreparedDevices
-					for i := range expected {
-						expected[i].Metadata = expectedDeviceMetadata(driver, expected[i].DeviceName)
-					}
-					require.ElementsMatch(t, expected, result.Devices)
+					require.ElementsMatch(t, tc.expectedPreparedDevices, result.Devices)
 				}
 			}
 
@@ -1227,13 +1226,16 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 					// Build expected devices based on the claim request
 					expectedPreparedDevices := []kubeletplugin.Device{}
 					if tc.expectedCPUSet.Size() != 0 || tc.expectedError {
+						// testSysFS doesn't include cpu/smt/control, so
+						// the driver's cpuTopology.SMTEnabled is always false
+						smtEnabled := false
 						for _, res := range tc.claims[0].Status.Allocation.Devices.Results {
 							expectedPreparedDevices = append(expectedPreparedDevices, kubeletplugin.Device{
 								PoolName:     res.Pool,
 								DeviceName:   res.Device,
 								CDIDeviceIDs: []string{cdiQualifiedName},
 								Requests:     []string{res.Request},
-								Metadata:     expectedDeviceMetadata(driver, res.Device),
+								Metadata:     expectedGroupMetadata(tc.groupBy, tc.cpuInfos, tc.reservedCPUs, res.Device, smtEnabled),
 							})
 						}
 					}
@@ -2116,19 +2118,68 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 	return driver
 }
 
-// expectedDeviceMetadata builds the DeviceMetadata that prepareDevices would
-// produce for a device, by looking up its attributes from the driver's
-// deviceSlices. Returns nil if the device is not found or has no attributes.
-func expectedDeviceMetadata(driver *CPUDriver, deviceName string) *kubeletplugin.DeviceMetadata {
-	attrs, ok := driver.getDeviceAttributes(deviceName)
-	if !ok || len(attrs) == 0 {
-		return nil
+// metadataFromCPUInfo builds a DeviceMetadata from static test data,
+// independent of production code paths.
+func metadataFromCPUInfo(cpu cpuinfo.CPUInfo, smtEnabled bool) *kubeletplugin.DeviceMetadata {
+	attrs := map[string]resourceapi.DeviceAttribute{
+		string(devattr.AttributeCPUID):      {IntValue: new(int64(cpu.CpuID))},
+		string(devattr.AttributeCoreID):     {IntValue: new(int64(cpu.CoreID))},
+		string(devattr.AttributeSocketID):   {IntValue: new(int64(cpu.SocketID))},
+		string(devattr.AttributeNUMANodeID): {IntValue: new(int64(cpu.NUMANodeID))},
+		string(devattr.AttributeCacheL3ID):  {IntValue: new(int64(cpu.UncoreCacheID))},
+		string(devattr.AttributeCoreType):   {StringValue: new(cpu.CoreType.String())},
+		string(devattr.AttributeSMTEnabled): {BoolValue: new(smtEnabled)},
+		"dra.net/numaNode":                  {IntValue: new(int64(cpu.NUMANodeID))},
 	}
-	metadataAttrs := make(map[string]resourceapi.DeviceAttribute, len(attrs))
-	for k, v := range attrs {
-		metadataAttrs[string(k)] = v
+	return &kubeletplugin.DeviceMetadata{Attributes: attrs}
+}
+
+// expectedGroupMetadata builds the expected DeviceMetadata for a grouped
+// device from static test data, independent of production code paths.
+func expectedGroupMetadata(groupBy string, cpuInfos []cpuinfo.CPUInfo, reservedCPUs cpuset.CPUSet, deviceName string, smtEnabled bool) *kubeletplugin.DeviceMetadata {
+	attrs := map[string]resourceapi.DeviceAttribute{}
+
+	switch groupBy {
+	case devattr.GROUP_BY_SOCKET:
+		var socketID int
+		_, _ = fmt.Sscanf(deviceName, devattr.CPUDeviceSocketGroupedPrefix+"%d", &socketID)
+		var numCPUs int64
+		for _, ci := range cpuInfos {
+			if ci.SocketID == socketID && !reservedCPUs.Contains(ci.CpuID) {
+				numCPUs++
+			}
+		}
+		attrs[string(devattr.AttributeSocketID)] = resourceapi.DeviceAttribute{IntValue: new(int64(socketID))}
+		attrs[string(devattr.AttributeNumCPUs)] = resourceapi.DeviceAttribute{IntValue: new(numCPUs)}
+		attrs[string(devattr.AttributeSMTEnabled)] = resourceapi.DeviceAttribute{BoolValue: new(smtEnabled)}
+
+	case devattr.GROUP_BY_NUMA_NODE:
+		var numaID int
+		_, _ = fmt.Sscanf(deviceName, devattr.CPUDeviceNUMAGroupedPrefix+"%d", &numaID)
+		var numCPUs int64
+		var socketID int
+		for _, ci := range cpuInfos {
+			if ci.NUMANodeID == numaID && !reservedCPUs.Contains(ci.CpuID) {
+				numCPUs++
+				socketID = ci.SocketID
+			}
+		}
+		attrs[string(devattr.AttributeNUMANodeID)] = resourceapi.DeviceAttribute{IntValue: new(int64(numaID))}
+		attrs[string(devattr.AttributeSocketID)] = resourceapi.DeviceAttribute{IntValue: new(int64(socketID))}
+		attrs[string(devattr.AttributeNumCPUs)] = resourceapi.DeviceAttribute{IntValue: new(numCPUs)}
+		attrs[string(devattr.AttributeSMTEnabled)] = resourceapi.DeviceAttribute{BoolValue: new(smtEnabled)}
+		attrs["dra.net/numaNode"] = resourceapi.DeviceAttribute{IntValue: new(int64(numaID))}
+
+	case devattr.GROUP_BY_MACHINE:
+		var numCPUs int64
+		for _, ci := range cpuInfos {
+			if !reservedCPUs.Contains(ci.CpuID) {
+				numCPUs++
+			}
+		}
+		attrs[string(devattr.AttributeNumCPUs)] = resourceapi.DeviceAttribute{IntValue: new(numCPUs)}
+		attrs[string(devattr.AttributeSMTEnabled)] = resourceapi.DeviceAttribute{BoolValue: new(smtEnabled)}
 	}
-	return &kubeletplugin.DeviceMetadata{
-		Attributes: metadataAttrs,
-	}
+
+	return &kubeletplugin.DeviceMetadata{Attributes: attrs}
 }

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1230,12 +1230,16 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 						// the driver's cpuTopology.SMTEnabled is always false
 						smtEnabled := false
 						for _, res := range tc.claims[0].Status.Allocation.Devices.Results {
+							var allocatedCPUs int64
+							if q, ok := res.ConsumedCapacity[devattr.CPUResourceQualifiedName]; ok {
+								allocatedCPUs = q.Value()
+							}
 							expectedPreparedDevices = append(expectedPreparedDevices, kubeletplugin.Device{
 								PoolName:     res.Pool,
 								DeviceName:   res.Device,
 								CDIDeviceIDs: []string{cdiQualifiedName},
 								Requests:     []string{res.Request},
-								Metadata:     expectedGroupMetadata(tc.groupBy, tc.cpuInfos, tc.reservedCPUs, res.Device, smtEnabled),
+								Metadata:     expectedGroupMetadata(tc.groupBy, tc.cpuInfos, tc.reservedCPUs, res.Device, smtEnabled, allocatedCPUs),
 							})
 						}
 					}
@@ -2136,7 +2140,7 @@ func metadataFromCPUInfo(cpu cpuinfo.CPUInfo, smtEnabled bool) *kubeletplugin.De
 
 // expectedGroupMetadata builds the expected DeviceMetadata for a grouped
 // device from static test data, independent of production code paths.
-func expectedGroupMetadata(groupBy string, cpuInfos []cpuinfo.CPUInfo, reservedCPUs cpuset.CPUSet, deviceName string, smtEnabled bool) *kubeletplugin.DeviceMetadata {
+func expectedGroupMetadata(groupBy string, cpuInfos []cpuinfo.CPUInfo, reservedCPUs cpuset.CPUSet, deviceName string, smtEnabled bool, allocatedCPUs int64) *kubeletplugin.DeviceMetadata {
 	attrs := map[string]resourceapi.DeviceAttribute{}
 
 	switch groupBy {
@@ -2179,6 +2183,10 @@ func expectedGroupMetadata(groupBy string, cpuInfos []cpuinfo.CPUInfo, reservedC
 		}
 		attrs[string(devattr.AttributeNumCPUs)] = resourceapi.DeviceAttribute{IntValue: new(numCPUs)}
 		attrs[string(devattr.AttributeSMTEnabled)] = resourceapi.DeviceAttribute{BoolValue: new(smtEnabled)}
+	}
+
+	if allocatedCPUs > 0 {
+		attrs[string(devattr.AttributeAllocatedNumCPUs)] = resourceapi.DeviceAttribute{IntValue: new(allocatedCPUs)}
 	}
 
 	return &kubeletplugin.DeviceMetadata{Attributes: attrs}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -798,7 +798,11 @@ func TestPrepareResourceClaims(t *testing.T) {
 					require.Empty(t, result.Devices)
 				} else {
 					require.NoError(t, result.Err)
-					require.ElementsMatch(t, tc.expectedPreparedDevices, result.Devices)
+					expected := tc.expectedPreparedDevices
+					for i := range expected {
+						expected[i].Metadata = expectedDeviceMetadata(driver, expected[i].DeviceName)
+					}
+					require.ElementsMatch(t, expected, result.Devices)
 				}
 			}
 
@@ -1229,6 +1233,7 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 								DeviceName:   res.Device,
 								CDIDeviceIDs: []string{cdiQualifiedName},
 								Requests:     []string{res.Request},
+								Metadata:     expectedDeviceMetadata(driver, res.Device),
 							})
 						}
 					}
@@ -2109,4 +2114,21 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 		}
 	}
 	return driver
+}
+
+// expectedDeviceMetadata builds the DeviceMetadata that prepareDevices would
+// produce for a device, by looking up its attributes from the driver's
+// deviceSlices. Returns nil if the device is not found or has no attributes.
+func expectedDeviceMetadata(driver *CPUDriver, deviceName string) *kubeletplugin.DeviceMetadata {
+	attrs, ok := driver.getDeviceAttributes(deviceName)
+	if !ok || len(attrs) == 0 {
+		return nil
+	}
+	metadataAttrs := make(map[string]resourceapi.DeviceAttribute, len(attrs))
+	for k, v := range attrs {
+		metadataAttrs[string(k)] = v
+	}
+	return &kubeletplugin.DeviceMetadata{
+		Attributes: metadataAttrs,
+	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -339,8 +339,8 @@ func (cp *CPUDriver) Stop() {
 	cp.draPlugin.Stop()
 }
 
-func (cp *CPUDriver) getDeviceAttributes(deviceName string) (map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, bool) {
-	for _, slice := range cp.topology.deviceSlices {
+func getDeviceAttributes(deviceSlices [][]resourceapi.Device, deviceName string) (map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, bool) {
+	for _, slice := range deviceSlices {
 		for _, dev := range slice {
 			if dev.Name == deviceName {
 				return dev.Attributes, true

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -36,6 +36,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	drametadatav1alpha1 "k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/utils/cpuset"
@@ -284,6 +285,8 @@ func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
 		kubeletplugin.KubeClient(cp.kubeClient),
 		kubeletplugin.RegistrarDirectoryPath(registrarDir(cp.kubeletRootDir)),
 		kubeletplugin.PluginDataDirectoryPath(driverPluginPath),
+		kubeletplugin.EnableDeviceMetadata(true),
+		kubeletplugin.MetadataVersions(drametadatav1alpha1.SchemeGroupVersion),
 	}
 	d, err := kubeletplugin.Start(ctx, cp, kubeletOpts...)
 	if err != nil {
@@ -334,6 +337,17 @@ func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
 func (cp *CPUDriver) Stop() {
 	cp.nriPlugin.Stop()
 	cp.draPlugin.Stop()
+}
+
+func (cp *CPUDriver) getDeviceAttributes(deviceName string) (map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, bool) {
+	for _, slice := range cp.topology.deviceSlices {
+		for _, dev := range slice {
+			if dev.Name == deviceName {
+				return dev.Attributes, true
+			}
+		}
+	}
+	return nil, false
 }
 
 // Shutdown is called when the runtime is shutting down.

--- a/test/e2e/metadata_test.go
+++ b/test/e2e/metadata_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	e2eclient "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/client"
+	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/fixture"
+	e2enode "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/node"
+	e2epod "github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/pod"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+type metadataEntry struct {
+	Path    string          `json:"path"`
+	Content json.RawMessage `json:"content"`
+}
+
+type metadataFile struct {
+	Requests []metadataRequest `json:"requests"`
+}
+
+type metadataRequest struct {
+	Name    string           `json:"name"`
+	Devices []metadataDevice `json:"devices"`
+}
+
+type metadataDevice struct {
+	Driver     string                  `json:"driver"`
+	Pool       string                  `json:"pool"`
+	Name       string                  `json:"name"`
+	Attributes map[string]metadataAttr `json:"attributes"`
+}
+
+type metadataAttr struct {
+	Int    *int64  `json:"int,omitempty"`
+	Bool   *bool   `json:"bool,omitempty"`
+	String *string `json:"string,omitempty"`
+}
+
+var _ = ginkgo.Describe("Device Metadata", ginkgo.Ordered, func() {
+	var (
+		rootFxt           *fixture.Fixture
+		restConfig        *rest.Config
+		targetNode        *v1.Node
+		dracpuTesterImage string
+		cpuDeviceMode     string
+		groupBy           string
+	)
+
+	ginkgo.BeforeAll(func(ctx context.Context) {
+		dracpuTesterImage = os.Getenv("DRACPU_E2E_TEST_IMAGE")
+		gomega.Expect(dracpuTesterImage).ToNot(gomega.BeEmpty(), "missing environment variable DRACPU_E2E_TEST_IMAGE")
+
+		var err error
+		rootFxt, err = fixture.ForGinkgo()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture")
+
+		restConfig, err = e2eclient.NewK8SConfig()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create Kubernetes config")
+
+		daemonSet, err := rootFxt.K8SClientset.AppsV1().DaemonSets("kube-system").Get(ctx, "dracpu", metav1.GetOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
+		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty())
+		cfgValues, err := getDriverConfigValues(ctx, rootFxt.K8SClientset, "kube-system", daemonSet)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot read driver config values")
+		cpuDeviceMode = cfgValues.CPUDeviceMode
+		groupBy = cfgValues.GroupBy
+		rootFxt.Log.Info("daemonset configuration", "mode", cpuDeviceMode, "groupBy", groupBy)
+
+		targetNode, err = e2enode.PickWorker(ctx, rootFxt.K8SClientset, 5*time.Second, 1*time.Minute, rootFxt.Log)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		rootFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
+	})
+
+	ginkgo.Context("when a pod with a CPU claim is running", func() {
+		var fxt *fixture.Fixture
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			fxt = rootFxt.WithPrefix("metadata")
+			gomega.Expect(fxt.Setup(ctx)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			gomega.Expect(fxt.Teardown(ctx)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("should publish device attributes as KEP-5304 metadata files", func(ctx context.Context) {
+			if groupBy == device.GROUP_BY_MACHINE {
+				ginkgo.Skip("skipping this test in machine grouping mode as we do not configure opaque config in claim")
+			}
+
+			const numCPUs = 2
+			isConsumable := cpuDeviceMode != device.CPU_DEVICE_MODE_INDIVIDUAL
+
+			ginkgo.By("creating a resource claim")
+			claimName := "metadata-test-claim"
+			claim := &resourcev1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: fxt.Namespace.Name,
+					Name:      claimName,
+				},
+				Spec: makeResourceClaimSpec(numCPUs, isConsumable),
+			}
+			_, err := fxt.K8SClientset.ResourceV1().ResourceClaims(fxt.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("creating a pod that references the claim")
+			pod := makeTesterPodWithNamedClaim(fxt.Namespace.Name, dracpuTesterImage, claimName, targetNode.Name)
+			pod, err = e2epod.CreateSync(ctx, fxt.K8SClientset, pod)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("reading metadata files from inside the container")
+			stdout, stderr, err := e2epod.Exec(ctx, restConfig, fxt.K8SClientset, pod, "/dracpumetadata")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(),
+				"dracpumetadata failed; stdout: %s; stderr: %s", stdout, stderr)
+
+			var entries []metadataEntry
+			gomega.Expect(json.Unmarshal([]byte(stdout), &entries)).To(gomega.Succeed(),
+				"failed to parse dracpumetadata output: %s", stdout)
+			gomega.Expect(entries).ToNot(gomega.BeEmpty(), "no metadata files found")
+
+			ginkgo.By("verifying metadata content")
+			var metadata metadataFile
+			gomega.Expect(json.Unmarshal(entries[0].Content, &metadata)).To(gomega.Succeed(),
+				"failed to parse metadata JSON: %s", string(entries[0].Content))
+
+			gomega.Expect(metadata.Requests).To(gomega.HaveLen(1))
+			req := metadata.Requests[0]
+			gomega.Expect(req.Name).To(gomega.Equal("request-cpus"))
+			gomega.Expect(req.Devices).ToNot(gomega.BeEmpty())
+
+			dev := req.Devices[0]
+			gomega.Expect(dev.Driver).To(gomega.Equal("dra.cpu"))
+
+			ginkgo.By("verifying mode-specific attributes")
+			switch cpuDeviceMode {
+			case device.CPU_DEVICE_MODE_INDIVIDUAL:
+				expectIntAttr(dev.Attributes, "dra.cpu/cpuID")
+				expectIntAttr(dev.Attributes, "dra.cpu/coreID")
+				expectIntAttr(dev.Attributes, "dra.cpu/socketID")
+				expectIntAttr(dev.Attributes, "dra.cpu/numaNodeID")
+				expectIntAttr(dev.Attributes, "dra.cpu/cacheL3ID")
+				expectStringAttr(dev.Attributes, "dra.cpu/coreType")
+				expectBoolAttr(dev.Attributes, "dra.cpu/smtEnabled")
+			default: // grouped
+				expectBoolAttr(dev.Attributes, "dra.cpu/smtEnabled")
+				expectIntAttr(dev.Attributes, "dra.cpu/numCPUs")
+				expectAllocatedNumCPUs(dev.Attributes, numCPUs)
+				switch groupBy {
+				case device.GROUP_BY_SOCKET:
+					expectIntAttr(dev.Attributes, "dra.cpu/socketID")
+				default: // NUMA node (default when groupBy is "" or "numanode")
+					expectIntAttr(dev.Attributes, "dra.cpu/numaNodeID")
+					expectIntAttr(dev.Attributes, "dra.cpu/socketID")
+				}
+			}
+		})
+	})
+})
+
+func expectIntAttr(attrs map[string]metadataAttr, name string) {
+	ginkgo.GinkgoHelper()
+	attr, ok := attrs[name]
+	gomega.Expect(ok).To(gomega.BeTrue(), "missing attribute %s", name)
+	gomega.Expect(attr.Int).ToNot(gomega.BeNil(), "attribute %s should be int", name)
+}
+
+func expectBoolAttr(attrs map[string]metadataAttr, name string) {
+	ginkgo.GinkgoHelper()
+	attr, ok := attrs[name]
+	gomega.Expect(ok).To(gomega.BeTrue(), "missing attribute %s", name)
+	gomega.Expect(attr.Bool).ToNot(gomega.BeNil(), "attribute %s should be bool", name)
+}
+
+func expectStringAttr(attrs map[string]metadataAttr, name string) {
+	ginkgo.GinkgoHelper()
+	attr, ok := attrs[name]
+	gomega.Expect(ok).To(gomega.BeTrue(), "missing attribute %s", name)
+	gomega.Expect(attr.String).ToNot(gomega.BeNil(), "attribute %s should be string", name)
+}
+
+func expectAllocatedNumCPUs(attrs map[string]metadataAttr, expected int) {
+	ginkgo.GinkgoHelper()
+	attr, ok := attrs["dra.cpu/allocatedNumCPUs"]
+	gomega.Expect(ok).To(gomega.BeTrue(), "missing dra.cpu/allocatedNumCPUs")
+	gomega.Expect(attr.Int).ToNot(gomega.BeNil())
+	gomega.Expect(*attr.Int).To(gomega.Equal(int64(expected)))
+
+	numCPUsAttr, ok := attrs["dra.cpu/numCPUs"]
+	gomega.Expect(ok).To(gomega.BeTrue(), "missing dra.cpu/numCPUs")
+	gomega.Expect(*numCPUsAttr.Int).To(gomega.BeNumerically(">=", int64(expected)))
+}

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -26,9 +26,11 @@ RUN go mod download
 COPY . .
 RUN go build -o /go/bin/dracpuinfo ./test/image/dracpuinfo
 RUN go build -o /go/bin/dracputester ./test/image/dracputester
+RUN go build -o /go/bin/dracpumetadata ./test/image/dracpumetadata
 
 # copy binaries onto base image
 FROM gcr.io/distroless/base-debian12
 COPY --from=builder --chown=root:root /go/bin/dracpuinfo /dracpuinfo
 COPY --from=builder --chown=root:root /go/bin/dracputester /dracputester
+COPY --from=builder --chown=root:root /go/bin/dracpumetadata /dracpumetadata
 CMD ["/dracputester"]

--- a/test/image/dracpumetadata/app.go
+++ b/test/image/dracpumetadata/app.go
@@ -1,0 +1,63 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const metadataBasePath = "/var/run/kubernetes.io/dra-device-attributes"
+
+type metadataEntry struct {
+	Path    string          `json:"path"`
+	Content json.RawMessage `json:"content"`
+}
+
+func main() {
+	var entries []metadataEntry
+
+	err := filepath.WalkDir(metadataBasePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		data, err := os.ReadFile(path) //nolint:gosec // path is from WalkDir under a fixed base directory
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		entries = append(entries, metadataEntry{
+			Path:    path,
+			Content: json.RawMessage(data),
+		})
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error scanning metadata: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(entries); err != nil {
+		fmt.Fprintf(os.Stderr, "error encoding output: %v\n", err)
+		os.Exit(2)
+	}
+}


### PR DESCRIPTION
## Summary

- Enable KEP-5304 device metadata publishing so consumers can read
  per-device attributes (NUMA node, socket, core ID, etc.) from
  metadata files mounted into containers
- Add `EnableDeviceMetadata`, `MetadataVersions`, and
  `PluginDataDirectoryPath` options to `kubeletplugin.Start()`
- Populate `Metadata` field on each prepared device in `prepareDevices()`
  with the same attributes published in the ResourceSlice
- Add `getDeviceAttributes()` helper that looks up attributes from
  the existing `deviceSlices` field

Fixes #264

## Test plan

- [x] Existing unit tests updated to verify metadata is populated
- [x] All unit tests pass (`go test ./pkg/driver/...`)
- [x] `golangci-lint` passes with zero issues
- [ ] Manual verification: deploy on test cluster, create CPU claim,
      verify metadata JSON files at
      `/var/run/kubernetes.io/dra-device-attributes/` inside container