### PR TITLE
fix: treat an empty requests list in opaque configs as applying to all requests

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -388,12 +389,10 @@ func (cp *CPUDriver) getOpaqueCPUSet(logger logr.Logger, allocation *resourceapi
 		if config.Source != resourceapi.AllocationConfigSourceClaim {
 			return cpuset.CPUSet{}, false, fmt.Errorf("opaque config: configuration from DeviceClass is not supported by this driver, custom cpusets must be defined per ResourceClaim request")
 		}
-		// Each parameter block must target exactly 1 request using the 'requests' field
-		if len(config.Requests) != 1 {
-			return cpuset.CPUSet{}, false, fmt.Errorf("opaque config: parameters block must target exactly 1 request using the 'requests' field, found %d", len(config.Requests))
-		}
-
-		if config.Requests[0] == alloc.Request {
+		// An empty requests list means the configuration applies to all requests in
+		// the claim. In 1.37+ kube-scheduler omits the list when the config applies
+		// to all requests.
+		if len(config.Requests) == 0 || slices.Contains(config.Requests, alloc.Request) {
 			matchedConfig = &config
 			matchCount++
 		}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1833,7 +1833,7 @@ func TestOpaqueConfigAllocation(t *testing.T) {
 			},
 		},
 		{
-			name: "CPU config block with empty requests list is rejected",
+			name: "CPU config block with empty requests list applies to all requests",
 			claims: []*resourceapi.ResourceClaim{
 				func() *resourceapi.ResourceClaim {
 					claim := testClaim("claim-1", testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2})
@@ -1854,19 +1854,19 @@ func TestOpaqueConfigAllocation(t *testing.T) {
 					return claim
 				}(),
 			},
-			expectedErrors: map[string]string{
-				"claim-1": "opaque config: parameters block must target exactly 1 request using the 'requests' field",
+			expectedAllocations: map[string]cpuset.CPUSet{
+				"claim-1": cpuset.New(2, 6),
 			},
 		},
 		{
-			name: "CPU config block targeting multiple requests is rejected",
+			name: "CPU config block listing multiple requests applies to the targeted request",
 			claims: []*resourceapi.ResourceClaim{
 				func() *resourceapi.ResourceClaim {
 					claim := testClaim("claim-1", testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2})
 					claim.Status.Allocation.Devices.Config = []resourceapi.DeviceAllocationConfiguration{
 						{
 							Source:   resourceapi.AllocationConfigSourceClaim,
-							Requests: []string{"req-1", "req-2"},
+							Requests: []string{"claim-1", "req-2"},
 							DeviceConfiguration: resourceapi.DeviceConfiguration{
 								Opaque: &resourceapi.OpaqueDeviceConfiguration{
 									Driver: testDriverName,
@@ -1880,8 +1880,8 @@ func TestOpaqueConfigAllocation(t *testing.T) {
 					return claim
 				}(),
 			},
-			expectedErrors: map[string]string{
-				"claim-1": "opaque config: parameters block must target exactly 1 request using the 'requests' field",
+			expectedAllocations: map[string]cpuset.CPUSet{
+				"claim-1": cpuset.New(2, 6),
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for contributing to dra-driver-cpu.

Please fill in the sections below so reviewers can quickly understand scope,
risk, and validation. If a section does not apply, write "N/A".
-->

#### What type of PR is this?
/kind bug
<!-- Add one or more labels in the PR comments, for example:
/kind bug
/kind feature
/kind documentation
/kind cleanup
/kind deprecation
/kind regression
-->

#### What this PR does / why we need it

https://github.com/kubernetes/kubernetes/pull/139731 changed how the allocator copies a claim's device configs into the allocation result: when a config applies to every request in the claim, the requests list is omitted (the API defines an empty list as "applies to all requests"). The driver currently requires the list to contain exactly one element, so on 1.37+ it rejects every config, and machine mode claim with opaque config fail `NodePrepareResources`. This change updates the driver to match upstream behavior. 

#### Which issue(s) this PR is related to

https://github.com/kubernetes-sigs/dra-driver-cpu/issues/266

<!--
Use "Fixes #<issue>" when applicable.
For cross-repo issues, include the full URL.
-->

#### Special notes for reviewers

<!--
Call out anything that is useful for review:
- API or behavior changes
- migration impact
- compatibility concerns
- follow-up work
-->

#### Release note

<!--
If this change is not user-facing, write:
NONE
-->

```release-note
None
```

#### Documentation updates

None
<!--
List docs changed by this PR or write NONE.
Example:
- README updates
- Helm chart docs
- release process docs
-->
