### PR TITLE
chore: remove extraArgs from helm chart

### DIFF
--- a/deployment/helm/dra-driver-cpu/README.md
+++ b/deployment/helm/dra-driver-cpu/README.md
@@ -42,7 +42,6 @@ helm install dra-driver-cpu oci://registry.k8s.io/dra-driver-cpu/charts/dra-driv
 | args.logLevel | int | `4` | Log verbosity level passed as `--v` |
 | args.reservedCPUs | string | `""` | **Deprecated:** folded into the generated `driverConfig` ConfigMap and takes priority over it; use `driverConfig.reservedCPUs` instead. CPUs reserved for the OS and kubelet, excluded from DRA management (e.g. `"0-1"`). |
 | driverConfig | object | `{}` | Driver config file contents. When non-empty, or when a deprecated `args.*` field below is set, a ConfigMap is created and mounted into the driver container as /etc/dracpu/config.yaml. `args.*` fields that mirror a deprecated CLI flag (`cpuDeviceMode`, `groupBy`, `reservedCPUs`, `hostnameOverride`) are folded into the generated config automatically and take priority over the same field set here. |
-| extraArgs | list | `[]` | Extra command-line arguments appended to the driver arguments |
 | extraVolumeMounts | list | `[]` | Extra volume mounts for the driver container |
 | extraVolumes | list | `[]` | Extra volumes for the DaemonSet pod |
 | fullnameOverride | string | `""` | Override the full release name |

--- a/deployment/helm/dra-driver-cpu/templates/_helpers.tpl
+++ b/deployment/helm/dra-driver-cpu/templates/_helpers.tpl
@@ -62,13 +62,6 @@ check below for why that specific check exists.
 {{- fail (printf "value %q differs from kubeletRootDir only in case, and the chart reads the exact name: it would be ignored and the kubelet paths would render at the default" $key) -}}
 {{- end -}}
 {{- end -}}
-{{- /* Matched on the parsed flag name: the flag package treats -name and --name
-       alike. */ -}}
-{{- range .Values.extraArgs -}}
-{{- if eq "kubelet-root-dir" (. | trimPrefix "--" | trimPrefix "-" | splitList "=" | first) -}}
-{{- fail "set kubeletRootDir instead of passing --kubelet-root-dir through extraArgs: the hostPath mounts render from kubeletRootDir, so the flag would move on its own" -}}
-{{- end -}}
-{{- end -}}
 {{- /* An upgrade run with --reuse-values carries the values the release was
        installed with, so a release older than this value has no key here at
        all. Absent reads as the default, and so does null, which Helm drops

--- a/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
+++ b/deployment/helm/dra-driver-cpu/templates/daemonset.yaml
@@ -73,9 +73,6 @@ spec:
           {{- if ne $kubeletRoot "/var/lib/kubelet" }}
           - {{ printf "--kubelet-root-dir=%s" $kubeletRoot | quote }}
           {{- end }}
-          {{- with .Values.extraArgs }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
           {{- if $effectiveDriverConfig }}
           - --config=/etc/dracpu/config.yaml
           {{- end }}

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -58,13 +58,6 @@
       "$ref": "driverconfig.schema.json",
       "type": "object"
     },
-    "extraArgs": {
-      "description": "Extra command-line arguments appended to the driver arguments",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "extraVolumeMounts": {
       "description": "Extra volume mounts for the driver container",
       "type": "array",

--- a/deployment/helm/dra-driver-cpu/values.yaml
+++ b/deployment/helm/dra-driver-cpu/values.yaml
@@ -43,9 +43,6 @@ podAnnotations: {}
 # -- Extra labels to add to pods
 podLabels: {}
 
-# -- Extra command-line arguments appended to the driver arguments
-extraArgs: [] # @schema item: string
-
 # -- Extra volume mounts for the driver container
 extraVolumeMounts: [] # @schema item: object
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -171,10 +171,6 @@ The remaining flags aren't part of that deprecation:
   config file (see [driverConfig sub-fields](#driverconfig-sub-fields) above) and stays a
   standalone flag (or Helm `args.exposePCIeRoots`).
 - `--kubelet-root-dir`: the kubelet's own root directory (default `/var/lib/kubelet`).
-  Under Helm, set the chart's `kubeletRootDir` value rather than passing this flag through
-  `extraArgs`: the hostPath mounts render from the chart value, so the flag would move on
-  its own and leave the driver registered somewhere the kubelet isn't watching, which
-  surfaces later as a registration timeout rather than as anything naming the mismatch.
   Running the binary directly, or writing the manifests by hand, the flag is the way to set
   the root, together with matching `<root>/plugins` and `<root>/plugins_registry` mounts.
   Like `--expose-pcie-roots`, it is not deprecated and has no config file equivalent: the
@@ -228,7 +224,3 @@ the kubelet root; splitting them across releases fails with `invalid ownership m
 since the chart's `DeviceClass` is cluster-scoped under a fixed name. A cluster whose nodes
 disagree needs the driver deployed some other way until the chart can vary the root per
 node.
-
-Passing `--kubelet-root-dir` through `extraArgs` is refused at template time — set
-`kubeletRootDir` instead, since `extraArgs` would win the flag while the mounts kept
-rendering from the chart value.

--- a/internal/driverconfig/config_test.go
+++ b/internal/driverconfig/config_test.go
@@ -493,9 +493,8 @@ func TestResolve_ExcludedFieldInFileIsError(t *testing.T) {
 		{
 			field:   "kubeletRootDir",
 			content: "kubeletRootDir: /mnt/fast/k8s/kubelet",
-			// Both routes, because the chart refuses the flag through extraArgs:
-			// naming only the flag sends a Helm user to the one path the chart
-			// rejects, and the second failure arrives a deploy later.
+			// The error must name both routes or a Helm user will not know
+			// kubeletRootDir is what the chart actually maps the flag to.
 			wantErrs: []string{
 				"not configurable via the config file",
 				"use the chart's top-level kubeletRootDir value",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
`extraArgs` allows override any helm chart managed flags (which is unintentional I believe). It only existed as a side effect of generalizing the old sysfsOverlay and most of the flags are already covered by args or driverConfig. For example, helm chart already exposes its own flag to control the sysfs overlay with `--set driverConfig.sysfsOverlay` and this is what's used also in the example here https://github.com/kubernetes-sigs/dra-driver-cpu/blob/4fc973652a5a301f7077970a16f56ba35273658d/hack/examples/sysfs-overlay/values.yaml#L5
The other issue is, it forces extra precaution whenever we are touching config options/flags, kubeletRootDir is one example. 

#### Which issue(s) this PR is related to

#### Special notes for reviewers
Also, there is another minor side effect https://github.com/kubernetes-sigs/dra-driver-cpu/issues/256. Unless we have another use for it (which I would be interested to hear about), I’m not sure we would get much value from keeping this flag.

#### Release note

<!--
If this change is not user-facing, write:
NONE
-->

```release-note
NONE
```

#### Documentation updates
- README updates
- Helm chart docs

