### PR TITLE
fix: authenticate DRA CPUSET allocations during synchronize

### DIFF
--- a/pkg/driver/cdi.go
+++ b/pkg/driver/cdi.go
@@ -91,11 +91,16 @@ func (c *CdiManager) AddDevice(logger logr.Logger, deviceName string, envVar str
 	return nil
 }
 
+// Refresh reloads the CDI specs managed by the cache.
+func (c *CdiManager) Refresh() error {
+	if err := c.cache.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh CDI cache: %w", err)
+	}
+	return nil
+}
+
 // GetDeviceEnv returns the environment edits for a specific CDI device allocation.
 func (c *CdiManager) GetDeviceEnv(deviceName string) ([]string, error) {
-	if err := c.cache.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh CDI cache: %w", err)
-	}
 	device := c.cache.GetDevice(cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName))
 	if device == nil {
 		return nil, fmt.Errorf("failed to find CDI device %q", deviceName)

--- a/pkg/driver/cdi.go
+++ b/pkg/driver/cdi.go
@@ -99,7 +99,8 @@ func (c *CdiManager) Refresh() error {
 	return nil
 }
 
-// GetDeviceEnv returns the environment edits for a specific CDI device allocation.
+// GetDeviceEnv returns the environment edits for a specific CDI device allocation
+// from the current cache. Call Refresh before lookup to load the latest on-disk specs.
 func (c *CdiManager) GetDeviceEnv(deviceName string) ([]string, error) {
 	device := c.cache.GetDevice(cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName))
 	if device == nil {

--- a/pkg/driver/cdi.go
+++ b/pkg/driver/cdi.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
+	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
 	cdiSpec "tags.cncf.io/container-device-interface/specs-go"
 )
 
@@ -88,6 +89,18 @@ func (c *CdiManager) AddDevice(logger logr.Logger, deviceName string, envVar str
 
 	logger.V(4).Info("Added CDI device", "deviceName", deviceName, "specName", specName, "env", envVar)
 	return nil
+}
+
+// GetDeviceEnv returns the environment edits for a specific CDI device allocation.
+func (c *CdiManager) GetDeviceEnv(deviceName string) ([]string, error) {
+	if err := c.cache.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh CDI cache: %w", err)
+	}
+	device := c.cache.GetDevice(cdiparser.QualifiedName(cdiVendor, cdiClass, deviceName))
+	if device == nil {
+		return nil, fmt.Errorf("failed to find CDI device %q", deviceName)
+	}
+	return append([]string{}, device.ContainerEdits.Env...), nil
 }
 
 // RemoveDevice deletes the dedicated CDI spec file for a single device allocation.

--- a/pkg/driver/cdi_test.go
+++ b/pkg/driver/cdi_test.go
@@ -224,6 +224,8 @@ func TestGetDeviceEnv(t *testing.T) {
 	expectedEnv := "DRA_CPUSET_claim-cpu-get-env=0,1"
 	err = mgr.AddDevice(logger, deviceName, expectedEnv)
 	require.NoError(t, err)
+	err = mgr.Refresh()
+	require.NoError(t, err)
 
 	envs, err := mgr.GetDeviceEnv(deviceName)
 	require.NoError(t, err)

--- a/pkg/driver/cdi_test.go
+++ b/pkg/driver/cdi_test.go
@@ -212,3 +212,32 @@ func TestAddDeviceOverwrite(t *testing.T) {
 	// Verify that we do not create a new file
 	assertFileCount(1)
 }
+
+func TestGetDeviceEnv(t *testing.T) {
+	logger := testr.New(t)
+	tempCDIDir := t.TempDir()
+
+	mgr, err := NewCdiManager(logger, testDriverName, tempCDIDir)
+	require.NoError(t, err)
+
+	deviceName := "claim-cpu-get-env"
+	expectedEnv := "DRA_CPUSET_claim-cpu-get-env=0,1"
+	err = mgr.AddDevice(logger, deviceName, expectedEnv)
+	require.NoError(t, err)
+
+	envs, err := mgr.GetDeviceEnv(deviceName)
+	require.NoError(t, err)
+	require.Equal(t, []string{expectedEnv}, envs)
+}
+
+func TestGetDeviceEnvMissingDevice(t *testing.T) {
+	logger := testr.New(t)
+	tempCDIDir := t.TempDir()
+
+	mgr, err := NewCdiManager(logger, testDriverName, tempCDIDir)
+	require.NoError(t, err)
+
+	_, err = mgr.GetDeviceEnv("missing-device")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `failed to find CDI device "missing-device"`)
+}

--- a/pkg/driver/cdi_test.go
+++ b/pkg/driver/cdi_test.go
@@ -232,6 +232,27 @@ func TestGetDeviceEnv(t *testing.T) {
 	require.Equal(t, []string{expectedEnv}, envs)
 }
 
+func TestRefreshKeepsValidDevicesWhenAnotherSpecIsInvalid(t *testing.T) {
+	logger := testr.New(t)
+	tempCDIDir := t.TempDir()
+
+	mgr, err := NewCdiManager(logger, testDriverName, tempCDIDir)
+	require.NoError(t, err)
+
+	deviceName := "claim-cpu-valid"
+	expectedEnv := "DRA_CPUSET_claim-cpu-valid=0,1"
+	err = mgr.AddDevice(logger, deviceName, expectedEnv)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tempCDIDir, "unrelated-invalid.json"), []byte("{"), 0600)
+	require.NoError(t, err)
+	require.Error(t, mgr.Refresh())
+
+	envs, err := mgr.GetDeviceEnv(deviceName)
+	require.NoError(t, err)
+	require.Equal(t, []string{expectedEnv}, envs)
+}
+
 func TestGetDeviceEnvMissingDevice(t *testing.T) {
 	logger := testr.New(t)
 	tempCDIDir := t.TempDir()

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -79,10 +79,12 @@ func (m *mockKubeletPlugin) PublishResources(ctx context.Context, resources reso
 func (m *mockKubeletPlugin) Stop() {}
 
 type mockCdiMgr struct {
-	devices     map[string]string
-	addError    error
-	getError    error
-	removeError error
+	devices      map[string]string
+	addError     error
+	refreshError error
+	getError     error
+	removeError  error
+	refreshCalls int
 }
 
 func newMockCdiMgr() *mockCdiMgr {
@@ -105,6 +107,11 @@ func (m *mockCdiMgr) AddDevice(_ logr.Logger, deviceName, envVar string) error {
 	}
 	m.devices[deviceName] = envVar
 	return nil
+}
+
+func (m *mockCdiMgr) Refresh() error {
+	m.refreshCalls++
+	return m.refreshError
 }
 
 func (m *mockCdiMgr) GetDeviceEnv(deviceName string) ([]string, error) {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -81,6 +81,7 @@ func (m *mockKubeletPlugin) Stop() {}
 type mockCdiMgr struct {
 	devices     map[string]string
 	addError    error
+	getError    error
 	removeError error
 }
 
@@ -96,6 +97,17 @@ func (m *mockCdiMgr) AddDevice(_ logr.Logger, deviceName, envVar string) error {
 	}
 	m.devices[deviceName] = envVar
 	return nil
+}
+
+func (m *mockCdiMgr) GetDeviceEnv(deviceName string) ([]string, error) {
+	if m.getError != nil {
+		return nil, m.getError
+	}
+	env, ok := m.devices[deviceName]
+	if !ok {
+		return nil, fmt.Errorf("device %q not found", deviceName)
+	}
+	return []string{env}, nil
 }
 
 func (m *mockCdiMgr) RemoveDevice(_ logr.Logger, deviceName string) error {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -91,6 +91,14 @@ func newMockCdiMgr() *mockCdiMgr {
 	}
 }
 
+func newMockCdiMgrWithAllocations(allocations map[types.UID]cpuset.CPUSet) *mockCdiMgr {
+	mgr := newMockCdiMgr()
+	for uid, cpus := range allocations {
+		mgr.devices[getCDIDeviceName(uid)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, uid, cpus.String())
+	}
+	return mgr
+}
+
 func (m *mockCdiMgr) AddDevice(_ logr.Logger, deviceName, envVar string) error {
 	if m.addError != nil {
 		return m.addError

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -57,6 +57,7 @@ type KubeletPlugin interface {
 
 type cdiManager interface {
 	AddDevice(logger logr.Logger, deviceName string, envVar string) error
+	GetDeviceEnv(deviceName string) ([]string, error)
 	RemoveDevice(logger logr.Logger, deviceName string) error
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -57,6 +57,7 @@ type KubeletPlugin interface {
 
 type cdiManager interface {
 	AddDevice(logger logr.Logger, deviceName string, envVar string) error
+	Refresh() error
 	GetDeviceEnv(deviceName string) ([]string, error)
 	RemoveDevice(logger logr.Logger, deviceName string) error
 }

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -172,7 +172,9 @@ func TestMetricsNRIAllocationState(t *testing.T) {
 	driver, reg := newMetricsTestDriver(t)
 	claimUID := types.UID("claim-nri")
 	claimCPUs := cpuset.New(0, 1)
-	driver.cdiMgr.(*mockCdiMgr).devices[getCDIDeviceName(claimUID)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, claimCPUs.String())
+	driver.cdiMgr = newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+		claimUID: claimCPUs,
+	})
 	pod := &api.PodSandbox{Id: "sandbox", Uid: "pod-uid"}
 	container := &api.Container{
 		Id: "container", PodSandboxId: pod.Id, Name: "app",

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -172,6 +172,7 @@ func TestMetricsNRIAllocationState(t *testing.T) {
 	driver, reg := newMetricsTestDriver(t)
 	claimUID := types.UID("claim-nri")
 	claimCPUs := cpuset.New(0, 1)
+	driver.cdiMgr.(*mockCdiMgr).devices[getCDIDeviceName(claimUID)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, claimCPUs.String())
 	pod := &api.PodSandbox{Id: "sandbox", Uid: "pod-uid"}
 	container := &api.Container{
 		Id: "container", PodSandboxId: pod.Id, Name: "app",

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -65,10 +65,16 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 				allGuaranteedCPUs := cpuset.New()
 				for uid, cpus := range claimAllocations {
 					caLogger := cLogger.WithValues("claimUID", uid)
-					if err := cp.validateSynchronizedClaimAllocation(caLogger, uid, cpus); err != nil {
+					deviceName := getCDIDeviceName(uid)
+					envs, err := cp.cdiMgr.GetDeviceEnv(deviceName)
+					if err != nil {
+						return nil, fmt.Errorf("claim %q is not prepared by this driver: %w", uid, err)
+					}
+					err = validateSynchronizedClaimAllocation(caLogger, uid, cpus, envs)
+					if err != nil {
 						return nil, err
 					}
-					err := claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
+					err = claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
 					if err != nil {
 						return nil, err
 					}
@@ -145,17 +151,7 @@ func (cp *CPUDriver) validatePreparedClaimAllocation(uid types.UID, cpus cpuset.
 	return nil
 }
 
-func (cp *CPUDriver) validateSynchronizedClaimAllocation(logger logr.Logger, uid types.UID, cpus cpuset.CPUSet) error {
-	if cp.cdiMgr == nil {
-		return fmt.Errorf("cannot validate claim %q during synchronize: CDI manager is not initialized", uid)
-	}
-
-	deviceName := getCDIDeviceName(uid)
-	envs, err := cp.cdiMgr.GetDeviceEnv(deviceName)
-	if err != nil {
-		return fmt.Errorf("claim %q is not prepared by this driver: %w", uid, err)
-	}
-
+func validateSynchronizedClaimAllocation(logger logr.Logger, uid types.UID, cpus cpuset.CPUSet, envs []string) error {
 	allocations, err := parseDRAEnvToClaimAllocations(logger, envs)
 	if err != nil {
 		return fmt.Errorf("failed to parse CDI env for claim %q: %w", uid, err)
@@ -163,7 +159,7 @@ func (cp *CPUDriver) validateSynchronizedClaimAllocation(logger logr.Logger, uid
 
 	preparedCPUs, ok := allocations[uid]
 	if !ok {
-		return fmt.Errorf("validation failed for claim %q: driver-owned CDI spec %q does not contain a matching DRA allocation", uid, deviceName)
+		return fmt.Errorf("validation failed for claim %q: driver-owned CDI spec %q does not contain a matching DRA allocation", uid, getCDIDeviceName(uid))
 	}
 	if !preparedCPUs.Equals(cpus) {
 		return fmt.Errorf("validation failed for claim %q during synchronize: cpuset mismatch (expected %q from CDI, got %q from runtime)", uid, preparedCPUs.String(), cpus.String())

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -65,6 +65,9 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 				allGuaranteedCPUs := cpuset.New()
 				for uid, cpus := range claimAllocations {
 					caLogger := cLogger.WithValues("claimUID", uid)
+					if err := cp.validateSynchronizedClaimAllocation(caLogger, uid, cpus); err != nil {
+						return nil, err
+					}
 					err := claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
 					if err != nil {
 						return nil, err
@@ -138,6 +141,32 @@ func (cp *CPUDriver) validatePreparedClaimAllocation(uid types.UID, cpus cpuset.
 	}
 	if !preparedCPUs.Equals(cpus) {
 		return fmt.Errorf("validation failed for claim %q: cpuset mismatch (expected %q, got %q)", uid, preparedCPUs.String(), cpus.String())
+	}
+	return nil
+}
+
+func (cp *CPUDriver) validateSynchronizedClaimAllocation(logger logr.Logger, uid types.UID, cpus cpuset.CPUSet) error {
+	if cp.cdiMgr == nil {
+		return fmt.Errorf("cannot validate claim %q during synchronize: CDI manager is not initialized", uid)
+	}
+
+	deviceName := getCDIDeviceName(uid)
+	envs, err := cp.cdiMgr.GetDeviceEnv(deviceName)
+	if err != nil {
+		return fmt.Errorf("claim %q is not prepared by this driver: %w", uid, err)
+	}
+
+	allocations, err := parseDRAEnvToClaimAllocations(logger, envs)
+	if err != nil {
+		return fmt.Errorf("failed to parse CDI env for claim %q: %w", uid, err)
+	}
+
+	preparedCPUs, ok := allocations[uid]
+	if !ok {
+		return fmt.Errorf("validation failed for claim %q: driver-owned CDI spec %q does not contain a matching DRA allocation", uid, deviceName)
+	}
+	if !preparedCPUs.Equals(cpus) {
+		return fmt.Errorf("validation failed for claim %q during synchronize: cpuset mismatch (expected %q from CDI, got %q from runtime)", uid, preparedCPUs.String(), cpus.String())
 	}
 	return nil
 }

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -41,7 +41,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	podConfigStore := store.NewPodConfig()
 	claimTracker := store.NewClaimTracker()
 	var containerUpdates []*api.ContainerUpdate
-	cdiCacheRefreshed := false
+	cdiCacheRefreshAttempted := false
 
 	for _, pod := range pods {
 		pLogger := logger.WithValues("pod", ctxlog.KObj(pod), "podUID", pod.Uid)
@@ -54,20 +54,20 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 
 			claimAllocations, err := parseDRAEnvToClaimAllocations(cLogger, container.Env)
 			if err != nil {
-				cLogger.Error(err, "error parsing DRA env for container")
-				return nil, err
+				cLogger.Error(err, "ignoring container with malformed DRA env during synchronize")
+				continue
 			}
 			containerUID := types.UID(container.GetId())
 			var claimUIDs []types.UID
 			allGuaranteedCPUs := cpuset.New()
 			for uid, cpus := range claimAllocations {
 				caLogger := cLogger.WithValues("claimUID", uid)
-				if !cdiCacheRefreshed {
+				if !cdiCacheRefreshAttempted {
 					err = cp.cdiMgr.Refresh()
+					cdiCacheRefreshAttempted = true
 					if err != nil {
-						return nil, err
+						logger.Error(err, "failed to refresh CDI cache, continuing with available CDI devices")
 					}
-					cdiCacheRefreshed = true
 				}
 
 				deviceName := getCDIDeviceName(uid)

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -41,6 +41,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	podConfigStore := store.NewPodConfig()
 	claimTracker := store.NewClaimTracker()
 	var containerUpdates []*api.ContainerUpdate
+	cdiCacheRefreshed := false
 
 	for _, pod := range pods {
 		pLogger := logger.WithValues("pod", ctxlog.KObj(pod), "podUID", pod.Uid)
@@ -57,32 +58,43 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 				return nil, err
 			}
 			containerUID := types.UID(container.GetId())
-			var state *store.ContainerState
 			var claimUIDs []types.UID
-			if len(claimAllocations) == 0 {
+			allGuaranteedCPUs := cpuset.New()
+			for uid, cpus := range claimAllocations {
+				caLogger := cLogger.WithValues("claimUID", uid)
+				if !cdiCacheRefreshed {
+					err = cp.cdiMgr.Refresh()
+					if err != nil {
+						return nil, err
+					}
+					cdiCacheRefreshed = true
+				}
+
+				deviceName := getCDIDeviceName(uid)
+				envs, err := cp.cdiMgr.GetDeviceEnv(deviceName)
+				if err != nil {
+					caLogger.Error(err, "ignoring claim not prepared by this driver during synchronize")
+					continue
+				}
+				err = validateSynchronizedClaimAllocation(caLogger, uid, cpus, envs)
+				if err != nil {
+					caLogger.Error(err, "ignoring invalid claim allocation during synchronize")
+					continue
+				}
+				err = claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
+				if err != nil {
+					return nil, err
+				}
+
+				allGuaranteedCPUs = allGuaranteedCPUs.Union(cpus)
+				claimUIDs = append(claimUIDs, uid)
+				cpuAllocationStore.AddResourceClaimAllocation(caLogger, uid, cpus)
+			}
+
+			var state *store.ContainerState
+			if len(claimUIDs) == 0 {
 				state = store.NewContainerState(container.GetName(), containerUID)
 			} else {
-				allGuaranteedCPUs := cpuset.New()
-				for uid, cpus := range claimAllocations {
-					caLogger := cLogger.WithValues("claimUID", uid)
-					deviceName := getCDIDeviceName(uid)
-					envs, err := cp.cdiMgr.GetDeviceEnv(deviceName)
-					if err != nil {
-						return nil, fmt.Errorf("claim %q is not prepared by this driver: %w", uid, err)
-					}
-					err = validateSynchronizedClaimAllocation(caLogger, uid, cpus, envs)
-					if err != nil {
-						return nil, err
-					}
-					err = claimTracker.SetOwner(caLogger, uid, types.UID(pod.Uid), container.Name)
-					if err != nil {
-						return nil, err
-					}
-
-					allGuaranteedCPUs = allGuaranteedCPUs.Union(cpus)
-					claimUIDs = append(claimUIDs, uid)
-					cpuAllocationStore.AddResourceClaimAllocation(caLogger, uid, cpus)
-				}
 				cLogger.V(2).Info("found guaranteed CPUs", "cpus", allGuaranteedCPUs.String())
 				state = store.NewContainerState(container.GetName(), containerUID, claimUIDs...)
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -347,12 +347,13 @@ func TestNRISynchronize(t *testing.T) {
 	pod2 := &api.PodSandbox{Id: "pod-id-2", Name: "my-pod-2", Namespace: "my-ns", Uid: "pod-uid-2"}
 
 	testCases := []struct {
-		name            string
-		driver          *CPUDriver
-		runtimePods     []*api.PodSandbox
-		runtimeCtrs     []*api.Container
-		expectedUpdates []*api.ContainerUpdate
-		expectedError   string
+		name                 string
+		driver               *CPUDriver
+		runtimePods          []*api.PodSandbox
+		runtimeCtrs          []*api.Container
+		expectedUpdates      []*api.ContainerUpdate
+		expectedError        string
+		expectedRefreshCalls int
 	}{
 		{
 			name: "empty runtime state clears the store",
@@ -402,6 +403,7 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-7"}}},
 				},
 			},
+			expectedRefreshCalls: 1,
 		},
 		{
 			name: "only shared containers",
@@ -455,6 +457,7 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-3"}}},
 				},
 			},
+			expectedRefreshCalls: 1,
 		},
 		{
 			name: "container with multiple claims",
@@ -478,6 +481,7 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-3"}}},
 				},
 			},
+			expectedRefreshCalls: 1,
 		},
 		{
 			name: "malformed DRA env fails synchronize",
@@ -495,25 +499,39 @@ func TestNRISynchronize(t *testing.T) {
 				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
 				{Id: "p1-malformed", PodSandboxId: pod1.Id, Name: "malformed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "a-b")}},
 			},
-			expectedError: "failed to parse cpuset value",
+			expectedError:        "failed to parse cpuset value",
+			expectedRefreshCalls: 1,
 		},
 		{
-			name: "runtime DRA env without matching driver-owned CDI spec fails synchronize",
+			name: "invalid claim does not prevent other containers from synchronizing",
 			driver: &CPUDriver{
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cdiMgr:             newMockCdiMgr(),
-				topology:           deviceTopology{cpuTopology: topo},
+				cdiMgr: newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-B": cpuset.New(2, 3),
+				}),
+				topology: deviceTopology{cpuTopology: topo},
 			},
-			runtimePods: []*api.PodSandbox{pod1},
+			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
-				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
+				{Id: "p1-invalid", PodSandboxId: pod1.Id, Name: "invalid-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
+				{Id: "p2-guaranteed", PodSandboxId: pod2.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-B=%s", cdiEnvVarPrefix, "2,3")}},
 			},
-			expectedError: `claim "claim-A" is not prepared by this driver`,
+			expectedUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "p2-guaranteed",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "2-3"}}},
+				},
+				{
+					ContainerId: "p1-invalid",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1,4-7"}}},
+				},
+			},
+			expectedRefreshCalls: 1,
 		},
 		{
-			name: "runtime DRA env that mismatches driver-owned CDI spec fails synchronize",
+			name: "runtime DRA env that mismatches driver-owned CDI spec is ignored",
 			driver: &CPUDriver{
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
@@ -525,15 +543,22 @@ func TestNRISynchronize(t *testing.T) {
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
-				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
+				{Id: "p1-invalid", PodSandboxId: pod1.Id, Name: "invalid-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
 			},
-			expectedError: `validation failed for claim "claim-A" during synchronize: cpuset mismatch`,
+			expectedUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "p1-invalid",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
+				},
+			},
+			expectedRefreshCalls: 1,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			updates, err := tc.driver.Synchronize(context.Background(), tc.runtimePods, tc.runtimeCtrs)
+			require.Equal(t, tc.expectedRefreshCalls, tc.driver.cdiMgr.(*mockCdiMgr).refreshCalls)
 
 			if tc.expectedError != "" {
 				require.Error(t, err)

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -484,7 +484,7 @@ func TestNRISynchronize(t *testing.T) {
 			expectedRefreshCalls: 1,
 		},
 		{
-			name: "malformed DRA env fails synchronize",
+			name: "malformed DRA env does not prevent other containers from synchronizing",
 			driver: &CPUDriver{
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
@@ -496,10 +496,43 @@ func TestNRISynchronize(t *testing.T) {
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
-				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
 				{Id: "p1-malformed", PodSandboxId: pod1.Id, Name: "malformed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "a-b")}},
+				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
 			},
-			expectedError:        "failed to parse cpuset value",
+			expectedUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "p1-guaranteed",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1"}}},
+				},
+			},
+			expectedRefreshCalls: 1,
+		},
+		{
+			name: "CDI cache refresh error does not prevent valid claims from synchronizing",
+			driver: func() *CPUDriver {
+				cdiMgr := newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-A": cpuset.New(0, 1),
+					"claim-B": cpuset.New(2, 3),
+				})
+				cdiMgr.refreshError = fmt.Errorf("unrelated invalid CDI spec")
+				return &CPUDriver{
+					podConfigStore:     store.NewPodConfig(),
+					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+					claimTracker:       store.NewClaimTracker(),
+					cdiMgr:             cdiMgr,
+					topology:           deviceTopology{cpuTopology: topo},
+				}
+			}(),
+			runtimePods: []*api.PodSandbox{pod1},
+			runtimeCtrs: []*api.Container{
+				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1"), fmt.Sprintf("%s_claim-B=%s", cdiEnvVarPrefix, "2,3")}},
+			},
+			expectedUpdates: []*api.ContainerUpdate{
+				{
+					ContainerId: "p1-guaranteed",
+					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-3"}}},
+				},
+			},
 			expectedRefreshCalls: 1,
 		},
 		{

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -361,6 +361,7 @@ func TestNRISynchronize(t *testing.T) {
 					podConfigStore:     store.NewPodConfig(),
 					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 					claimTracker:       store.NewClaimTracker(),
+					cdiMgr:             newMockCdiMgr(),
 					topology:           deviceTopology{cpuTopology: topo},
 				}
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState("stale-ctr", "stale-id", types.UID("stale-claim")))
@@ -376,7 +377,12 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				topology:           deviceTopology{cpuTopology: topo},
+				cdiMgr: func() *mockCdiMgr {
+					mgr := newMockCdiMgr()
+					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
+					return mgr
+				}(),
+				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -405,6 +411,7 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
+				cdiMgr:             newMockCdiMgr(),
 				topology:           deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
@@ -429,7 +436,13 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				topology:           deviceTopology{cpuTopology: topo},
+				cdiMgr: func() *mockCdiMgr {
+					mgr := newMockCdiMgr()
+					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
+					mgr.devices[getCDIDeviceName("claim-B")] = fmt.Sprintf("%s_claim-B=%s", cdiEnvVarPrefix, "2,3")
+					return mgr
+				}(),
+				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -453,7 +466,13 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				topology:           deviceTopology{cpuTopology: topo},
+				cdiMgr: func() *mockCdiMgr {
+					mgr := newMockCdiMgr()
+					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
+					mgr.devices[getCDIDeviceName("claim-B")] = fmt.Sprintf("%s_claim-B=%s", cdiEnvVarPrefix, "2,3")
+					return mgr
+				}(),
+				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -472,7 +491,12 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				topology:           deviceTopology{cpuTopology: topo},
+				cdiMgr: func() *mockCdiMgr {
+					mgr := newMockCdiMgr()
+					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
+					return mgr
+				}(),
+				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -480,6 +504,40 @@ func TestNRISynchronize(t *testing.T) {
 				{Id: "p1-malformed", PodSandboxId: pod1.Id, Name: "malformed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "a-b")}},
 			},
 			expectedError: "failed to parse cpuset value",
+		},
+		{
+			name: "runtime DRA env without matching driver-owned CDI spec fails synchronize",
+			driver: &CPUDriver{
+				podConfigStore:     store.NewPodConfig(),
+				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+				claimTracker:       store.NewClaimTracker(),
+				cdiMgr:             newMockCdiMgr(),
+				topology:           deviceTopology{cpuTopology: topo},
+			},
+			runtimePods: []*api.PodSandbox{pod1},
+			runtimeCtrs: []*api.Container{
+				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
+			},
+			expectedError: `claim "claim-A" is not prepared by this driver`,
+		},
+		{
+			name: "runtime DRA env that mismatches driver-owned CDI spec fails synchronize",
+			driver: &CPUDriver{
+				podConfigStore:     store.NewPodConfig(),
+				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+				claimTracker:       store.NewClaimTracker(),
+				cdiMgr: func() *mockCdiMgr {
+					mgr := newMockCdiMgr()
+					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "2,3")
+					return mgr
+				}(),
+				topology: deviceTopology{cpuTopology: topo},
+			},
+			runtimePods: []*api.PodSandbox{pod1},
+			runtimeCtrs: []*api.Container{
+				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")}},
+			},
+			expectedError: `validation failed for claim "claim-A" during synchronize: cpuset mismatch`,
 		},
 	}
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -377,11 +377,9 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cdiMgr: func() *mockCdiMgr {
-					mgr := newMockCdiMgr()
-					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
-					return mgr
-				}(),
+				cdiMgr: newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-A": cpuset.New(0, 1),
+				}),
 				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
@@ -436,12 +434,10 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cdiMgr: func() *mockCdiMgr {
-					mgr := newMockCdiMgr()
-					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
-					mgr.devices[getCDIDeviceName("claim-B")] = fmt.Sprintf("%s_claim-B=%s", cdiEnvVarPrefix, "2,3")
-					return mgr
-				}(),
+				cdiMgr: newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-A": cpuset.New(0, 1),
+					"claim-B": cpuset.New(2, 3),
+				}),
 				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
@@ -466,12 +462,10 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cdiMgr: func() *mockCdiMgr {
-					mgr := newMockCdiMgr()
-					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
-					mgr.devices[getCDIDeviceName("claim-B")] = fmt.Sprintf("%s_claim-B=%s", cdiEnvVarPrefix, "2,3")
-					return mgr
-				}(),
+				cdiMgr: newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-A": cpuset.New(0, 1),
+					"claim-B": cpuset.New(2, 3),
+				}),
 				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1},
@@ -491,11 +485,9 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cdiMgr: func() *mockCdiMgr {
-					mgr := newMockCdiMgr()
-					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "0,1")
-					return mgr
-				}(),
+				cdiMgr: newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-A": cpuset.New(0, 1),
+				}),
 				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1},
@@ -526,11 +518,9 @@ func TestNRISynchronize(t *testing.T) {
 				podConfigStore:     store.NewPodConfig(),
 				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 				claimTracker:       store.NewClaimTracker(),
-				cdiMgr: func() *mockCdiMgr {
-					mgr := newMockCdiMgr()
-					mgr.devices[getCDIDeviceName("claim-A")] = fmt.Sprintf("%s_claim-A=%s", cdiEnvVarPrefix, "2,3")
-					return mgr
-				}(),
+				cdiMgr: newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-A": cpuset.New(2, 3),
+				}),
 				topology: deviceTopology{cpuTopology: topo},
 			},
 			runtimePods: []*api.PodSandbox{pod1},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug



#### What this PR does / why we need it
Validates `DRA_CPUSET_<claimUID>` allocations reported during NRI `Synchronize` against the corresponding driver-owned CDI device.

Synchronization now fails closed when the CDI device is missing or its CPU set does not match the runtime environment, instead of treating the runtime environment as authoritative.

#### Which issue(s) this PR is related to

Fixes #248
