### PR TITLE
fix: reject grouped allocations with missing CPU capacity

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -125,21 +125,21 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 	var cpuAssignment cpuset.CPUSet
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 	for _, alloc := range claim.Status.Allocation.Devices.Results {
-		claimCPUCount := int64(0)
 		if alloc.Driver != cp.driverName {
 			continue
 		}
-		if quantity, ok := alloc.ConsumedCapacity[device.CPUResourceQualifiedName]; ok {
-			if quantity.Sign() <= 0 {
-				return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q must be positive, got %s", alloc.Device, quantity.String())}
-			}
-			count := quantity.Value()
-			if quantity.CmpInt64(count) != 0 {
-				return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q must be a whole number, got %s", alloc.Device, quantity.String())}
-			}
-			claimCPUCount = count
-			logger.V(4).Info("found CPU request", "numCPUs", count, "device", alloc.Device)
+		quantity, ok := alloc.ConsumedCapacity[device.CPUResourceQualifiedName]
+		if !ok {
+			return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q is missing", alloc.Device)}
 		}
+		if quantity.Sign() <= 0 {
+			return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q must be positive, got %s", alloc.Device, quantity.String())}
+		}
+		claimCPUCount := quantity.Value()
+		if quantity.CmpInt64(claimCPUCount) != 0 {
+			return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q must be a whole number, got %s", alloc.Device, quantity.String())}
+		}
+		logger.V(4).Info("found CPU request", "numCPUs", claimCPUCount, "device", alloc.Device)
 
 		topo := cp.topology.cpuTopology
 

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -130,7 +130,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		}
 		quantity, ok := alloc.ConsumedCapacity[device.CPUResourceQualifiedName]
 		if !ok {
-			return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q is missing", alloc.Device)}
+			return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity %q for device %q is missing", device.CPUResourceQualifiedName, alloc.Device)}
 		}
 		if quantity.Sign() <= 0 {
 			return kubeletplugin.PrepareResult{Err: fmt.Errorf("CPU capacity for device %q must be positive, got %s", alloc.Device, quantity.String())}

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1239,68 +1239,19 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 
 func TestPrepareResourceClaimsGroupedModeRejectsInvalidCPUCapacity(t *testing.T) {
 	testCases := []struct {
-		name          string
-		capacity      string
-		expectedError string
+		name            string
+		groupBy         string
+		device          string
+		capacity        string
+		includeCapacity bool
+		expectedError   string
 	}{
-		{name: "fractional below one", capacity: "500m", expectedError: "must be a whole number"},
-		{name: "fractional above one", capacity: "1500m", expectedError: "must be a whole number"},
-		{name: "zero", capacity: "0", expectedError: "must be positive"},
-		{name: "negative", capacity: "-1", expectedError: "must be positive"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			prov := Providers{
-				CPUInfo: &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT},
-				SysFS:   testSysFS(mockCPUInfos_SingleSocket_4CPUS_HT),
-			}
-			conf := Config{
-				DriverName:       testDriverName,
-				NodeName:         testNodeName,
-				CPUDeviceMode:    devattr.CPU_DEVICE_MODE_GROUPED,
-				CPUDeviceGroupBy: devattr.GROUP_BY_SOCKET,
-			}
-			driver, err := New(testr.New(t), prov, &conf)
-			require.NoError(t, err)
-			mockCdiMgr := newMockCdiMgr()
-			driver.cdiMgr = mockCdiMgr
-
-			claimUID := types.UID("claim-invalid-capacity")
-			claim := testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
-				{
-					Driver:  testDriverName,
-					Pool:    testNodeName,
-					Device:  "cpudevsocket000",
-					Request: string(claimUID),
-					ConsumedCapacity: map[resourceapi.QualifiedName]resource.Quantity{
-						devattr.CPUResourceQualifiedName: resource.MustParse(tc.capacity),
-					},
-				},
-			})
-
-			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{claim})
-			require.NoError(t, err)
-			result := preparedClaims[claimUID]
-			require.ErrorContains(t, result.Err, tc.expectedError)
-			require.Empty(t, result.Devices)
-			require.Empty(t, mockCdiMgr.devices)
-
-			_, allocated := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
-			require.False(t, allocated)
-			require.True(t, cpuset.New(0, 1, 2, 3).Equals(driver.cpuAllocationStore.GetSharedCPUs()))
-		})
-	}
-}
-
-func TestPrepareResourceClaimsGroupedModeRejectsMissingCPUCapacity(t *testing.T) {
-	testCases := []struct {
-		name    string
-		groupBy string
-		device  string
-	}{
-		{name: "socket", groupBy: devattr.GROUP_BY_SOCKET, device: "cpudevsocket000"},
-		{name: "NUMA node", groupBy: devattr.GROUP_BY_NUMA_NODE, device: "cpudevnuma000"},
+		{name: "fractional below one", groupBy: devattr.GROUP_BY_SOCKET, device: "cpudevsocket000", capacity: "500m", includeCapacity: true, expectedError: "must be a whole number"},
+		{name: "fractional above one", groupBy: devattr.GROUP_BY_SOCKET, device: "cpudevsocket000", capacity: "1500m", includeCapacity: true, expectedError: "must be a whole number"},
+		{name: "zero", groupBy: devattr.GROUP_BY_SOCKET, device: "cpudevsocket000", capacity: "0", includeCapacity: true, expectedError: "must be positive"},
+		{name: "negative", groupBy: devattr.GROUP_BY_SOCKET, device: "cpudevsocket000", capacity: "-1", includeCapacity: true, expectedError: "must be positive"},
+		{name: "missing in socket grouping", groupBy: devattr.GROUP_BY_SOCKET, device: "cpudevsocket000", expectedError: fmt.Sprintf("CPU capacity %q for device %q is missing", devattr.CPUResourceQualifiedName, "cpudevsocket000")},
+		{name: "missing in NUMA node grouping", groupBy: devattr.GROUP_BY_NUMA_NODE, device: "cpudevnuma000", expectedError: fmt.Sprintf("CPU capacity %q for device %q is missing", devattr.CPUResourceQualifiedName, "cpudevnuma000")},
 	}
 
 	for _, tc := range testCases {
@@ -1320,20 +1271,24 @@ func TestPrepareResourceClaimsGroupedModeRejectsMissingCPUCapacity(t *testing.T)
 			mockCdiMgr := newMockCdiMgr()
 			driver.cdiMgr = mockCdiMgr
 
-			claimUID := types.UID("claim-missing-capacity")
-			claim := testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
-				{
-					Driver:  testDriverName,
-					Pool:    testNodeName,
-					Device:  tc.device,
-					Request: string(claimUID),
-				},
-			})
+			claimUID := types.UID("claim-invalid-capacity")
+			allocationResult := resourceapi.DeviceRequestAllocationResult{
+				Driver:  testDriverName,
+				Pool:    testNodeName,
+				Device:  tc.device,
+				Request: string(claimUID),
+			}
+			if tc.includeCapacity {
+				allocationResult.ConsumedCapacity = map[resourceapi.QualifiedName]resource.Quantity{
+					devattr.CPUResourceQualifiedName: resource.MustParse(tc.capacity),
+				}
+			}
+			claim := testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{allocationResult})
 
 			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{claim})
 			require.NoError(t, err)
 			result := preparedClaims[claimUID]
-			require.ErrorContains(t, result.Err, fmt.Sprintf("CPU capacity for device %q is missing", tc.device))
+			require.ErrorContains(t, result.Err, tc.expectedError)
 			require.Empty(t, result.Devices)
 			require.Empty(t, mockCdiMgr.devices)
 

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1293,6 +1293,95 @@ func TestPrepareResourceClaimsGroupedModeRejectsInvalidCPUCapacity(t *testing.T)
 	}
 }
 
+func TestPrepareResourceClaimsGroupedModeRejectsMissingCPUCapacity(t *testing.T) {
+	testCases := []struct {
+		name    string
+		groupBy string
+		device  string
+	}{
+		{name: "socket", groupBy: devattr.GROUP_BY_SOCKET, device: "cpudevsocket000"},
+		{name: "NUMA node", groupBy: devattr.GROUP_BY_NUMA_NODE, device: "cpudevnuma000"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := Providers{
+				CPUInfo: &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT},
+				SysFS:   testSysFS(mockCPUInfos_SingleSocket_4CPUS_HT),
+			}
+			conf := Config{
+				DriverName:       testDriverName,
+				NodeName:         testNodeName,
+				CPUDeviceMode:    devattr.CPU_DEVICE_MODE_GROUPED,
+				CPUDeviceGroupBy: tc.groupBy,
+			}
+			driver, err := New(testr.New(t), prov, &conf)
+			require.NoError(t, err)
+			mockCdiMgr := newMockCdiMgr()
+			driver.cdiMgr = mockCdiMgr
+
+			claimUID := types.UID("claim-missing-capacity")
+			claim := testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+				{
+					Driver:  testDriverName,
+					Pool:    testNodeName,
+					Device:  tc.device,
+					Request: string(claimUID),
+				},
+			})
+
+			preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{claim})
+			require.NoError(t, err)
+			result := preparedClaims[claimUID]
+			require.ErrorContains(t, result.Err, fmt.Sprintf("CPU capacity for device %q is missing", tc.device))
+			require.Empty(t, result.Devices)
+			require.Empty(t, mockCdiMgr.devices)
+
+			_, allocated := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+			require.False(t, allocated)
+			require.True(t, cpuset.New(0, 1, 2, 3).Equals(driver.cpuAllocationStore.GetSharedCPUs()))
+		})
+	}
+}
+
+func TestPrepareResourceClaimsGroupedModeIgnoresAllocationsFromOtherDrivers(t *testing.T) {
+	prov := Providers{
+		CPUInfo: &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT},
+		SysFS:   testSysFS(mockCPUInfos_SingleSocket_4CPUS_HT),
+	}
+	conf := Config{
+		DriverName:       testDriverName,
+		NodeName:         testNodeName,
+		CPUDeviceMode:    devattr.CPU_DEVICE_MODE_GROUPED,
+		CPUDeviceGroupBy: devattr.GROUP_BY_SOCKET,
+	}
+	driver, err := New(testr.New(t), prov, &conf)
+	require.NoError(t, err)
+	mockCdiMgr := newMockCdiMgr()
+	driver.cdiMgr = mockCdiMgr
+
+	claimUID := types.UID("claim-other-driver")
+	claim := testClaimWithResults(claimUID, []resourceapi.DeviceRequestAllocationResult{
+		{
+			Driver:  "other-driver",
+			Pool:    testNodeName,
+			Device:  "other-device",
+			Request: string(claimUID),
+		},
+	})
+
+	preparedClaims, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{claim})
+	require.NoError(t, err)
+	result := preparedClaims[claimUID]
+	require.NoError(t, result.Err)
+	require.Empty(t, result.Devices)
+	require.Empty(t, mockCdiMgr.devices)
+
+	_, allocated := driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
+	require.False(t, allocated)
+	require.True(t, cpuset.New(0, 1, 2, 3).Equals(driver.cpuAllocationStore.GetSharedCPUs()))
+}
+
 func TestPrepareResourceClaimsRepeatedCalls(t *testing.T) {
 	claimUID := types.UID("claim-1")
 	cdiDeviceName := getCDIDeviceName(claimUID)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Grouped CPU devices allow multiple allocations and therefore matching allocation results are expected to include the consumed `dra.cpu/cpu` capacity.

When that entry was missing, socket and NUMA grouping treated the allocation as requesting zero CPUs and returned success through the no-CPU-assignment path. This PR rejects such malformed grouped CPU allocations with an explicit error instead.

Allocation results belonging to other drivers continue to be ignored, preserving multi-driver claim behavior.

The PR adds regression coverage for:

- missing CPU capacity in socket grouping;
- missing CPU capacity in NUMA grouping;
- allocation results from other drivers without consumed CPU capacity.

#### Which issue(s) this PR is related to

Fixes #271

#### Special notes for reviewers

This is node-side validation only and does not change the device API. The validation applies to matching allocations in all grouped modes, whose devices set `AllowMultipleAllocations=true`.

Validation completed with:

```text
go test ./pkg/... ./internal/... ./api/... ./cmd/...
go test -race -count=1 ./pkg/driver
```

#### Release note

```release-note
NONE
```

#### Documentation updates

NONE
