### PR TITLE
fix: refuse a config key spelled differently from the schema

### DIFF
--- a/internal/driverconfig/cfgfile.go
+++ b/internal/driverconfig/cfgfile.go
@@ -19,8 +19,13 @@ package driverconfig
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"maps"
 	"os"
+	"reflect"
+	"slices"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 )
@@ -38,6 +43,12 @@ func buildConfMap(filePath string) (map[string]any, error) {
 	}
 	delete(confMap, "apiVersion")
 
+	// Before anything reads the map by name: the decoder folds case, the checks
+	// below do not.
+	if err := rejectNonCanonicalKeys(confMap); err != nil {
+		return nil, err
+	}
+
 	if err := rejectExcludedFields(confMap); err != nil {
 		return nil, err
 	}
@@ -45,14 +56,72 @@ func buildConfMap(filePath string) (map[string]any, error) {
 	return confMap, nil
 }
 
+// canonicalConfigKeys is the set of names a config file may use, taken from
+// Config's own json tags so a field added later cannot be forgotten here. Direct
+// fields and explicit tag names only: TestConfigDeclaresExplicitJSONNames rejects
+// any other shape, so encoding/json's embedding and tag-dominance rules do not
+// have to be reproduced here.
+func canonicalConfigKeys() map[string]bool {
+	// Not a Config field, so reflection cannot find it, but `ApiVersion` deserves
+	// the same correction as any other misspelling.
+	keys := map[string]bool{"apiVersion": true}
+	for field := range reflect.TypeFor[Config]().Fields() {
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name != "" && name != "-" {
+			keys[name] = true
+		}
+	}
+	return keys
+}
+
+// rejectNonCanonicalKeys refuses a key that is not spelled the way Config
+// declares it. encoding/json matches a field without regard to case while the
+// checks around it compare exactly, so a folded spelling slips past both the
+// excluded-field check and the explicit-flag precedence pass. Folding those
+// comparisons instead would let two keys differing only in case decode into one
+// field, so the file is refused rather than resolved. A name matching no field
+// is left to DisallowUnknownFields.
+func rejectNonCanonicalKeys(confMap map[string]any) error {
+	canonical := slices.Sorted(maps.Keys(canonicalConfigKeys()))
+	var problems []string
+	// Sorted, and reporting every key it rejects: ranging a map gave one file a
+	// different message on each node, and each fix cost another restart. The other
+	// checks each stop at the first problem, since they run elsewhere.
+	for _, key := range slices.Sorted(maps.Keys(confMap)) {
+		if slices.Contains(canonical, key) {
+			continue
+		}
+		for _, want := range canonical {
+			if !strings.EqualFold(key, want) {
+				continue
+			}
+			if alternative, excluded := schemaExcludedFields[want]; excluded {
+				// Not the canonical spelling: the next check refuses that too, so
+				// answer the question they are about to ask instead.
+				problems = append(problems,
+					fmt.Sprintf("field %q is not configurable via the config file; %s", key, alternative))
+			} else {
+				problems = append(problems,
+					fmt.Sprintf("field %q is spelled differently from the schema; use %q", key, want))
+			}
+			break
+		}
+	}
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "; "))
+	}
+	return nil
+}
+
 // rejectExcludedFields errors out if confMap sets any key in
 // schemaExcludedFields; those fields aren't configurable via the config
 // file regardless of how it's supplied (Helm's driverConfig or a raw
 // --config file).
 func rejectExcludedFields(confMap map[string]any) error {
-	for jsonKey, alternative := range schemaExcludedFields {
+	// Sorted, so a file setting two excluded fields names the same one every run.
+	for _, jsonKey := range slices.Sorted(maps.Keys(schemaExcludedFields)) {
 		if _, ok := confMap[jsonKey]; ok {
-			return fmt.Errorf("field %q is not configurable via the config file; %s", jsonKey, alternative)
+			return fmt.Errorf("field %q is not configurable via the config file; %s", jsonKey, schemaExcludedFields[jsonKey])
 		}
 	}
 	return nil
@@ -65,8 +134,10 @@ func loadFile(path string) (map[string]any, error) {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
+	// Strict for the duplicate keys, not the unknown ones: the target is a map, so
+	// nothing is unknown, but Unmarshal keeps one of a repeated key at random.
 	confMap := map[string]any{}
-	if err := yaml.Unmarshal(data, &confMap); err != nil {
+	if err := yaml.UnmarshalStrict(data, &confMap); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -107,6 +107,127 @@ cpuDeviceMode: individual
 	assert.Equal(t, device.CPU_DEVICE_MODE_GROUPED, result.CPUDeviceMode)
 }
 
+// TestLoad_RejectsAmbiguousKeys covers the ways a config file can reach a field
+// without naming it the way the schema does. Each has to fail, and the message
+// has to say what to write instead: for an excluded field that is the
+// alternative setting rather than the canonical spelling, which the next check
+// refuses anyway, and a name matching no field at all stays the decoder's to
+// report.
+func TestLoad_RejectsAmbiguousKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		file            string
+		flags           []string
+		wantContains    []string
+		wantNotContains []string
+	}{{
+		name:         "folded spelling",
+		file:         "apiVersion: v1alpha1\nreservedcpus: \"0-3\"\n",
+		wantContains: []string{"reservedcpus", "reservedCPUs"},
+	}, {
+		name:         "folded spelling, mixed case",
+		file:         "apiVersion: v1alpha1\nReservedCPUs: \"0-3\"\n",
+		wantContains: []string{"ReservedCPUs", "reservedCPUs"},
+	}, {
+		name:         "folded spelling, upper case",
+		file:         "apiVersion: v1alpha1\nRESERVEDCPUS: \"0-3\"\n",
+		wantContains: []string{"RESERVEDCPUS", "reservedCPUs"},
+	}, {
+		name:         "folded spelling, one letter",
+		file:         "apiVersion: v1alpha1\nreservedCpus: \"0-3\"\n",
+		wantContains: []string{"reservedCpus", "reservedCPUs"},
+	}, {
+		// Without this the file reached the precedence pass, where the delete is
+		// by exact name, and overwrote the flag.
+		name:         "folded spelling against an explicit flag",
+		file:         "apiVersion: v1alpha1\nreservedcpus: \"2-3\"\n",
+		flags:        []string{"--reserved-cpus=0-1"},
+		wantContains: []string{"reservedcpus", "reservedCPUs"},
+	}, {
+		name:         "the same key twice",
+		file:         "apiVersion: v1alpha1\nreservedCPUs: \"0-1\"\nreservedCPUs: \"2-3\"\n",
+		wantContains: []string{"reservedCPUs"},
+	}, {
+		name:         "the same key twice, folded",
+		file:         "apiVersion: v1alpha1\nreservedCPUs: \"0-1\"\nreservedcpus: \"2-3\"\n",
+		wantContains: []string{"reservedcpus"},
+	}, {
+		name:            "folded apiVersion",
+		file:            "ApiVersion: v1alpha1\nreservedCPUs: \"0-1\"\n",
+		wantContains:    []string{`use "apiVersion"`},
+		wantNotContains: []string{"unknown field"},
+	}, {
+		name:            "folded excluded field",
+		file:            "apiVersion: v1alpha1\nbindaddress: \":9999\"\n",
+		wantContains:    []string{"not configurable via the config file", "healthzPort"},
+		wantNotContains: []string{"is spelled differently"},
+	}, {
+		name:            "folded excluded field, upper case",
+		file:            "apiVersion: v1alpha1\nBINDADDRESS: \":9999\"\n",
+		wantContains:    []string{"not configurable via the config file", "healthzPort"},
+		wantNotContains: []string{"is spelled differently"},
+	}, {
+		name:            "folded excluded field with a flag alternative",
+		file:            "apiVersion: v1alpha1\nexposepcieroots: true\n",
+		wantContains:    []string{"not configurable via the config file", "args.exposePCIeRoots"},
+		wantNotContains: []string{"is spelled differently"},
+	}, {
+		name:            "a name that matches nothing",
+		file:            "apiVersion: v1alpha1\ntotallyUnknownField: 1\n",
+		wantContains:    []string{"totallyUnknownField"},
+		wantNotContains: []string{"spelled differently"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgFile := writeFile(t, dir, "config.yaml", tc.file)
+
+			cfg := driverconfig.Default()
+			fs := newFlagSet(t, &cfg, tc.flags)
+
+			_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+
+			require.Error(t, err)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, err.Error(), want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				assert.NotContains(t, err.Error(), notWant)
+			}
+		})
+	}
+}
+
+// TestLoad_ReportsEveryMiscasedKey: a hand-edited file usually has more than
+// one, and fixing them one restart at a time is the difference between one
+// CrashLoopBackOff and three. A key misspelled rather than miscased is not this
+// check's to batch, and the decoder reports those one at a time.
+//
+// Asserted as the whole string rather than key by key. Ranging a map named a
+// different key on each node for the same ConfigMap, so the keys are sorted, and
+// an exact message is what pins that ordering along with each canonical
+// spelling, the separator, and the shape of the whole thing.
+func TestLoad_ReportsEveryMiscasedKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+reservedcpus: "0-3"
+groupby: socket
+cpudevicemode: individual
+`)
+
+	cfg := driverconfig.Default()
+	fs := newFlagSet(t, &cfg, nil)
+
+	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+
+	require.Error(t, err)
+	assert.EqualError(t, err,
+		`config file "`+cfgFile+`": `+
+			`field "cpudevicemode" is spelled differently from the schema; use "cpuDeviceMode"; `+
+			`field "groupby" is spelled differently from the schema; use "groupBy"; `+
+			`field "reservedcpus" is spelled differently from the schema; use "reservedCPUs"`)
+}
+
 // TestLoad_PartialFile: fields absent from the file retain their default values.
 func TestLoad_PartialFile(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/driverconfig/schema_internal_test.go
+++ b/internal/driverconfig/schema_internal_test.go
@@ -58,3 +58,60 @@ func TestGenerateDriverConfigSchema_CoversAllFields(t *testing.T) {
 		}
 	}
 }
+
+// TestConfigDeclaresExplicitJSONNames pins the shape canonicalConfigKeys reads.
+//
+// That helper takes direct fields and explicit tag names, which is all Config
+// has. encoding/json resolves more than that -- it promotes an embedded
+// struct's fields, matches an untagged field by its Go name, and reads
+// `json:"-,"` as a field literally named "-" rather than an ignored one -- so a
+// field of any of those shapes would be settable through a config file while
+// the helper had never heard of it, which is the gap it exists to close.
+//
+// Enforced here rather than reimplemented there: a partial copy of that
+// resolution would have to be kept in step with the standard library by hand,
+// and this fails at build time the moment Config grows a shape it does not
+// cover.
+func TestConfigDeclaresExplicitJSONNames(t *testing.T) {
+	// Seeded rather than empty: apiVersion is not a Config field, so nothing in
+	// the loop would collide with it, but buildConfMap reads and strips it before
+	// the decoder runs. A field claiming that name would pass every check here
+	// and then never be settable from a file at all.
+	byName := map[string]string{"apiVersion": "the schema property buildConfMap strips"}
+	for field := range reflect.TypeFor[Config]().Fields() {
+		if field.Anonymous {
+			t.Errorf("field %q is embedded; canonicalConfigKeys reads direct fields only, "+
+				"so the fields promoted out of it would not be in the canonical set", field.Name)
+			continue
+		}
+		if field.PkgPath != "" {
+			continue // unexported, so the decoder cannot reach it either
+		}
+		tag, tagged := field.Tag.Lookup("json")
+		if !tagged {
+			t.Errorf("field %q has no json tag; the decoder would match it by its Go name, "+
+				"which is not what canonicalConfigKeys collects", field.Name)
+			continue
+		}
+		name, _, hasOptions := strings.Cut(tag, ",")
+		if name == "-" {
+			if hasOptions {
+				t.Errorf(`field %q is tagged json:"-,", which names it "-" rather than `+
+					`ignoring it; canonicalConfigKeys reads it as ignored`, field.Name)
+			}
+			continue
+		}
+		if name == "" {
+			t.Errorf("field %q has an empty json name; the decoder would match it by its "+
+				"Go name, which is not what canonicalConfigKeys collects", field.Name)
+			continue
+		}
+		for other, otherField := range byName {
+			if strings.EqualFold(name, other) {
+				t.Errorf("json names %q (%s) and %q (%s) fold onto each other, so one of them "+
+					"could never be spelled canonically", name, field.Name, other, otherField)
+			}
+		}
+		byName[name] = field.Name
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`encoding/json` matches a struct field without regard to case, so `reservedcpus` in a config file sets `ReservedCPUs` just as `reservedCPUs` does. Everything around the decoder compares exactly, and two places depend on that.

`rejectExcludedFields` looks its names up directly, so a folded spelling sets a field the schema excludes from the file: `bindaddress: ":9999"` reaches `BindAddress`, although `bindAddress` is refused.

`Load` deletes the keys of explicitly-passed flags so the file cannot override them, and that delete is by exact name too. A file with `reservedcpus: "2-3"` survives the precedence pass and overwrites `--reserved-cpus=0-1`, which is the opposite of what the flag help and the configuration guidelines say happens.

Folding both comparisons would close those two but leave a file setting `reservedCPUs` and `reservedcpus` decoding both into one field, with whichever the decoder applies last winning. A file that reads one way and loads another is refused instead, and the message says which spelling to use.

The canonical set comes from `Config`'s own json tags, so a field added later cannot be forgotten here. A name matching no field at all is left to the decoder, which already rejects it through `DisallowUnknownFields`.

#### Which issue(s) this PR is related to

None filed; found while reviewing #272. It should land before #272: that PR adds `kubeletRootDir` to the excluded fields, and until this one is in, a config file spelling it `kubeletrootdir` still reaches the field and outranks an explicitly passed `--kubelet-root-dir`, which is exactly the driver-versus-mounts divergence #272 exists to prevent. That path is a hand-written `--config` file; the chart's values schema rejects the key in either spelling.

#### Special notes for reviewers

This rejects config files that load today, in two ways. A file using a folded spelling currently works by accident, and a file setting the same key twice currently keeps one of them in an undefined order. Both now fail at startup, closed rather than silently applying a value the reader did not intend.

Helm normally catches a folded key through values schema validation (`additionalProperties: false` on `driverConfig`). The driver-side check still matters for a raw `--config` file, and for a Helm install or upgrade run with `--skip-schema-validation`: I checked, and `--set-string driverConfig.reservedcpus=2-3` under that flag puts `reservedcpus: 2-3` into the generated ConfigMap verbatim, where this change is what stops it.

The canonical set is Config's own explicit json tags on its direct fields. `encoding/json` resolves more than that, so a field that was embedded, untagged, or tagged `json:"-,"` would be settable through a file while this check had never heard of it. That is enforced by a test over `Config` rather than reimplemented here, so it fails at build time the moment `Config` grows a shape the helper does not cover.

#### Release note

```release-note
Config files now reject keys whose letter case differs from the schema, as well as duplicate YAML keys. A non-canonical key can no longer bypass excluded-field checks or override an explicitly passed command-line flag.
```

#### Documentation updates

NONE


