### PR TITLE
feat: add per-allocated-CPU metadata entries for grouped modes

### DIFF
--- a/pkg/device/attributes.go
+++ b/pkg/device/attributes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package device
 
 import (
+	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	resourceapi "k8s.io/api/resource/v1"
 )
 
@@ -50,6 +51,21 @@ const (
 	// claim from a grouped device's capacity.
 	AttributeAllocatedNumCPUs resourceapi.QualifiedName = "dra.cpu/allocatedNumCPUs"
 )
+
+// CPUAttributes builds the per-CPU device attributes from a CPUInfo and SMT state.
+func CPUAttributes(cpu cpuinfo.CPUInfo, smtEnabled bool) map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	attrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+		AttributeNUMANodeID: {IntValue: new(int64(cpu.NUMANodeID))},
+		AttributeSocketID:   {IntValue: new(int64(cpu.SocketID))},
+		AttributeSMTEnabled: {BoolValue: new(smtEnabled)},
+		AttributeCacheL3ID:  {IntValue: new(int64(cpu.UncoreCacheID))},
+		AttributeCoreType:   {StringValue: new(cpu.CoreType.String())},
+		AttributeCoreID:     {IntValue: new(int64(cpu.CoreID))},
+		AttributeCPUID:      {IntValue: new(int64(cpu.CpuID))},
+	}
+	SetCompatibilityAttributes(attrs, int64(cpu.NUMANodeID))
+	return attrs
+}
 
 // SetCompatibilityAttributes add attributes to enable compatibility (e.g. alignment) with other
 // DRA resource drivers leveraging attributes which are not kubernetes standard.

--- a/pkg/device/builder.go
+++ b/pkg/device/builder.go
@@ -246,16 +246,7 @@ func createCPUDeviceSlices(deviceInfos []cpuDeviceInfo, pcieRootMapper *store.PC
 	var allDevices []resourceapi.Device
 	for _, deviceInfo := range deviceInfos {
 		cpu := deviceInfo.cpu
-		deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-			AttributeNUMANodeID: {IntValue: new(int64(cpu.NUMANodeID))},
-			AttributeSocketID:   {IntValue: new(int64(cpu.SocketID))},
-			AttributeSMTEnabled: {BoolValue: new(smtEnabled)},
-			AttributeCacheL3ID:  {IntValue: new(int64(cpu.UncoreCacheID))},
-			AttributeCoreType:   {StringValue: new(cpu.CoreType.String())},
-			AttributeCoreID:     {IntValue: new(int64(cpu.CoreID))},
-			AttributeCPUID:      {IntValue: new(int64(cpu.CpuID))},
-		}
-		SetCompatibilityAttributes(deviceAttrs, int64(cpu.NUMANodeID))
+		deviceAttrs := CPUAttributes(cpu, smtEnabled)
 		addPCIeRootsAttribute(pcieRootMapper, deviceAttrs, cpu.CpuID)
 
 		cpuDevice := resourceapi.Device{

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -302,6 +302,37 @@ func (cp *CPUDriver) prepareDevices(logger logr.Logger, claim *resourceapi.Resou
 		preparedDevices = append(preparedDevices, preparedDevice)
 	}
 
+	if cp.cpuDeviceMode == device.CPU_DEVICE_MODE_GROUPED && claimCPUSet.Size() > 0 {
+		var requestNames []string
+		for _, allocResult := range claim.Status.Allocation.Devices.Results {
+			if allocResult.Driver == cp.driverName && allocResult.Request != "" {
+				requestNames = append(requestNames, allocResult.Request)
+			}
+		}
+		for _, cpuID := range claimCPUSet.List() {
+			cpuInfo, ok := cp.topology.cpuTopology.CPUDetails[cpuID]
+			if !ok {
+				logger.Error(nil, "CPU not found in topology", "cpuID", cpuID)
+				continue
+			}
+			attrs := device.CPUAttributes(cpuInfo, cp.topology.cpuTopology.SMTEnabled)
+
+			metadataAttrs := make(map[string]resourceapi.DeviceAttribute, len(attrs))
+			for k, v := range attrs {
+				metadataAttrs[string(k)] = v
+			}
+			preparedDevices = append(preparedDevices, kubeletplugin.Device{
+				PoolName:   cp.nodeName,
+				DeviceName: fmt.Sprintf("%s%03d", device.CPUDevicePrefix, cpuID),
+				Requests:   requestNames,
+				Metadata: &kubeletplugin.DeviceMetadata{
+					Attributes: metadataAttrs,
+				},
+			})
+		}
+		logger.V(6).Info("added per-CPU metadata devices", "numCPUs", claimCPUSet.Size(), "totalDevices", len(preparedDevices))
+	}
+
 	logger.V(4).Info("prepared devices for resource claim", "preparedDevices", preparedDevices)
 	return kubeletplugin.PrepareResult{
 		Devices: preparedDevices,

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -1226,6 +1226,10 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 					// Build expected devices based on the claim request
 					expectedPreparedDevices := []kubeletplugin.Device{}
 					if tc.expectedCPUSet.Size() != 0 || tc.expectedError {
+						cpuInfoMap := make(map[int]cpuinfo.CPUInfo)
+						for _, ci := range tc.cpuInfos {
+							cpuInfoMap[ci.CpuID] = ci
+						}
 						// testSysFS doesn't include cpu/smt/control, so
 						// the driver's cpuTopology.SMTEnabled is always false
 						smtEnabled := false
@@ -1240,6 +1244,23 @@ func TestPrepareResourceClaimsGroupedMode(t *testing.T) {
 								CDIDeviceIDs: []string{cdiQualifiedName},
 								Requests:     []string{res.Request},
 								Metadata:     expectedGroupMetadata(tc.groupBy, tc.cpuInfos, tc.reservedCPUs, res.Device, smtEnabled, allocatedCPUs),
+							})
+						}
+						// Collect request names for per-CPU devices
+						var requestNames []string
+						for _, res := range tc.claims[0].Status.Allocation.Devices.Results {
+							if res.Driver == testDriverName && res.Request != "" {
+								requestNames = append(requestNames, res.Request)
+							}
+						}
+						// Expect per-allocated-CPU metadata entries
+						for _, cpuID := range tc.expectedCPUSet.List() {
+							ci := cpuInfoMap[cpuID]
+							expectedPreparedDevices = append(expectedPreparedDevices, kubeletplugin.Device{
+								PoolName:   testNodeName,
+								DeviceName: fmt.Sprintf("%s%03d", devattr.CPUDevicePrefix, cpuID),
+								Requests:   requestNames,
+								Metadata:   metadataFromCPUInfo(ci, smtEnabled),
 							})
 						}
 					}

--- a/test/e2e/metadata_test.go
+++ b/test/e2e/metadata_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
@@ -158,6 +159,7 @@ var _ = ginkgo.Describe("Device Metadata", ginkgo.Ordered, func() {
 			gomega.Expect(dev.Driver).To(gomega.Equal("dra.cpu"))
 
 			ginkgo.By("verifying mode-specific attributes")
+			isGrouped := cpuDeviceMode != device.CPU_DEVICE_MODE_INDIVIDUAL
 			switch cpuDeviceMode {
 			case device.CPU_DEVICE_MODE_INDIVIDUAL:
 				expectIntAttr(dev.Attributes, "dra.cpu/cpuID")
@@ -177,6 +179,28 @@ var _ = ginkgo.Describe("Device Metadata", ginkgo.Ordered, func() {
 				default: // NUMA node (default when groupBy is "" or "numanode")
 					expectIntAttr(dev.Attributes, "dra.cpu/numaNodeID")
 					expectIntAttr(dev.Attributes, "dra.cpu/socketID")
+				}
+			}
+
+			if isGrouped {
+				ginkgo.By("verifying per-allocated-CPU metadata entries")
+				var perCPUDevices []metadataDevice
+				for _, d := range req.Devices {
+					if strings.HasPrefix(d.Name, device.CPUDevicePrefix) &&
+						!strings.HasPrefix(d.Name, device.CPUDeviceNUMAGroupedPrefix) &&
+						!strings.HasPrefix(d.Name, device.CPUDeviceSocketGroupedPrefix) &&
+						d.Name != device.CPUDeviceMachineGrouped {
+						perCPUDevices = append(perCPUDevices, d)
+					}
+				}
+				gomega.Expect(perCPUDevices).To(gomega.HaveLen(numCPUs),
+					"expected %d per-CPU metadata entries, got %d", numCPUs, len(perCPUDevices))
+				for _, cpuDev := range perCPUDevices {
+					expectIntAttr(cpuDev.Attributes, "dra.cpu/cpuID")
+					expectIntAttr(cpuDev.Attributes, "dra.cpu/numaNodeID")
+					expectIntAttr(cpuDev.Attributes, "dra.cpu/socketID")
+					expectIntAttr(cpuDev.Attributes, "dra.cpu/coreID")
+					expectBoolAttr(cpuDev.Attributes, "dra.cpu/smtEnabled")
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- In grouped modes, add per-allocated-CPU device entries to KEP-5304
  metadata alongside the group device entry
- Each allocated CPU gets its own metadata entry with full topology
  attributes (cpuID, numaNodeID, socketID, coreID, cacheL3ID, coreType,
  smtEnabled)
- Extract shared `CPUAttributes()` function to eliminate duplication
  between `builder.go` and `dra_hooks.go`
- Individual mode unchanged

Fixes #285

## Example

Grouped-by-NUMA claim requesting 4 CPUs on a 4-NUMA Dell XE9680 (2x Intel Xeon Gold 6448Y, 128 CPUs). The metadata contains 1 group device + 4 per-CPU entries:

```json
{
  "requests": [
    {
      "name": "req-cpu",
      "devices": [
        {
          "driver": "dra.cpu",
          "name": "cpudevnuma000",
          "attributes": {
            "dra.cpu/allocatedNumCPUs": {"int": 4},
            "dra.cpu/numCPUs": {"int": 32},
            "dra.cpu/numaNodeID": {"int": 0},
            "dra.cpu/socketID": {"int": 0},
            "dra.cpu/smtEnabled": {"bool": true}
          }
        },
        {
          "driver": "dra.cpu",
          "name": "cpudev000",
          "attributes": {
            "dra.cpu/cpuID": {"int": 0},
            "dra.cpu/coreID": {"int": 0},
            "dra.cpu/socketID": {"int": 0},
            "dra.cpu/numaNodeID": {"int": 0},
            "dra.cpu/cacheL3ID": {"int": 0},
            "dra.cpu/coreType": {"string": "standard"},
            "dra.cpu/smtEnabled": {"bool": true}
          }
        },
        {
          "driver": "dra.cpu",
          "name": "cpudev024",
          "attributes": {
            "dra.cpu/cpuID": {"int": 24},
            "dra.cpu/coreID": {"int": 1},
            "dra.cpu/numaNodeID": {"int": 0},
            "..."
          }
        },
        {
          "driver": "dra.cpu",
          "name": "cpudev064",
          "attributes": {
            "dra.cpu/cpuID": {"int": 64},
            "dra.cpu/coreID": {"int": 0},
            "dra.cpu/numaNodeID": {"int": 0},
            "..."
          }
        },
        {
          "driver": "dra.cpu",
          "name": "cpudev088",
          "attributes": {
            "dra.cpu/cpuID": {"int": 88},
            "dra.cpu/coreID": {"int": 1},
            "dra.cpu/numaNodeID": {"int": 0},
            "..."
          }
        }
      ]
    }
  ]
}
```

CPUs 0 and 64 are SMT siblings (coreID 0). CPUs 24 and 88 are SMT siblings (coreID 1). All on NUMA node 0, socket 0, L3 cache 0.

## Test plan

- [x] Unit tests for per-CPU entries in all grouped modes
- [x] E2e test verifies per-CPU device count and attributes
- [x] `golangci-lint` passes with zero issues
- [x] Verified on Dell XE9680 (4 NUMA nodes, grouped-by-NUMA and
      grouped-by-socket modes)