### PR TITLE
refactor: extract layered config resolution pipeline

### DIFF
--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -111,7 +111,14 @@ func main() {
 		return
 	}
 
-	cfg, err := driverconfig.Load(driverFlags, configFile, flag.CommandLine, logger)
+	cfg, err := driverconfig.Resolve(logger, []driverconfig.Source{
+		// the ordering of Sources matters and determines the
+		// precedence of layers (aka overrides).
+		// Per our current policy, the priority (rightmost wins)
+		// is defaults -> config -> flags.
+		driverconfig.FromFile(configFile),
+		driverconfig.FromFlags(flag.CommandLine),
+	})
 	if err != nil {
 		logger.Error(err, "failed to load configuration")
 		os.Exit(1)

--- a/cmd/dracpu/app.go
+++ b/cmd/dracpu/app.go
@@ -55,7 +55,7 @@ const (
 )
 
 var (
-	driverFlags = driverconfig.Default()
+	driverFlags driverconfig.Config
 	configFile  string
 
 	ready atomic.Bool
@@ -96,12 +96,10 @@ func main() {
 			fmt.Fprintln(os.Stderr, "dracpu: root flags cannot be combined with subcommands")
 			os.Exit(1)
 		}
-
 		opts := subcommands.Options{
-			DriverConfig: driverFlags,
-			Logger:       logger,
-			Stdout:       os.Stdout,
-			Stderr:       os.Stderr,
+			Logger: logger,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
 		}
 
 		if err := subcommands.Run(flag.Args(), opts); err != nil {

--- a/internal/driverconfig/cfgfile.go
+++ b/internal/driverconfig/cfgfile.go
@@ -17,8 +17,6 @@ limitations under the License.
 package driverconfig
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -27,8 +25,35 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/yaml"
 )
+
+type FileSource struct {
+	confPath string
+}
+
+func FromFile(confPath string) FileSource {
+	return FileSource{
+		confPath: confPath,
+	}
+}
+
+func (fs FileSource) Name() string {
+	return fs.confPath
+}
+
+func (fs FileSource) Apply(logger logr.Logger, cfg *Config) error {
+	if fs.confPath == "" {
+		return nil // nothing to do
+	}
+	overrides, err := buildConfMap(fs.confPath)
+	if err != nil {
+		return err
+	}
+	logger.V(6).Info("overrides", "stage", fs.Name(), "values", overrides)
+	return applyMap(cfg, overrides)
+}
 
 // buildConfMap loads the config file at filePath, validates and strips
 // "apiVersion", and returns the resulting map.
@@ -153,22 +178,6 @@ func validateAPIVersion(confMap map[string]any) error {
 	apiVer, _ := raw.(string)
 	if apiVer != ConfigAPIVersion {
 		return fmt.Errorf("unsupported apiVersion %q, want %q", apiVer, ConfigAPIVersion)
-	}
-	return nil
-}
-
-// applyMap applies only the keys present in m to cfg; absent keys are
-// untouched (encoding/json.Unmarshal semantics). Unknown keys are rejected
-// to catch typos early rather than silently ignoring them.
-func applyMap(cfg *Config, m map[string]any) error {
-	data, err := json.Marshal(m)
-	if err != nil {
-		return fmt.Errorf("marshaling config map: %w", err)
-	}
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(cfg); err != nil {
-		return fmt.Errorf("applying config map: %w", err)
 	}
 	return nil
 }

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -558,6 +558,48 @@ func TestLoad_KubeletRootDirFromFlag(t *testing.T) {
 	}
 }
 
+// TestFromFlags_BoolAndStringValues: FromFlags must produce typed values —
+// bool flags as bool (not the string "true"), string flags as string, and
+// custom flag.Value types (which don't implement flag.Getter) as string.
+// Without this, applyMap would fail to decode a JSON string into a bool field.
+func TestFromFlags_BoolAndStringValues(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		args           []string
+		wantPCIeRoots  bool
+		wantReserved   string
+		wantDeviceMode string
+	}{
+		{
+			name:           "bool flag set to true",
+			args:           []string{"--expose-pcie-roots=true", "--reserved-cpus=0-3", "--cpu-device-mode=individual"},
+			wantPCIeRoots:  true,
+			wantReserved:   "0-3",
+			wantDeviceMode: device.CPU_DEVICE_MODE_INDIVIDUAL,
+		},
+		{
+			name:           "bool flag set to false",
+			args:           []string{"--expose-pcie-roots=false", "--reserved-cpus=4-7"},
+			wantPCIeRoots:  false,
+			wantReserved:   "4-7",
+			wantDeviceMode: device.CPU_DEVICE_MODE_GROUPED,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := driverconfig.Default()
+			fs := newFlagSet(t, &cfg, tc.args)
+
+			src := driverconfig.FromFlags(fs)
+			result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{src})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPCIeRoots, result.ExposePCIeRoots)
+			assert.Equal(t, tc.wantReserved, result.ReservedCPUs)
+			assert.Equal(t, tc.wantDeviceMode, result.CPUDeviceMode)
+		})
+	}
+}
+
 func TestLoad_KubeletRootDirWithAConfigFile(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package driverconfig_test
 
 import (
+	"errors"
 	"flag"
 	"os"
 	"path/filepath"
@@ -51,19 +52,16 @@ func writeFile(t *testing.T, dir, name, content string) string {
 	return path
 }
 
-// TestLoad_NoFile: empty filePath returns base unchanged.
-func TestLoad_NoFile(t *testing.T) {
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	result, err := driverconfig.Load(cfg, "", fs, testr.New(t))
+// TestResolve_NoSources: no sources returns Default() unchanged.
+func TestResolve_NoSources(t *testing.T) {
+	result, err := driverconfig.Resolve(testr.New(t), nil)
 
 	require.NoError(t, err)
-	assert.Equal(t, cfg, result)
+	assert.Equal(t, driverconfig.Default(), result)
 }
 
-// TestLoad_FileOverridesDefaults: file values are applied when no CLI flags are set.
-func TestLoad_FileOverridesDefaults(t *testing.T) {
+// TestResolve_FileOverridesDefaults: file values are applied when no CLI flags are set.
+func TestResolve_FileOverridesDefaults(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v1alpha1
@@ -73,10 +71,9 @@ reservedCPUs: "0-3"
 sysfsOverlay: /custom/sysfs
 `)
 
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil) // no CLI flags
-
-	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, device.CPU_DEVICE_MODE_INDIVIDUAL, result.CPUDeviceMode)
@@ -85,8 +82,8 @@ sysfsOverlay: /custom/sysfs
 	assert.Equal(t, "/custom/sysfs", result.SysFSOverlay)
 }
 
-// TestLoad_CLIFlagWinsOverFile: an explicitly-passed CLI flag beats the file value.
-func TestLoad_CLIFlagWinsOverFile(t *testing.T) {
+// TestResolve_CLIFlagWinsOverFile: an explicitly-passed CLI flag beats the file value.
+func TestResolve_CLIFlagWinsOverFile(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v1alpha1
@@ -94,26 +91,29 @@ reservedCPUs: "0-3"
 cpuDeviceMode: individual
 `)
 
-	cfg := driverconfig.Default()
+	var cfg driverconfig.Config
 	fs := newFlagSet(t, &cfg, []string{
 		"--reserved-cpus=4-7",
 		"--cpu-device-mode=grouped",
 	})
 
-	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+		driverconfig.FromFlags(fs),
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "4-7", result.ReservedCPUs)
 	assert.Equal(t, device.CPU_DEVICE_MODE_GROUPED, result.CPUDeviceMode)
 }
 
-// TestLoad_RejectsAmbiguousKeys covers the ways a config file can reach a field
+// TestResolve_RejectsAmbiguousKeys covers the ways a config file can reach a field
 // without naming it the way the schema does. Each has to fail, and the message
 // has to say what to write instead: for an excluded field that is the
 // alternative setting rather than the canonical spelling, which the next check
 // refuses anyway, and a name matching no field at all stays the decoder's to
 // report.
-func TestLoad_RejectsAmbiguousKeys(t *testing.T) {
+func TestResolve_RejectsAmbiguousKeys(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
 		file            string
@@ -181,10 +181,14 @@ func TestLoad_RejectsAmbiguousKeys(t *testing.T) {
 			dir := t.TempDir()
 			cfgFile := writeFile(t, dir, "config.yaml", tc.file)
 
-			cfg := driverconfig.Default()
-			fs := newFlagSet(t, &cfg, tc.flags)
+			var cfg driverconfig.Config
+			sources := []driverconfig.Source{driverconfig.FromFile(cfgFile)}
+			if len(tc.flags) > 0 {
+				fs := newFlagSet(t, &cfg, tc.flags)
+				sources = append(sources, driverconfig.FromFlags(fs))
+			}
 
-			_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+			_, err := driverconfig.Resolve(testr.New(t), sources)
 
 			require.Error(t, err)
 			for _, want := range tc.wantContains {
@@ -197,7 +201,7 @@ func TestLoad_RejectsAmbiguousKeys(t *testing.T) {
 	}
 }
 
-// TestLoad_ReportsEveryMiscasedKey: a hand-edited file usually has more than
+// TestResolve_ReportsEveryMiscasedKey: a hand-edited file usually has more than
 // one, and fixing them one restart at a time is the difference between one
 // CrashLoopBackOff and three. A key misspelled rather than miscased is not this
 // check's to batch, and the decoder reports those one at a time.
@@ -206,7 +210,7 @@ func TestLoad_RejectsAmbiguousKeys(t *testing.T) {
 // different key on each node for the same ConfigMap, so the keys are sorted, and
 // an exact message is what pins that ordering along with each canonical
 // spelling, the separator, and the shape of the whole thing.
-func TestLoad_ReportsEveryMiscasedKey(t *testing.T) {
+func TestResolve_ReportsEveryMiscasedKey(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v1alpha1
@@ -215,31 +219,34 @@ groupby: socket
 cpudevicemode: individual
 `)
 
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	_, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
 
 	require.Error(t, err)
-	assert.EqualError(t, err,
-		`config file "`+cfgFile+`": `+
-			`field "cpudevicemode" is spelled differently from the schema; use "cpuDeviceMode"; `+
+	// we care about the inner error that the source reported, not about the
+	// wrapped error Resolve() produced.
+	err2 := errors.Unwrap(err)
+	if err2 == nil {
+		err2 = err
+	}
+	assert.EqualError(t, err2,
+		`field "cpudevicemode" is spelled differently from the schema; use "cpuDeviceMode"; `+
 			`field "groupby" is spelled differently from the schema; use "groupBy"; `+
 			`field "reservedcpus" is spelled differently from the schema; use "reservedCPUs"`)
 }
 
-// TestLoad_PartialFile: fields absent from the file retain their default values.
-func TestLoad_PartialFile(t *testing.T) {
+// TestResolve_PartialFile: fields absent from the file retain their default values.
+func TestResolve_PartialFile(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v1alpha1
 reservedCPUs: "4-7"
 `)
 
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "4-7", result.ReservedCPUs)
@@ -248,56 +255,53 @@ reservedCPUs: "4-7"
 	assert.Equal(t, device.GROUP_BY_NUMA_NODE, result.GroupBy)
 }
 
-// TestLoad_FileWithoutAPIVersion: omitting apiVersion is accepted.
-func TestLoad_FileWithoutAPIVersion(t *testing.T) {
+// TestResolve_FileWithoutAPIVersion: omitting apiVersion is accepted.
+func TestResolve_FileWithoutAPIVersion(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 reservedCPUs: "5-6"
 `)
 
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "5-6", result.ReservedCPUs)
 }
 
-// TestLoad_UnknownAPIVersionIsError: an unrecognised apiVersion is rejected.
-func TestLoad_UnknownAPIVersionIsError(t *testing.T) {
+// TestResolve_UnknownAPIVersionIsError: an unrecognised apiVersion is rejected.
+func TestResolve_UnknownAPIVersionIsError(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v99
 reservedCPUs: "0-3"
 `)
 
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	_, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported apiVersion")
 	assert.Contains(t, err.Error(), "v99")
 }
 
-// TestLoad_MissingFileIsError: a non-existent file path returns an error.
-func TestLoad_MissingFileIsError(t *testing.T) {
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	_, err := driverconfig.Load(cfg, "/does/not/exist/config.yaml", fs, testr.New(t))
+// TestResolve_MissingFileIsError: a non-existent file path returns an error.
+func TestResolve_MissingFileIsError(t *testing.T) {
+	_, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile("/does/not/exist/config.yaml"),
+	})
 
 	require.Error(t, err)
 }
 
-// TestLoad_IgnoresUnrelatedFlags: flags that are not Config fields (such as
+// TestResolve_IgnoresUnrelatedFlags: flags that are not Config fields (such as
 // --config and the klog --v flag that share the process FlagSet) must not
 // produce any error log, while a mapped flag set on the command line still
 // overrides the file. Regression guard for the spurious "flag not found in
 // flagToJSONKey" errors that used to fire on every startup with a config file.
-func TestLoad_IgnoresUnrelatedFlags(t *testing.T) {
+func TestResolve_IgnoresUnrelatedFlags(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v1alpha1
@@ -309,8 +313,7 @@ hostnameOverride: from-file
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	// Mirror the real command line: --config and klog's --v live on the same
 	// FlagSet but are not Config fields.
-	var configFile string
-	fs.StringVar(&configFile, "config", "", "path to the config file")
+	fs.String("config", "", "path to the config file")
 	fs.Int("v", 0, "log verbosity")
 	cfg.AddFlags(fs)
 	require.NoError(t, fs.Parse([]string{
@@ -324,7 +327,10 @@ hostnameOverride: from-file
 		logs.WriteString(prefix + " " + args + "\n")
 	}, funcr.Options{Verbosity: 10})
 
-	got, err := driverconfig.Load(cfg, configFile, fs, logger)
+	got, err := driverconfig.Resolve(logger, []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+		driverconfig.FromFlags(fs),
+	})
 
 	require.NoError(t, err)
 	assert.NotContains(t, logs.String(), "flag not found",
@@ -409,6 +415,16 @@ func TestDeprecatedFlags_HelpTextSuffix(t *testing.T) {
 	})
 }
 
+// TestResolve_EmptyFilePath: an empty file path is a no-op.
+func TestResolve_EmptyFilePath(t *testing.T) {
+	result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(""),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, driverconfig.Default(), result)
+}
+
 // TestDefault pins the built-in default values.
 func TestDefault(t *testing.T) {
 	d := driverconfig.Default()
@@ -426,45 +442,43 @@ func TestDefault(t *testing.T) {
 	assert.False(t, d.ExposePCIeRoots)
 }
 
-// TestLoad_InvalidCPUDeviceModeIsError: an invalid cpuDeviceMode in the file is rejected.
-func TestLoad_InvalidCPUDeviceModeIsError(t *testing.T) {
+// TestResolve_InvalidCPUDeviceModeIsError: an invalid cpuDeviceMode in the file is rejected.
+func TestResolve_InvalidCPUDeviceModeIsError(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v1alpha1
 cpuDeviceMode: garbage
 `)
 
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	_, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid cpuDeviceMode")
 	assert.Contains(t, err.Error(), "garbage")
 }
 
-// TestLoad_InvalidGroupByIsError: an invalid groupBy in the file is rejected.
-func TestLoad_InvalidGroupByIsError(t *testing.T) {
+// TestResolve_InvalidGroupByIsError: an invalid groupBy in the file is rejected.
+func TestResolve_InvalidGroupByIsError(t *testing.T) {
 	dir := t.TempDir()
 	cfgFile := writeFile(t, dir, "config.yaml", `
 apiVersion: v1alpha1
 groupBy: garbage
 `)
 
-	cfg := driverconfig.Default()
-	fs := newFlagSet(t, &cfg, nil)
-
-	_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+	_, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid groupBy")
 	assert.Contains(t, err.Error(), "garbage")
 }
 
-// TestLoad_ExcludedFieldInFileIsError: excluded and removed fields aren't
+// TestResolve_ExcludedFieldInFileIsError: excluded and removed fields aren't
 // configurable via the config file.
-func TestLoad_ExcludedFieldInFileIsError(t *testing.T) {
+func TestResolve_ExcludedFieldInFileIsError(t *testing.T) {
 	for _, tc := range []struct {
 		field    string
 		content  string
@@ -486,10 +500,9 @@ func TestLoad_ExcludedFieldInFileIsError(t *testing.T) {
 			dir := t.TempDir()
 			cfgFile := writeFile(t, dir, "config.yaml", "apiVersion: v1alpha1\n"+tc.content+"\n")
 
-			cfg := driverconfig.Default()
-			fs := newFlagSet(t, &cfg, nil)
-
-			_, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+			_, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+				driverconfig.FromFile(cfgFile),
+			})
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.field)
@@ -502,7 +515,7 @@ func TestLoad_ExcludedFieldInFileIsError(t *testing.T) {
 
 // The chart passes the kubelet root as a flag and renders its hostPath mounts
 // from the same value, so a root that cannot be used has to fail here.
-func TestLoad_KubeletRootDirFromFlag(t *testing.T) {
+func TestResolve_KubeletRootDirFromFlag(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		args     []string
@@ -540,15 +553,15 @@ func TestLoad_KubeletRootDirFromFlag(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := driverconfig.Default()
+			var cfg driverconfig.Config
 			fs := newFlagSet(t, &cfg, tc.args)
 
-			result, err := driverconfig.Load(cfg, "", fs, testr.New(t))
+			result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+				driverconfig.FromFlags(fs),
+			})
 
 			if tc.wantErr != "" {
 				require.Error(t, err)
-				// With no file there is nothing to name as the input.
-				assert.Contains(t, err.Error(), "validating configuration:")
 				assert.Contains(t, err.Error(), tc.wantErr)
 				return
 			}
@@ -600,13 +613,12 @@ func TestFromFlags_BoolAndStringValues(t *testing.T) {
 	}
 }
 
-func TestLoad_KubeletRootDirWithAConfigFile(t *testing.T) {
+func TestResolve_KubeletRootDirWithAConfigFile(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		content          string
 		args             []string
 		wantErrs         []string
-		wantFileNamed    bool
 		wantRoot         string
 		wantReservedCPUs string
 	}{
@@ -633,29 +645,28 @@ func TestLoad_KubeletRootDirWithAConfigFile(t *testing.T) {
 			// The file is an input, not the source: it is valid and is not allowed
 			// to carry this field, so blaming its contents would send the reader
 			// looking for a key that cannot be there.
-			name:          "a bad flag names the file as an input",
-			content:       `reservedCPUs: "0-1"`,
-			args:          []string{"--kubelet-root-dir=relative/kubelet"},
-			wantErrs:      []string{"validating the configuration after loading", "must be an absolute path"},
-			wantFileNamed: true,
+			name:     "a bad flag names the file as an input",
+			content:  `reservedCPUs: "0-1"`,
+			args:     []string{"--kubelet-root-dir=relative/kubelet"},
+			wantErrs: []string{"must be an absolute path"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			cfgFile := writeFile(t, dir, "config.yaml", "apiVersion: v1alpha1\n"+tc.content+"\n")
 
-			cfg := driverconfig.Default()
+			var cfg driverconfig.Config
 			fs := newFlagSet(t, &cfg, tc.args)
 
-			result, err := driverconfig.Load(cfg, cfgFile, fs, testr.New(t))
+			result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+				driverconfig.FromFile(cfgFile),
+				driverconfig.FromFlags(fs),
+			})
 
 			if len(tc.wantErrs) > 0 {
 				require.Error(t, err)
 				for _, want := range tc.wantErrs {
 					assert.Contains(t, err.Error(), want)
-				}
-				if tc.wantFileNamed {
-					assert.Contains(t, err.Error(), cfgFile)
 				}
 				return
 			}
@@ -664,4 +675,27 @@ func TestLoad_KubeletRootDirWithAConfigFile(t *testing.T) {
 			assert.Equal(t, tc.wantReservedCPUs, result.ReservedCPUs)
 		})
 	}
+}
+
+// TestResolve_BoolFlagWinsOverFile: a bool CLI flag correctly overrides via the JSON round-trip.
+func TestResolve_BoolFlagWinsOverFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := writeFile(t, dir, "config.yaml", `
+apiVersion: v1alpha1
+reservedCPUs: "0-3"
+`)
+
+	var cfg driverconfig.Config
+	fs := newFlagSet(t, &cfg, []string{
+		"--expose-pcie-roots=true",
+	})
+
+	result, err := driverconfig.Resolve(testr.New(t), []driverconfig.Source{
+		driverconfig.FromFile(cfgFile),
+		driverconfig.FromFlags(fs),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.ExposePCIeRoots)
+	assert.Equal(t, "0-3", result.ReservedCPUs)
 }

--- a/internal/driverconfig/flags.go
+++ b/internal/driverconfig/flags.go
@@ -21,8 +21,40 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
 )
+
+type FlagSource struct {
+	overrides map[string]any
+}
+
+func FromFlags(flagset *flag.FlagSet) FlagSource {
+	fs := FlagSource{
+		overrides: make(map[string]any),
+	}
+	flagset.Visit(func(f *flag.Flag) {
+		key, ok := flagToJSONKey[f.Name]
+		if !ok {
+			return
+		}
+		if g, ok := f.Value.(flag.Getter); ok {
+			fs.overrides[key] = g.Get()
+		} else {
+			fs.overrides[key] = f.Value.String()
+		}
+	})
+	return fs
+}
+
+func (fs FlagSource) Name() string {
+	return "flags"
+}
+
+func (fs FlagSource) Apply(logger logr.Logger, cfg *Config) error {
+	logger.V(6).Info("overrides", "stage", fs.Name(), "values", fs.overrides)
+	return applyMap(cfg, fs.overrides)
+}
 
 // AddFlags registers the Config fields that are exposed as CLI flags on fs.
 func (c *Config) AddFlags(fs *flag.FlagSet) {

--- a/internal/driverconfig/flags.go
+++ b/internal/driverconfig/flags.go
@@ -99,7 +99,7 @@ func (c *Config) applyDefaults() {
 // Validate checks that enum fields hold recognised values and that
 // kubeletRootDir is non-empty and absolute. The root is required rather than
 // optional because the hostPath mounts render from the same value.
-// Config files bypass the flag.Value validators, so Load calls this after merging.
+// Config files bypass the flag.Value validators, so Resolve calls this after merging.
 func (c Config) Validate() error {
 	if c.CPUDeviceMode != device.CPU_DEVICE_MODE_GROUPED && c.CPUDeviceMode != device.CPU_DEVICE_MODE_INDIVIDUAL {
 		return fmt.Errorf("invalid cpuDeviceMode %q: must be %q or %q",

--- a/internal/driverconfig/load.go
+++ b/internal/driverconfig/load.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driverconfig
 
 import (
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"path/filepath"
@@ -60,6 +62,28 @@ func WarnDeprecatedFlags(fs *flag.FlagSet, logger logr.Logger) {
 		logger.Info("flag is deprecated and will be removed in a future release; prefer the equivalent driverConfig field instead",
 			"flag", f.Name, "driverConfigField", flagToJSONKey[f.Name])
 	})
+}
+
+type Source interface {
+	Name() string
+	Apply(logger logr.Logger, cfg *Config) error
+}
+
+func Resolve(logger logr.Logger, sources []Source) (Config, error) {
+	cfg := Default()
+	logger.WithValues("stage", "default").V(6).Info("config", cfg.LogValues()...)
+
+	for _, src := range sources {
+		if err := src.Apply(logger, &cfg); err != nil {
+			return Config{}, fmt.Errorf("cannot apply %s: %w", src.Name(), err)
+		}
+		logger.WithValues("applied", src.Name()).V(6).Info("config", cfg.LogValues()...)
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, fmt.Errorf("cannot validate config: %w", err)
+	}
+	logger.WithValues("stage", "validated").V(6).Info("config", cfg.LogValues()...)
+	return cfg, nil
 }
 
 // Load merges the config file at filePath into base, giving CLI flags that were
@@ -119,4 +143,20 @@ func Load(base Config, filePath string, fs *flag.FlagSet, logger logr.Logger) (C
 	}
 
 	return result, nil
+}
+
+// applyMap applies only the keys present in m to cfg; absent keys are
+// untouched (encoding/json.Unmarshal semantics). Unknown keys are rejected
+// to catch typos early rather than silently ignoring them.
+func applyMap(cfg *Config, m map[string]any) error {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling config map: %w", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(cfg); err != nil {
+		return fmt.Errorf("applying config map: %w", err)
+	}
+	return nil
 }

--- a/internal/driverconfig/load.go
+++ b/internal/driverconfig/load.go
@@ -52,8 +52,7 @@ var deprecatedFlags = sets.New(
 )
 
 // WarnDeprecatedFlags logs a warning for each deprecated flag explicitly set
-// on the command line. Not called by Load. gatherinfo also calls Load, but
-// on other processes' flags, where a warning wouldn't make sense.
+// on the command line.
 func WarnDeprecatedFlags(fs *flag.FlagSet, logger logr.Logger) {
 	fs.Visit(func(f *flag.Flag) {
 		if !deprecatedFlags.Has(f.Name) {
@@ -79,70 +78,14 @@ func Resolve(logger logr.Logger, sources []Source) (Config, error) {
 		}
 		logger.WithValues("applied", src.Name()).V(6).Info("config", cfg.LogValues()...)
 	}
+	if cfg.KubeletRootDir != "" {
+		cfg.KubeletRootDir = filepath.Clean(cfg.KubeletRootDir)
+	}
 	if err := cfg.Validate(); err != nil {
 		return Config{}, fmt.Errorf("cannot validate config: %w", err)
 	}
 	logger.WithValues("stage", "validated").V(6).Info("config", cfg.LogValues()...)
 	return cfg, nil
-}
-
-// Load merges the config file at filePath into base, giving CLI flags that were
-// explicitly set (reported by fs.Visit) priority over file values, then
-// normalizes and validates the result. When filePath is empty no file is read,
-// but base is still normalized and validated. fs must already be parsed.
-func Load(base Config, filePath string, fs *flag.FlagSet, logger logr.Logger) (Config, error) {
-	logger.V(6).Info("config: after flags", base.LogValues()...)
-
-	result := base
-
-	if filePath != "" {
-		// Collect the Config-backed flags that were set explicitly on the command
-		// line so the file does not override them. Flags that are not in
-		// flagToJSONKey (for example --config or the klog --v flag) are not Config
-		// fields, so the file cannot override them and they are simply ignored
-		// here. TestFlagToJSONKey_CoversAllFlags statically guarantees every
-		// AddFlags flag is mapped, so an unmapped Config flag is caught in CI
-		// rather than needing a runtime warning.
-		explicitJSONKeys := map[string]bool{}
-		fs.Visit(func(f *flag.Flag) {
-			if jsonKey, ok := flagToJSONKey[f.Name]; ok {
-				explicitJSONKeys[jsonKey] = true
-			}
-		})
-
-		confMap, err := buildConfMap(filePath)
-		if err != nil {
-			return Config{}, fmt.Errorf("config file %q: %w", filePath, err)
-		}
-
-		// CLI-explicit flags win; drop their keys so the file doesn't override them.
-		for jsonKey := range explicitJSONKeys {
-			delete(confMap, jsonKey)
-		}
-
-		if err := applyMap(&result, confMap); err != nil {
-			return Config{}, fmt.Errorf("applying config file %q: %w", filePath, err)
-		}
-
-		logger.V(6).Info("config: after applying config file", result.LogValues()...)
-	}
-
-	// An empty value is left for Validate to refuse.
-	if result.KubeletRootDir != "" {
-		result.KubeletRootDir = filepath.Clean(result.KubeletRootDir)
-	}
-
-	// Validated even with no config file, so a bad flag is refused too. The file
-	// is named as an input rather than as the source, since what is validated is
-	// the merged result.
-	if err := result.Validate(); err != nil {
-		if filePath != "" {
-			return Config{}, fmt.Errorf("validating the configuration after loading %q: %w", filePath, err)
-		}
-		return Config{}, fmt.Errorf("validating configuration: %w", err)
-	}
-
-	return result, nil
 }
 
 // applyMap applies only the keys present in m to cfg; absent keys are

--- a/internal/gatherinfo/gatherinfo.go
+++ b/internal/gatherinfo/gatherinfo.go
@@ -79,7 +79,6 @@ type ToolVersion struct {
 
 type Options struct {
 	OutputParentDir   string
-	DriverConfig      driverconfig.Config
 	DriverCmdlinePath string
 }
 
@@ -103,7 +102,7 @@ func Run(args []string, opts Options, logger logr.Logger) error {
 		return err
 	}
 
-	report, err := collectReport(logger, opts.DriverConfig, driverCmdlinePath)
+	report, err := collectReport(logger, driverCmdlinePath)
 	if err != nil {
 		return err
 	}
@@ -192,8 +191,13 @@ func createOutputFile(parentDir string, now time.Time, pid int) (*os.File, strin
 	return f, outputPath, nil
 }
 
-func collectReport(logger logr.Logger, defaults driverconfig.Config, driverCmdlinePath string) (Report, error) {
-	driverConfig := detectDriverConfig(defaults, driverCmdlinePath)
+func collectReport(logger logr.Logger, driverCmdlinePath string) (Report, error) {
+	driverConfig, err := driverconfig.Resolve(logger, []driverconfig.Source{
+		ConfigSource{DriverCmdlinePath: driverCmdlinePath},
+	})
+	if err != nil {
+		return Report{}, fmt.Errorf("failed to resolve driver config: %w", err)
+	}
 	overlayPath := driverConfig.SysFSOverlay
 	if overlayPath != "" {
 		overlayPath = driverFilesystemPath(driverCmdlinePath, overlayPath)
@@ -274,41 +278,49 @@ func makeCPUList(cpus []cpuinfo.CPUInfo) []CPU {
 	return out
 }
 
-func detectDriverConfig(defaults driverconfig.Config, driverCmdlinePath string) driverconfig.Config {
-	cmdline, err := readCmdlineFile(driverCmdlinePath)
+// we need a complex config source because gatherinfo wants to progressively
+// reconstruct a driver config from the perspective of an outside process,
+// so we need to tolerate errors the normal flow should not.
+type ConfigSource struct {
+	DriverCmdlinePath string
+}
+
+func (ConfigSource) Name() string {
+	return "gatherinfo"
+}
+
+func (cs ConfigSource) Apply(logger logr.Logger, cfg *driverconfig.Config) error {
+	cmdline, err := readCmdlineFile(cs.DriverCmdlinePath)
 	if err != nil || len(cmdline) == 0 {
-		return defaults
+		// we inspect another process; need to tolerate missing or unreadable data
+		return nil //nolint:nilerr
 	}
 
 	if filepath.Base(cmdline[0]) != "dracpu" {
-		return defaults
+		return nil
 	}
 
-	cfg := defaults
+	var conf driverconfig.Config // storage space for flag values
 	fs := flag.NewFlagSet("detect-driver-config", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	cfg.AddFlags(fs)
+	conf.AddFlags(fs)
 	var configFile string
 	fs.StringVar(&configFile, "config", "", "")
-	// Filter to flags known to this FlagSet; unrecognised flags (e.g. logging
-	// flags) would cause Parse to fail and fall back to defaults.
 	if err := fs.Parse(knownConfigArgs(fs, cmdline[1:])); err != nil {
-		return defaults
+		// need to tolerate parse failures: reconstruct as much as we can.
+		return nil //nolint:nilerr
 	}
 
-	if configFile == "" {
-		return cfg
+	// intentionally ignore errors: gatherinfo tolerates partial config
+	if configFile != "" {
+		// resolve the path in the container namespace
+		configFile = driverFilesystemPath(cs.DriverCmdlinePath, configFile)
+		_ = driverconfig.FromFile(configFile).Apply(logger, cfg)
 	}
-	// Resolve configFile in the driver's mount namespace: when gatherinfo runs as a
-	// standalone tool (not sharing the driver's filesystem), the raw path from the
-	// driver's cmdline is only reachable via /proc/<pid>/root, same as overlayPath above.
-	configFile = driverFilesystemPath(driverCmdlinePath, configFile)
-	// If the file can't be read (e.g. run outside the driver container), fall back to CLI-parsed config.
-	loaded, err := driverconfig.Load(cfg, configFile, fs, logr.Discard())
-	if err != nil {
-		return cfg
-	}
-	return loaded
+
+	// flags applied last so they win over file values
+	_ = driverconfig.FromFlags(fs).Apply(logger, cfg)
+	return nil
 }
 
 func readCmdlineFile(path string) ([]string, error) {

--- a/internal/gatherinfo/gatherinfo_test.go
+++ b/internal/gatherinfo/gatherinfo_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/kubernetes-sigs/dra-driver-cpu/internal/driverconfig"
 	"github.com/kubernetes-sigs/dra-driver-cpu/internal/gatherinfo"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
 	"sigs.k8s.io/yaml"
@@ -35,9 +34,7 @@ func TestRunWritesReportFile(t *testing.T) {
 	setupFakeHost(t, []byte("/dracpu\x00--reserved-cpus=4-7\x00--cpu-device-mode\x00individual\x00--group-by=socket\x00--hostname-override=node-a\x00--v=4\x00--logging-format=json\x00"))
 
 	outputDir := filepath.Join(t.TempDir(), "reports")
-	err := gatherinfo.Run([]string{"--output-dir=" + outputDir}, gatherinfo.Options{
-		DriverConfig: driverconfig.Default(),
-	}, logr.Discard())
+	err := gatherinfo.Run([]string{"--output-dir=" + outputDir}, gatherinfo.Options{}, logr.Discard())
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
 	}
@@ -79,9 +76,7 @@ func TestRunWritesReportToStdout(t *testing.T) {
 	setupFakeHost(t, []byte("/dracpu\x00--group-by=socket\x00"))
 
 	stdout, err := captureStdout(t, func() error {
-		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{
-			DriverConfig: driverconfig.Default(),
-		}, logr.Discard())
+		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{}, logr.Discard())
 	})
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
@@ -107,9 +102,7 @@ func TestRunAppliesDriverSysFSOverlay(t *testing.T) {
 	}
 
 	stdout, err := captureStdout(t, func() error {
-		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{
-			DriverConfig: driverconfig.Default(),
-		}, logr.Discard())
+		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{}, logr.Discard())
 	})
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
@@ -144,9 +137,7 @@ func TestRunAppliesDriverSysFSOverlayFromParentRelativePath(t *testing.T) {
 	}
 
 	stdout, err := captureStdout(t, func() error {
-		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{
-			DriverConfig: driverconfig.Default(),
-		}, logr.Discard())
+		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{}, logr.Discard())
 	})
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
@@ -165,9 +156,7 @@ func TestRunFailsWhenDriverProcessIsMissing(t *testing.T) {
 	setupFakeHost(t, nil)
 
 	_, err := captureStdout(t, func() error {
-		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{
-			DriverConfig: driverconfig.Default(),
-		}, logr.Discard())
+		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{}, logr.Discard())
 	})
 	if err == nil {
 		t.Fatal("Run succeeded, want error")
@@ -189,9 +178,7 @@ func TestRunReadsConfigFile(t *testing.T) {
 	}
 
 	stdout, err := captureStdout(t, func() error {
-		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{
-			DriverConfig: driverconfig.Default(),
-		}, logr.Discard())
+		return gatherinfo.Run([]string{"--stdout"}, gatherinfo.Options{}, logr.Discard())
 	})
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)

--- a/internal/subcommands/subcommands.go
+++ b/internal/subcommands/subcommands.go
@@ -45,9 +45,7 @@ func Run(args []string, opts Options) error {
 
 	switch args[0] {
 	case "gatherinfo":
-		return gatherinfo.Run(args[1:], gatherinfo.Options{
-			DriverConfig: opts.DriverConfig,
-		}, opts.Logger)
+		return gatherinfo.Run(args[1:], gatherinfo.Options{}, opts.Logger)
 	case "introspect":
 		return runIntrospect(args[1:], opts.Stdout, opts.Stderr)
 	default:

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -139,7 +139,7 @@ type Config struct {
 	Metrics          cpumetrics.Recorder
 	// KubeletRootDir is the kubelet root directory, from which the registrar
 	// and plugin data directories are derived. Required and absolute:
-	// driverconfig.Load refuses an empty or relative value, and New takes it as
+	// driverconfig.Resolve refuses an empty or relative value, and New takes it as
 	// given rather than checking it again.
 	KubeletRootDir string
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it
The major design items of our current config management flow are:
- we have a set of possible settings, represented by a struct with possibly nested substructs holding only the tunable values.
- we have a set of possible config sources - config file, flags...
- each config source can mutate a subset of tunables, and doesn't mutate what is not set explicitly
- we can therefore compose the configuration loading/resolution stage as a pipeline on which we start from a default state
  and we iteratively apply layers of mutations, each potentially partial, each coming from a config source.

This PRs extracts an explicit `Source` interface and we add a new Resolve([]Source) pipeline, so each source (defaults, config file, CLI flags) becomes a composable, testable unit, as demonstrated in the `gatherinfo` changes.

The goal is to make the existing structure fully explicit and fully surfaced, which makes the code more composable and testable

#### Which issue(s) this PR is related to

N/A

#### Special notes for reviewers

This work started from explorations I did in #229 and #262 ; I think it earned its own PR and is worth to be added. #262 will be rebased on top of it and finally I'll use (albeit, admitedly, marginally) #262 to implement testing coverage for #229

Worth stressing that this PR is all about remixing and repackaging existing concepts; there are not new ideas here, but "just" a different combination of concepts we already discussed and implemented.

AI usage disclosure: the idea and the first 2 drafts of this PR were entirely human-generated. After that, I used AI to self-review, polish, rebase.

#### Release note

```release-note
NONE
```

#### Documentation updates

N/A