### PR TITLE
cleanup: simplify CPUInfoProvider interface by removing GetCPUInfos

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -61,9 +61,7 @@ type cdiManager interface {
 }
 
 // CPUInfoProvider is an interface for getting CPU information.
-// TODO(pravk03): This interface can be simplified. We can export only GetCPUTopology() and remove GetCPUInfos().
 type CPUInfoProvider interface {
-	GetCPUInfos(logger logr.Logger) ([]cpuinfo.CPUInfo, error)
 	GetCPUTopology(logger logr.Logger) (*cpuinfo.CPUTopology, error)
 }
 


### PR DESCRIPTION
### Summary
Simplifies the `CPUInfoProvider` interface in `pkg/driver/driver.go` by removing the redundant `GetCPUInfos()` method signature as suggested in the TODO comment.

### Changes
- Removed `GetCPUInfos(logger logr.Logger) ([]cpuinfo.CPUInfo, error)` from `CPUInfoProvider` interface in `pkg/driver/driver.go`.

### Validation
```bash
go test ./pkg/... ./internal/... ./cmd/... -count=1
