### PR TITLE
chore: drop NET_ADMIN & SYS_ADMIN from daemonset

### DIFF
--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -101,9 +101,6 @@ spec:
           limits:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        securityContext:
-          capabilities:
-            add: ["NET_ADMIN", "SYS_ADMIN"]
         volumeMounts:
         - name: device-plugin
           mountPath: {{ include "dra-driver-cpu.pluginsDir" $kubeletRoot | quote }}

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -19,9 +19,9 @@ Optional features need additional cluster feature gates:
 | `grouped` device mode (the default) on Kubernetes 1.34/1.35 | `DRAConsumableCapacity` (enabled by default from 1.36) |
 | PCIe root attributes (`--expose-pcie-roots`)                | `DRAListTypeAttributes`                                |
 
-The driver is Linux-only and needs node-level privileges (host networking, the `NET_ADMIN`
-and `SYS_ADMIN` capabilities, and NRI socket, CDI directory, and kubelet plugin directory
-access) — see [Security considerations](#security-considerations).
+The driver is Linux-only and needs node-level privileges (host networking, and NRI socket,
+CDI directory, and kubelet plugin directory access) — see
+[Security considerations](#security-considerations).
 
 ## Installing with Helm
 
@@ -102,10 +102,9 @@ systemctl restart containerd
 
 ## Security considerations
 
-The driver needs node-level privileges. It runs as a DaemonSet with `hostNetwork: true` and
-the `NET_ADMIN` and `SYS_ADMIN` capabilities, with hostPath
-mounts for the NRI socket (`/var/run/nri`), the CDI spec directory (`/var/run/cdi`), and the
-kubelet plugin directories.
+The driver needs node-level privileges: `hostNetwork: true`, and hostPath mounts for the NRI
+socket (`/var/run/nri`), the CDI spec directory (`/var/run/cdi`), and the kubelet plugin
+directories.
 
 ## Upgrading
 

--- a/manifests/base/daemonset-dracpu.part.yaml
+++ b/manifests/base/daemonset-dracpu.part.yaml
@@ -49,9 +49,6 @@ spec:
           requests:
             cpu: "100m"
             memory: "50Mi"
-        securityContext:
-          capabilities:
-            add: ["NET_ADMIN", "SYS_ADMIN"]
         volumeMounts:
         - name: device-plugin
           mountPath: /var/lib/kubelet/plugins


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
These capabilities are redundant because the driver applies cpuset changes via the NRI which the container runtime enforces on its behalf. So the driver does not really need `NET_ADMIN` or `SYS_ADMIN`.  I don't recall where exactly, but I do remember @pravk03 has asked in the past about similar changes. 

#### Which issue(s) this PR is related to


#### Special notes for reviewers
I've done very simple testing with exclusive CPUs allocation just to double check on top of e2e, which I hope would/should catch in case with face some unexpected bumps. 

#### Release note

<!--
If this change is not user-facing, write:
NONE
-->

```release-note
manifests: drop NET_ADMIN & SYS_ADMIN from daemonset
```

#### Documentation updates
- README updates

