### PR TITLE
fix: report why kubelet did not register the plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/component-helpers v0.36.0
 	k8s.io/dynamic-resource-allocation v0.36.0
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/kubelet v0.36.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/yaml v1.6.0
 	tags.cncf.io/container-device-interface v1.1.0
@@ -92,7 +93,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/kubelet v0.36.0 // indirect
 	k8s.io/streaming v0.36.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"testing/fstest"
 
@@ -38,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
+	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 	"k8s.io/utils/cpuset"
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
 )
@@ -66,6 +68,11 @@ func testSysFS(infos []cpuinfo.CPUInfo) fstest.MapFS {
 type mockKubeletPlugin struct {
 	publishedResources *resourceslice.DriverResources
 	publishError       error
+	// statusFunc answers one registration poll, and is given the number of the
+	// call so a test can change kubelet's answer over time. Left nil by the
+	// tests that do not exercise registration.
+	statusFunc  func(call int32) *registerapi.RegistrationStatus
+	statusCalls atomic.Int32
 }
 
 func (m *mockKubeletPlugin) PublishResources(ctx context.Context, resources resourceslice.DriverResources) error {
@@ -74,6 +81,13 @@ func (m *mockKubeletPlugin) PublishResources(ctx context.Context, resources reso
 		return m.publishError
 	}
 	return nil
+}
+
+func (m *mockKubeletPlugin) RegistrationStatus() *registerapi.RegistrationStatus {
+	if m.statusFunc == nil {
+		return nil
+	}
+	return m.statusFunc(m.statusCalls.Add(1))
 }
 
 func (m *mockKubeletPlugin) Stop() {}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"os"
@@ -39,12 +40,17 @@ import (
 	drametadatav1alpha1 "k8s.io/dynamic-resource-allocation/api/metadata/v1alpha1"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
+	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 	"k8s.io/utils/cpuset"
 )
 
 const (
 	// maxAttempts indicates the number of times the driver will try to recover itself before failing
 	maxAttempts = 5
+	// registrationPollInterval and registrationTimeout bound the wait for kubelet to
+	// acknowledge the plugin at startup
+	registrationPollInterval = 1 * time.Second
+	registrationTimeout      = 30 * time.Second
 )
 
 const opIDLen = 8
@@ -52,6 +58,7 @@ const opIDLen = 8
 // KubeletPlugin is an interface that describes the methods used from kubeletplugin.Helper.
 type KubeletPlugin interface {
 	PublishResources(context.Context, resourceslice.DriverResources) error
+	RegistrationStatus() *registerapi.RegistrationStatus
 	Stop()
 }
 
@@ -293,14 +300,7 @@ func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
 		return asyncErr, fmt.Errorf("start kubelet plugin: %w", err)
 	}
 	cp.draPlugin = d
-	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(context.Context) (bool, error) {
-		status := d.RegistrationStatus()
-		if status == nil {
-			return false, nil
-		}
-		return status.PluginRegistered, nil
-	})
-	if err != nil {
+	if err := waitForRegistration(ctx, d, registrarDir(cp.kubeletRootDir), registrationPollInterval, registrationTimeout); err != nil {
 		return asyncErr, err
 	}
 
@@ -354,6 +354,42 @@ func getDeviceAttributes(deviceSlices [][]resourceapi.Device, deviceName string)
 func (cp *CPUDriver) Shutdown(ctx context.Context) {
 	logger := ctxlog.FromContext(ctx)
 	logger.Info("runtime shutting down")
+}
+
+// waitForRegistration waits for kubelet to report the plugin as registered. On timeout
+// it reports the last reason kubelet gave for refusing, or that it never reported at all.
+func waitForRegistration(ctx context.Context, p KubeletPlugin, registrarPath string, interval, timeout time.Duration) error {
+	logger := ctxlog.FromContext(ctx)
+	var lastRejection string
+	var sawStatus bool
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(context.Context) (bool, error) {
+		status := p.RegistrationStatus()
+		if status == nil {
+			return false, nil
+		}
+		sawStatus = true
+		// Kubelet retries from scratch, so keep the newest reason but do not stop here.
+		// Only the newest survives to the error, so an earlier one is logged instead of lost.
+		if status.Error != "" && status.Error != lastRejection {
+			if lastRejection != "" {
+				logger.Info("kubelet gave a new reason for refusing the plugin", "previous", lastRejection, "current", status.Error)
+			}
+			lastRejection = status.Error
+		}
+		return status.PluginRegistered, nil
+	})
+	// Only a timeout is worth explaining; a cancelled context is the caller shutting down.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	switch {
+	case lastRejection != "":
+		return fmt.Errorf("kubelet did not register the plugin, last rejection was %q: %w", lastRejection, err)
+	case sawStatus:
+		return fmt.Errorf("kubelet did not register the plugin and reported no reason: %w", err)
+	default:
+		return fmt.Errorf("kubelet never reported a registration status, check that it watches %s: %w", registrarPath, err)
+	}
 }
 
 type nriRunner interface {

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -23,8 +23,10 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 )
 
 type mockNRIRunner struct {
@@ -100,6 +102,106 @@ func TestRunNRIPluginWithRetry_SuccessfulRunNoRetry(t *testing.T) {
 	err := runNRIPluginWithRetry(ctx, runner, maxAttempts)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Equal(t, int32(1), runner.calls.Load())
+}
+
+// TestWaitForRegistration covers an unexported function, which we would normally
+// reach through its caller instead. CPUDriver.Start does a lot and takes no
+// injectable dependencies, so there is no seam to reach this behaviour from
+// outside the package today. Testing it directly is the exception rather than the
+// pattern, and it can move behind Start once Start is separable.
+func TestWaitForRegistration(t *testing.T) {
+	const registrarPath = "/var/lib/kubelet/plugins_registry"
+	rejection := func(reason string) *registerapi.RegistrationStatus {
+		return &registerapi.RegistrationStatus{Error: reason}
+	}
+
+	for _, tc := range []struct {
+		name string
+		// status answers one poll. Calling cancel ends the wait the way a shutdown does.
+		status       func(cancel context.CancelFunc, call int32) *registerapi.RegistrationStatus
+		wantErr      bool
+		wantErrIs    error
+		wantInErr    []string
+		wantNotInErr []string
+		minCalls     int32
+	}{
+		{
+			name: "registered on the first poll",
+			status: func(context.CancelFunc, int32) *registerapi.RegistrationStatus {
+				return &registerapi.RegistrationStatus{PluginRegistered: true}
+			},
+		},
+		{
+			name: "the newest rejection is the one reported",
+			status: func(_ context.CancelFunc, call int32) *registerapi.RegistrationStatus {
+				if call == 1 {
+					return rejection("unsupported plugin API version")
+				}
+				return rejection("driver name already registered")
+			},
+			wantErr:      true,
+			wantInErr:    []string{"driver name already registered"},
+			wantNotInErr: []string{"unsupported plugin API version"},
+			minCalls:     2,
+		},
+		{
+			name: "unregistered with no reason given",
+			status: func(context.CancelFunc, int32) *registerapi.RegistrationStatus {
+				return &registerapi.RegistrationStatus{}
+			},
+			wantErr:   true,
+			wantInErr: []string{"reported no reason"},
+		},
+		{
+			name: "kubelet never reported a status",
+			status: func(context.CancelFunc, int32) *registerapi.RegistrationStatus {
+				return nil
+			},
+			wantErr:   true,
+			wantInErr: []string{registrarPath},
+		},
+		{
+			name: "a shutdown is not diagnosed",
+			status: func(cancel context.CancelFunc, _ int32) *registerapi.RegistrationStatus {
+				cancel()
+				return nil
+			},
+			wantErr:      true,
+			wantErrIs:    context.Canceled,
+			wantNotInErr: []string{registrarPath},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			registrar := &mockKubeletPlugin{
+				statusFunc: func(call int32) *registerapi.RegistrationStatus {
+					return tc.status(cancel, call)
+				},
+			}
+
+			err := waitForRegistration(ctx, registrar, registrarPath, time.Millisecond, 200*time.Millisecond)
+			if tc.minCalls > 0 {
+				require.GreaterOrEqual(t, registrar.statusCalls.Load(), tc.minCalls, "too few polls for this case to prove anything")
+			}
+			if !tc.wantErr {
+				require.NoError(t, err)
+				require.Equal(t, int32(1), registrar.statusCalls.Load(), "a registered plugin should end the wait right away")
+				return
+			}
+			require.Error(t, err)
+			if tc.wantErrIs != nil {
+				require.ErrorIs(t, err, tc.wantErrIs)
+			}
+			for _, want := range tc.wantInErr {
+				require.ErrorContains(t, err, want)
+			}
+			for _, unwanted := range tc.wantNotInErr {
+				require.NotContains(t, err.Error(), unwanted)
+			}
+		})
+	}
 }
 
 func TestGenerateShortID(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`Start` waits up to 30 seconds for kubelet to acknowledge the plugin, polling `RegistrationStatus()` and looking only at `PluginRegistered`. The same status carries the reason kubelet gives when it turns the plugin down, and that field was dropped, so a driver that kubelet keeps rejecting fails with a bare `context deadline exceeded` and nothing about why.

Bailing out as soon as a rejection appears would be wrong: kubelet retries registration from scratch, so a single unregistered status is not the end of the attempt. The wait keeps polling and only remembers the newest non-empty reason, which it attaches if the timeout is reached.

Three outcomes are worth telling apart, and the error now says which one happened:

- kubelet rejected the plugin and said why, and the reason is quoted;
- kubelet reported the plugin as unregistered but gave no reason;
- kubelet never reported at all, and the message names the registrar directory.

The third case is the shape seen in #231: when the socket sits outside the directory kubelet watches, kubelet never discovers it, `RegistrationStatus()` stays nil, and no reason is ever produced, so pointing at the registrar path is the only useful thing left to say. The cases where a reason does show up are kubelet-side rejections, such as an unsupported plugin API version, a driver name or metadata rejection, or a handler registration failure.

Only a wait that actually ran out gets explained, keyed off `context.DeadlineExceeded` the way the DRA scheduler plugin keys its own binding timeout. A cancelled context means the caller is shutting down and already carries its reason, so it passes through untouched rather than collecting advice about kubelet that does not apply.

#### Which issue(s) this PR is related to

Fixes #254

#### Special notes for reviewers

The wait moved into `waitForRegistration` so a fake registrar can drive it, following how `runNRIPluginWithRetry` is structured and tested. The poll interval and timeout became parameters so the tests do not have to sit through the real 30 seconds; the call site passes the existing 1s and 30s values, so nothing about the timing changes.

I deliberately left out logging the rejection as it arrives. Kubelet can report the same refusal on every one-second poll, so a log line per poll would be thirty repeats of one fact, and the failure already surfaces through `driver failed to start`, which is the shape `docs/dev/logging.md` asks for: fail the flow, and let the error point at the fix. If you would rather see it sooner than the timeout, a single `V(2)` line the first time a reason appears would be easy to add.

Naming `*registerapi.RegistrationStatus` in the small interface promotes `k8s.io/kubelet` from an indirect to a direct requirement in `go.mod`. It is the same v0.36.0 already in the module graph and matches the other `k8s.io` modules, so nothing new is pulled in. If you would rather not take the direct requirement, I am glad to keep the wait inline in `Start` instead, at the cost of the unit test.

#### Release note

```release-note
The CPU DRA driver now reports the reason kubelet gave when plugin registration times out, rather than only the timeout itself.
```

#### Documentation updates

NONE
