### PR TITLE
feat: log the loaded configuration as YAML on startup

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -132,7 +132,7 @@ func runDriver(logger logr.Logger, cfg driverconfig.Config) error {
 
 func run(logger logr.Logger, cfg driverconfig.Config) error {
 	printVersion(logger)
-	logger.Info("CONFIG", cfg.LogValues()...)
+	logger.Info("configuration successfully loaded", "configuration", cfg.Dump())
 
 	reservedCPUSet, err := cpuset.Parse(cfg.ReservedCPUs)
 	if err != nil {

--- a/internal/driverconfig/config.go
+++ b/internal/driverconfig/config.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package driverconfig
 
+import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
 // ConfigAPIVersion is the version validated in config files.
 const ConfigAPIVersion = "v1alpha1"
 
@@ -49,4 +55,29 @@ func (c Config) LogValues() []any {
 		"sysfsOverlay", c.SysFSOverlay,
 		"kubeletRootDir", c.KubeletRootDir,
 	}
+}
+
+// dumpConfig mirrors Config field-for-field but drops the omitempty json
+// tags, so Dump also prints zero values (e.g. exposePCIeRoots=false).
+type dumpConfig struct {
+	Kubeconfig       string `json:"kubeconfig"`
+	HostnameOverride string `json:"hostnameOverride"`
+	BindAddress      string `json:"bindAddress"`
+	ReservedCPUs     string `json:"reservedCPUs"`
+	CPUDeviceMode    string `json:"cpuDeviceMode"`
+	GroupBy          string `json:"groupBy"`
+	ExposePCIeRoots  bool   `json:"exposePCIeRoots"`
+	SysFSOverlay     string `json:"sysfsOverlay"`
+	KubeletRootDir   string `json:"kubeletRootDir"`
+}
+
+// Dump renders the Config as YAML, for logging a human-readable snapshot of
+// the fully loaded configuration. Zero values are included, unlike
+// marshalling Config directly, since they reflect real runtime state.
+func (c Config) Dump() string {
+	out, err := yaml.Marshal(dumpConfig(c))
+	if err != nil {
+		return fmt.Sprintf("<!!! FAILED TO MARSHAL Config: %v !!!>", err)
+	}
+	return string(out)
 }

--- a/internal/driverconfig/logvalues_internal_test.go
+++ b/internal/driverconfig/logvalues_internal_test.go
@@ -44,3 +44,20 @@ func TestConfigLogValues_CoversAllFields(t *testing.T) {
 		}
 	}
 }
+
+// TestConfigDump_IncludesZeroValues: every Config json field appears in Dump,
+// even at its zero value.
+func TestConfigDump_IncludesZeroValues(t *testing.T) {
+	out := Config{}.Dump()
+
+	typ := reflect.TypeFor[Config]()
+	for field := range typ.Fields() {
+		jsonName, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if jsonName == "" || jsonName == "-" {
+			continue
+		}
+		if !strings.Contains(out, jsonName+":") {
+			t.Errorf("Config field %q (json key %q) is missing from Dump output:\n%s", field.Name, jsonName, out)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it
before 
```
I0807 09:24:22.065142       1 app.go:272] "dracpu" goVersion="go1.26.5" build="2e6c4737598a85790343634dd1bcef6fa2564d1c" time="2026-08-06T16:46:54Z"
I0807 09:24:22.065285       1 app.go:135] "CONFIG" kubeconfig="" bindAddress=":8080" cpuDeviceMode="grouped" groupBy="numanode" reservedCPUs="" hostnameOverride="" exposePCIeRoots=false sysfsOverlay="" kubeletRootDir="/var/lib/kubelet"
I0807 09:24:22.065594       1 envvar.go:195] "Feature gate default state" feature="UnlockWhileProcessingFIFO" enabled=true
I0807 09:24:22.065604       1 envvar.go:195] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0807 09:24:22.065608       1 envvar.go:195] "Feature gate default state" feature="WatchListClient" enabled=true
```

after

```logs
I0807 09:25:44.494561       1 app.go:272] "dracpu" goVersion="go1.26.5" build="49a79cbda20989172e7326dae3dec5e6f1897add" time="2026-08-07T09:00:37Z"
I0807 09:25:44.494803       1 app.go:135] "configuration successfully loaded" configuration=<
	bindAddress: :8080
	cpuDeviceMode: grouped
	groupBy: numanode
	kubeletRootDir: /var/lib/kubelet
 >
I0807 09:25:44.495039       1 envvar.go:195] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0807 09:25:44.495054       1 envvar.go:195] "Feature gate default state" feature="InformerResourceVersion" enabled=true
I0807 09:25:44.495058       1 envvar.go:195] "Feature gate default state" feature="AtomicFIFO" enabled=true
```
#### Which issue(s) this PR is related to

NONE

#### Special notes for reviewers

#### Release note

<!--
If this change is not user-facing, write:
NONE
-->

```release-note
Log the loaded configuration as YAML on driver startup
```
#### Documentation updates