### PR TITLE
chore: group CPUDriver topology fields into their own struct

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -45,13 +45,13 @@ func (cp *CPUDriver) PublishResources(ctx context.Context) {
 	logger.V(4).Info("begin: publishing resources")
 	defer logger.V(4).Info("end: publishing resources")
 
-	if cp.deviceSlices == nil {
+	if cp.topology.deviceSlices == nil {
 		logger.Info("no devices to publish or error occurred")
 		return
 	}
 
-	slices := make([]resourceslice.Slice, 0, len(cp.deviceSlices))
-	for _, chunk := range cp.deviceSlices {
+	slices := make([]resourceslice.Slice, 0, len(cp.topology.deviceSlices))
+	for _, chunk := range cp.topology.deviceSlices {
 		slices = append(slices, resourceslice.Slice{Devices: chunk})
 	}
 
@@ -140,14 +140,14 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			logger.V(4).Info("found CPU request", "numCPUs", count, "device", alloc.Device)
 		}
 
-		topo := cp.cpuTopology
+		topo := cp.topology.cpuTopology
 
 		var cur cpuset.CPUSet
 		var err error
 
 		switch cp.cpuDeviceGroupBy {
 		case device.GROUP_BY_SOCKET:
-			socketID, ok := cp.deviceNameToSocketID[alloc.Device]
+			socketID, ok := cp.topology.deviceNameToSocketID[alloc.Device]
 			if !ok {
 				return kubeletplugin.PrepareResult{Err: fmt.Errorf("no valid socket ID found for device %s", alloc.Device)}
 			}
@@ -156,7 +156,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 			logger.V(4).Info("socket CPU availability", "socketID", socketID, "socketCPUs", socketCPUs.String(), "availableCPUs", availableCPUsForDevice.String())
 			cur, err = cpumanager.TakeByTopologyNUMAPacked(logger, topo, availableCPUsForDevice, int(claimCPUCount), cpumanager.CPUSortingStrategyPacked, true)
 		case device.GROUP_BY_NUMA_NODE:
-			numaNodeID, ok := cp.deviceNameToNUMANodeID[alloc.Device]
+			numaNodeID, ok := cp.topology.deviceNameToNUMANodeID[alloc.Device]
 			if !ok {
 				return kubeletplugin.PrepareResult{Err: fmt.Errorf("no valid NUMA node ID found for device %s", alloc.Device)}
 			}
@@ -173,7 +173,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 				return kubeletplugin.PrepareResult{Err: fmt.Errorf("no opaque cpuset configuration found for allocation request %q", alloc.Request)}
 			}
 
-			if err := cp.validateOpaqueCPUSet(opaqueCPUSet, cp.onlineCPUs, cpuAssignment, claimCPUCount); err != nil {
+			if err := cp.validateOpaqueCPUSet(opaqueCPUSet, cp.topology.onlineCPUs, cpuAssignment, claimCPUCount); err != nil {
 				return kubeletplugin.PrepareResult{Err: err}
 			}
 			cur = opaqueCPUSet
@@ -216,7 +216,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		if alloc.Driver != cp.driverName {
 			continue
 		}
-		cpuID, ok := cp.deviceNameToCPUID[alloc.Device]
+		cpuID, ok := cp.topology.deviceNameToCPUID[alloc.Device]
 		if !ok {
 			return kubeletplugin.PrepareResult{
 				Err: fmt.Errorf("device %q not found in device to CPU ID map", alloc.Device),

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -380,7 +380,7 @@ func TestPublishResources(t *testing.T) {
 				totalDevices += len(s.Devices)
 			}
 			require.Equal(t, tc.expectedDevices, totalDevices)
-			require.Len(t, cp.deviceNameToCPUID, tc.expectedDevices)
+			require.Len(t, cp.topology.deviceNameToCPUID, tc.expectedDevices)
 
 			// Verify device attributes
 			cpuInfosMap := make(map[int]cpuinfo.CPUInfo)
@@ -488,9 +488,9 @@ func TestPublishResourcesGroupedModeInitializesLookupMaps(t *testing.T) {
 			require.NotNil(t, mockPlugin.publishedResources)
 			switch tc.cpuDeviceGroupBy {
 			case devattr.GROUP_BY_SOCKET:
-				require.NotEmpty(t, cp.deviceNameToSocketID)
+				require.NotEmpty(t, cp.topology.deviceNameToSocketID)
 			case devattr.GROUP_BY_NUMA_NODE:
-				require.NotEmpty(t, cp.deviceNameToNUMANodeID)
+				require.NotEmpty(t, cp.topology.deviceNameToNUMANodeID)
 			}
 		})
 	}
@@ -796,11 +796,13 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 		require.NoError(t, err)
 		driver := &CPUDriver{
 			driverName: testDriverName,
-			deviceNameToCPUID: map[string]int{
-				"cpudev0": 0,
-				"cpudev1": 1,
-				"cpudev2": 2,
-				"cpudev3": 3,
+			topology: deviceTopology{
+				deviceNameToCPUID: map[string]int{
+					"cpudev0": 0,
+					"cpudev1": 1,
+					"cpudev2": 2,
+					"cpudev3": 3,
+				},
 			},
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 		}
@@ -815,13 +817,15 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 		topo, err := mockProvider.GetCPUTopology(logger)
 		require.NoError(t, err)
 		driver := &CPUDriver{
-			driverName:             testDriverName,
-			cpuDeviceMode:          devattr.CPU_DEVICE_MODE_GROUPED,
-			cpuDeviceGroupBy:       devattr.GROUP_BY_SOCKET,
-			cpuTopology:            topo,
-			deviceNameToSocketID:   map[string]int{"cpudevsocket0": 0},
-			deviceNameToNUMANodeID: map[string]int{},
-			cpuAllocationStore:     store.NewCPUAllocation(topo, cpuset.New()),
+			driverName:       testDriverName,
+			cpuDeviceMode:    devattr.CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy: devattr.GROUP_BY_SOCKET,
+			topology: deviceTopology{
+				cpuTopology:            topo,
+				deviceNameToSocketID:   map[string]int{"cpudevsocket0": 0},
+				deviceNameToNUMANodeID: map[string]int{},
+			},
+			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 		}
 		if withExistingAllocation {
 			driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, existingCPUs)
@@ -1398,14 +1402,16 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 		topo, _ := mockProvider.GetCPUTopology(logger)
 		cpuStore := store.NewCPUAllocation(topo, cpuset.New())
 		return &CPUDriver{
-			driverName:             testDriverName,
-			cpuDeviceMode:          devattr.CPU_DEVICE_MODE_GROUPED,
-			cpuDeviceGroupBy:       devattr.GROUP_BY_SOCKET,
-			cpuTopology:            topo,
-			deviceNameToSocketID:   map[string]int{"cpudevsocket0": 0, "cpudevsocket1": 1},
-			deviceNameToNUMANodeID: map[string]int{},
-			cpuAllocationStore:     cpuStore,
-			cdiMgr:                 cdiMgr,
+			driverName:       testDriverName,
+			cpuDeviceMode:    devattr.CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy: devattr.GROUP_BY_SOCKET,
+			topology: deviceTopology{
+				cpuTopology:            topo,
+				deviceNameToSocketID:   map[string]int{"cpudevsocket0": 0, "cpudevsocket1": 1},
+				deviceNameToNUMANodeID: map[string]int{},
+			},
+			cpuAllocationStore: cpuStore,
+			cdiMgr:             cdiMgr,
 		}, cpuStore, cdiMgr
 	}
 	makeNUMADriver := func(logger logr.Logger) (*CPUDriver, *store.CPUAllocation, *mockCdiMgr) {
@@ -1414,14 +1420,16 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 		topo, _ := mockProvider.GetCPUTopology(logger)
 		cpuStore := store.NewCPUAllocation(topo, cpuset.New())
 		return &CPUDriver{
-			driverName:             testDriverName,
-			cpuDeviceMode:          devattr.CPU_DEVICE_MODE_GROUPED,
-			cpuDeviceGroupBy:       devattr.GROUP_BY_NUMA_NODE,
-			cpuTopology:            topo,
-			deviceNameToSocketID:   map[string]int{},
-			deviceNameToNUMANodeID: map[string]int{"cpudevnuma0": 0, "cpudevnuma1": 1},
-			cpuAllocationStore:     cpuStore,
-			cdiMgr:                 cdiMgr,
+			driverName:       testDriverName,
+			cpuDeviceMode:    devattr.CPU_DEVICE_MODE_GROUPED,
+			cpuDeviceGroupBy: devattr.GROUP_BY_NUMA_NODE,
+			topology: deviceTopology{
+				cpuTopology:            topo,
+				deviceNameToSocketID:   map[string]int{},
+				deviceNameToNUMANodeID: map[string]int{"cpudevnuma0": 0, "cpudevnuma1": 1},
+			},
+			cpuAllocationStore: cpuStore,
+			cdiMgr:             cdiMgr,
 		}, cpuStore, cdiMgr
 	}
 
@@ -1979,12 +1987,12 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 	driver.driverName = testDriverName
 	driver.cpuDeviceMode = devattr.CPU_DEVICE_MODE_GROUPED
 	driver.cpuDeviceGroupBy = groupBy
-	driver.deviceNameToSocketID = make(map[string]int)
-	driver.deviceNameToNUMANodeID = make(map[string]int)
+	driver.topology.deviceNameToSocketID = make(map[string]int)
+	driver.topology.deviceNameToNUMANodeID = make(map[string]int)
 	mockProvider := &cpuinfo.MockCPUInfoProvider{CPUInfos: cpuInfos}
-	driver.cpuTopology, _ = mockProvider.GetCPUTopology(logger)
-	driver.onlineCPUs = driver.cpuTopology.CPUDetails.CPUs()
-	driver.cpuAllocationStore = store.NewCPUAllocation(driver.cpuTopology, reservedCPUs)
+	driver.topology.cpuTopology, _ = mockProvider.GetCPUTopology(logger)
+	driver.topology.onlineCPUs = driver.topology.cpuTopology.CPUDetails.CPUs()
+	driver.cpuAllocationStore = store.NewCPUAllocation(driver.topology.cpuTopology, reservedCPUs)
 	for claimUID, cpus := range initialAllocations {
 		driver.cpuAllocationStore.AddResourceClaimAllocation(logger, claimUID, cpus)
 	}
@@ -1995,11 +2003,11 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 	switch driver.cpuDeviceGroupBy {
 	case devattr.GROUP_BY_SOCKET:
 		for i := 0; i < topo.NumSockets; i++ {
-			driver.deviceNameToSocketID[fmt.Sprintf("%s%d", devattr.CPUDeviceSocketGroupedPrefix, i)] = i
+			driver.topology.deviceNameToSocketID[fmt.Sprintf("%s%d", devattr.CPUDeviceSocketGroupedPrefix, i)] = i
 		}
 	case devattr.GROUP_BY_NUMA_NODE:
 		for i := 0; i < topo.NumNUMANodes; i++ {
-			driver.deviceNameToNUMANodeID[fmt.Sprintf("%s%d", devattr.CPUDeviceNUMAGroupedPrefix, i)] = i
+			driver.topology.deviceNameToNUMANodeID[fmt.Sprintf("%s%d", devattr.CPUDeviceNUMAGroupedPrefix, i)] = i
 		}
 	}
 	return driver

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -61,9 +61,7 @@ type cdiManager interface {
 }
 
 // CPUInfoProvider is an interface for getting CPU information.
-// TODO(pravk03): This interface can be simplified. We can export only GetCPUTopology() and remove GetCPUInfos().
 type CPUInfoProvider interface {
-	GetCPUInfos(logger logr.Logger) ([]cpuinfo.CPUInfo, error)
 	GetCPUTopology(logger logr.Logger) (*cpuinfo.CPUTopology, error)
 }
 
@@ -77,19 +75,25 @@ type CPUDriver struct {
 	podConfigStore          *store.PodConfig
 	cpuAllocationStore      *store.CPUAllocation
 	cdiMgr                  cdiManager
-	cpuTopology             *cpuinfo.CPUTopology
-	deviceNameToCPUID       map[string]int
-	deviceNameToSocketID    map[string]int
-	deviceNameToNUMANodeID  map[string]int
-	deviceSlices            [][]resourceapi.Device
-	reservedCPUs            cpuset.CPUSet
-	onlineCPUs              cpuset.CPUSet
+	topology                deviceTopology
 	cpuDeviceMode           string
 	cpuDeviceGroupBy        string
 	claimTracker            *store.ClaimTracker
 	pcieRootMapper          *store.PCIeRootMapper
 	devicesPerResourceSlice int
 	metrics                 cpumetrics.Recorder
+}
+
+// deviceTopology holds the CPU topology and device-to-CPU/socket/NUMA
+// mappings. Set once in New(), read-only after that.
+type deviceTopology struct {
+	cpuTopology            *cpuinfo.CPUTopology
+	deviceNameToCPUID      map[string]int
+	deviceNameToSocketID   map[string]int
+	deviceNameToNUMANodeID map[string]int
+	deviceSlices           [][]resourceapi.Device
+	reservedCPUs           cpuset.CPUSet
+	onlineCPUs             cpuset.CPUSet
 }
 
 // Providers group the interfaces the CPUDriver depends on
@@ -143,13 +147,15 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 		metricsRecorder = cpumetrics.Noop()
 	}
 	plugin := &CPUDriver{
-		driverName:              config.DriverName,
-		nodeName:                config.NodeName,
-		kubeClient:              providers.K8SClient,
-		deviceNameToCPUID:       make(map[string]int),
-		deviceNameToSocketID:    make(map[string]int),
-		deviceNameToNUMANodeID:  make(map[string]int),
-		reservedCPUs:            config.ReservedCPUs,
+		driverName: config.DriverName,
+		nodeName:   config.NodeName,
+		kubeClient: providers.K8SClient,
+		topology: deviceTopology{
+			deviceNameToCPUID:      make(map[string]int),
+			deviceNameToSocketID:   make(map[string]int),
+			deviceNameToNUMANodeID: make(map[string]int),
+			reservedCPUs:           config.ReservedCPUs,
+		},
 		cpuDeviceMode:           config.CPUDeviceMode,
 		cpuDeviceGroupBy:        config.CPUDeviceGroupBy,
 		claimTracker:            store.NewClaimTracker(),
@@ -164,7 +170,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 		return nil, fmt.Errorf("failed to get online CPUs: %w", err)
 	}
 	logger.V(2).Info("detected online CPUs", "cpus", onlineCPUs.String())
-	plugin.onlineCPUs = onlineCPUs
+	plugin.topology.onlineCPUs = onlineCPUs
 
 	topo, err := providers.EnsureCPUInfo().GetCPUTopology(logger)
 	if err != nil {
@@ -173,7 +179,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 	if topo == nil {
 		return nil, fmt.Errorf("failed to get CPU topology: topology is nil")
 	}
-	plugin.cpuTopology = topo
+	plugin.topology.cpuTopology = topo
 
 	if config.ExposePCIeRoots {
 		if err := plugin.pcieRootMapper.Probe(logger, sfs, onlineCPUs); err != nil {
@@ -181,7 +187,7 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 		}
 	}
 
-	plugin.cpuAllocationStore = store.NewCPUAllocation(plugin.cpuTopology, config.ReservedCPUs)
+	plugin.cpuAllocationStore = store.NewCPUAllocation(plugin.topology.cpuTopology, config.ReservedCPUs)
 	plugin.refreshAllocationMetrics()
 	plugin.podConfigStore = store.NewPodConfig()
 
@@ -189,20 +195,20 @@ func New(logger logr.Logger, providers Providers, config *Config) (*CPUDriver, e
 
 	if plugin.cpuDeviceMode == device.CPU_DEVICE_MODE_GROUPED {
 		var nameToID map[string]int
-		devices, nameToID = device.BuildGrouped(logger, plugin.cpuDeviceGroupBy, plugin.cpuTopology, plugin.onlineCPUs, plugin.reservedCPUs, plugin.pcieRootMapper)
+		devices, nameToID = device.BuildGrouped(logger, plugin.cpuDeviceGroupBy, plugin.topology.cpuTopology, plugin.topology.onlineCPUs, plugin.topology.reservedCPUs, plugin.pcieRootMapper)
 		switch plugin.cpuDeviceGroupBy {
 		case device.GROUP_BY_SOCKET:
-			plugin.deviceNameToSocketID = nameToID
+			plugin.topology.deviceNameToSocketID = nameToID
 		case device.GROUP_BY_NUMA_NODE:
-			plugin.deviceNameToNUMANodeID = nameToID
+			plugin.topology.deviceNameToNUMANodeID = nameToID
 		}
 	} else {
-		devices, plugin.deviceNameToCPUID = device.Build(plugin.cpuTopology, plugin.reservedCPUs, plugin.pcieRootMapper)
+		devices, plugin.topology.deviceNameToCPUID = device.Build(plugin.topology.cpuTopology, plugin.topology.reservedCPUs, plugin.pcieRootMapper)
 	}
 
 	if len(devices) > 0 {
 		// Chunk devices into slices of at most devicesPerResourceSlice
-		plugin.deviceSlices = slices.Collect(slices.Chunk(devices, plugin.devicesPerResourceSlice))
+		plugin.topology.deviceSlices = slices.Collect(slices.Chunk(devices, plugin.devicesPerResourceSlice))
 	}
 	return plugin, nil
 }

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -47,13 +47,15 @@ func newMetricsTestDriver(t *testing.T) (*CPUDriver, *prometheus.Registry) {
 	recorder := cpumetrics.New(reg)
 	cpuStore := store.NewCPUAllocation(topo, cpuset.New())
 	driver := &CPUDriver{
-		driverName:  testDriverName,
-		cpuTopology: topo,
-		deviceNameToCPUID: map[string]int{
-			"cpudev0": 0,
-			"cpudev1": 1,
-			"cpudev2": 2,
-			"cpudev3": 3,
+		driverName: testDriverName,
+		topology: deviceTopology{
+			cpuTopology: topo,
+			deviceNameToCPUID: map[string]int{
+				"cpudev0": 0,
+				"cpudev1": 1,
+				"cpudev2": 2,
+				"cpudev3": 3,
+			},
 		},
 		podConfigStore:     store.NewPodConfig(),
 		cpuAllocationStore: cpuStore,

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -37,7 +37,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	logger.Info("begin: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
 	defer logger.Info("end: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
 
-	cpuAllocationStore := store.NewCPUAllocation(cp.cpuTopology, cp.reservedCPUs)
+	cpuAllocationStore := store.NewCPUAllocation(cp.topology.cpuTopology, cp.topology.reservedCPUs)
 	podConfigStore := store.NewPodConfig()
 	claimTracker := store.NewClaimTracker()
 	var containerUpdates []*api.ContainerUpdate

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -298,7 +298,7 @@ func TestStopContainer(t *testing.T) {
 					podConfigStore:     store.NewPodConfig(),
 					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 					claimTracker:       store.NewClaimTracker(),
-					cpuTopology:        topo,
+					topology:           deviceTopology{cpuTopology: topo},
 				}
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id), types.UID("claim-uid-1")))
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
@@ -313,7 +313,7 @@ func TestStopContainer(t *testing.T) {
 					podConfigStore:     store.NewPodConfig(),
 					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 					claimTracker:       store.NewClaimTracker(),
-					cpuTopology:        topo,
+					topology:           deviceTopology{cpuTopology: topo},
 				}
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id)))
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
@@ -361,7 +361,7 @@ func TestNRISynchronize(t *testing.T) {
 					podConfigStore:     store.NewPodConfig(),
 					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 					claimTracker:       store.NewClaimTracker(),
-					cpuTopology:        topo,
+					topology:           deviceTopology{cpuTopology: topo},
 				}
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState("stale-ctr", "stale-id", types.UID("stale-claim")))
 				return driver
@@ -376,7 +376,7 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cpuTopology:        topo,
+				topology:           deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -405,7 +405,7 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cpuTopology:        topo,
+				topology:           deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -429,7 +429,7 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cpuTopology:        topo,
+				topology:           deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -453,7 +453,7 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cpuTopology:        topo,
+				topology:           deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -472,7 +472,7 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cpuTopology:        topo,
+				topology:           deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -538,7 +538,7 @@ func TestStopContainerReleasesClaimToSharedPool(t *testing.T) {
 		podConfigStore:     store.NewPodConfig(),
 		cpuAllocationStore: cpuAllocationStore,
 		claimTracker:       store.NewClaimTracker(),
-		cpuTopology:        topo,
+		topology:           deviceTopology{cpuTopology: topo},
 	}
 	driver.podConfigStore.SetContainerState(types.UID(guaranteedPod.Uid),
 		store.NewContainerState(guaranteedCtr.Name, types.UID(guaranteedCtr.Id), claimUID))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
This is a minor/cosmetic improvement that was asked during the review of #249. All it does is sub grouping of `CPUDriver` topology fields. No behavioral change. Also, removed [GetCPUInfos()](https://github.com/kubernetes-sigs/dra-driver-cpu/blob/f08f3278be85cd0a0885b39a8d48991f1bdb620a/pkg/driver/driver.go#L66) along the way from the `CPUInfoProvider` interface, which is unused piece of code as it was noted. 

#### Which issue(s) this PR is related to
Fixes #


#### Special notes for reviewers

#### Release note

```release-note
NONE
```

#### Documentation updates