### PR TITLE
docs: drop the removed --show-metrics flag from the user page

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -155,7 +155,6 @@ The remaining flags aren't part of that deprecation:
 - `--config`: path to the config file described above.
 - `--kubeconfig`: path to a kubeconfig file, for out-of-cluster use. Also settable via the `kubeconfig` config field.
 - `--bind-address`: address the metrics server listens on.
-- `--show-metrics`: print the metrics endpoint and exit.
 - `--expose-pcie-roots`: adds the `resource.kubernetes.io/pcieRoot` standard value to CPU
   devices, reporting the PCIe roots close to each device. Since it always reports values
   as a list, this option requires the cluster feature gate `DRAListTypeAttributes` (see


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

`--show-metrics` went away with the introspect subcommands and nothing defines it any more. Passing it now exits with `flag provided but not defined: -show-metrics`, which `test/e2e_local/metrics_test.go` asserts, along with the usage text no longer listing it.

The user configuration page still offers it under the flags that are not deprecated. So the one page a user would look at is the one place still saying it works, and the test suite is already proving otherwise on every run.

`docs/dev/configuration.md` records that `dracpu introspect metrics` replaced it, and why, so deleting the line loses nothing. I would be happy to add a pointer from the user page to the subcommand if that reads better, but that is a different change from removing a line that is simply untrue.

#### Which issue(s) this PR fixes

None.

Split out of #274 at @fmuyassarov's request. I had removed this line there while editing the same list, and he asked for it separately since it did not belong to that change: "let's not do it here, this change doesn't belong to the PR".

#### Special notes for your reviewer

Documentation only, one line.

#### Release note

```release-note
NONE
```

#### Documentation updates

`docs/user/configuration.md`: the `--show-metrics` entry is removed.

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
