### PR TITLE
fix: match configs for selected subrequests

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/utils/cpuset"
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
@@ -379,23 +379,20 @@ func (cp *CPUDriver) getOpaqueCPUSet(logger logr.Logger, allocation *resourceapi
 		return cpuset.CPUSet{}, false, nil
 	}
 
+	configs := resourceclaim.ConfigForResult(allocation.Devices.Config, alloc)
 	var matchedConfig *resourceapi.DeviceAllocationConfiguration
 	matchCount := 0
 
-	for _, config := range allocation.Devices.Config {
-		if config.Opaque == nil || config.Opaque.Driver != cp.driverName {
+	for i := range configs {
+		config := &configs[i]
+		if config.Opaque.Driver != cp.driverName {
 			continue
 		}
 		if config.Source != resourceapi.AllocationConfigSourceClaim {
 			return cpuset.CPUSet{}, false, fmt.Errorf("opaque config: configuration from DeviceClass is not supported by this driver, custom cpusets must be defined per ResourceClaim request")
 		}
-		// An empty requests list means the configuration applies to all requests in
-		// the claim. In 1.37+ kube-scheduler omits the list when the config applies
-		// to all requests.
-		if len(config.Requests) == 0 || slices.Contains(config.Requests, alloc.Request) {
-			matchedConfig = &config
-			matchCount++
-		}
+		matchedConfig = config
+		matchCount++
 	}
 
 	if matchCount != 1 {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1885,6 +1885,33 @@ func TestOpaqueConfigAllocation(t *testing.T) {
 			},
 		},
 		{
+			name: "CPU config block targeting parent request applies to selected subrequest",
+			claims: []*resourceapi.ResourceClaim{
+				func() *resourceapi.ResourceClaim {
+					claim := testClaim("claim-1", testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2})
+					claim.Status.Allocation.Devices.Results[0].Request = "claim-1/selected"
+					claim.Status.Allocation.Devices.Config = []resourceapi.DeviceAllocationConfiguration{
+						{
+							Source:   resourceapi.AllocationConfigSourceClaim,
+							Requests: []string{"claim-1"},
+							DeviceConfiguration: resourceapi.DeviceConfiguration{
+								Opaque: &resourceapi.OpaqueDeviceConfiguration{
+									Driver: testDriverName,
+									Parameters: runtime.RawExtension{
+										Raw: []byte(`{"apiVersion": "v1alpha1", "cpuConfig": {"cpuset": "2,6"}}`),
+									},
+								},
+							},
+						},
+					}
+					return claim
+				}(),
+			},
+			expectedAllocations: map[string]cpuset.CPUSet{
+				"claim-1": cpuset.New(2, 6),
+			},
+		},
+		{
 			name: "CPU allocation with offline cores",
 			claims: []*resourceapi.ResourceClaim{
 				testClaimWithOpaqueConfig("claim-1", testDriverName, testNodeName, map[string]int64{devattr.CPUDeviceMachineGrouped: 2}, "99,100"),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Uses `resourceclaim.ConfigForResult` when selecting an opaque allocation config. This preserves the existing empty-list and exact-match behavior while also applying a config for a parent request such as `foo` to the selected prioritized subrequest `foo/bar`.

Without this, machine-mode `NodePrepareResources` rejects prioritized-list allocations with zero matching configurations.

#### Which issue(s) this PR is related to

Follow-up to https://github.com/kubernetes-sigs/dra-driver-cpu/pull/269#issuecomment-5138403095

#### Special notes for reviewers

#### Release note

```release-note
Fixed machine-mode preparation for prioritized-list requests whose opaque CPU configuration targets the parent request.
```

#### Documentation updates

NONE
