### PR TITLE
fix: reject containers when shared CPU pool is empty

### DIFF
--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -103,6 +103,13 @@ func getCDIDeviceName(uid types.UID) string {
 	return fmt.Sprintf("claim-%s", uid)
 }
 
+// reserveResourceClaimAllocation records a new claim allocation while applying
+// the shared-pool guard for currently running shared containers.
+func (cp *CPUDriver) reserveResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) error {
+	hasSharedContainers := len(cp.podConfigStore.GetContainersWithSharedCPUs()) > 0
+	return cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claimUID, cpus, hasSharedContainers)
+}
+
 func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
 	logger.V(4).Info("preparing grouped resource claim")
 
@@ -193,15 +200,8 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		return kubeletplugin.PrepareResult{}
 	}
 
-	// Refuse to exhaust the shared pool while shared containers are running: NRI
-	// cannot represent an empty CPUSet, so an emptied pool would leave shared
-	// containers with unsafe affinity (see #295).
-	if len(cp.podConfigStore.GetContainersWithSharedCPUs()) > 0 && allocatableCPUs.Difference(cpuAssignment).IsEmpty() {
-		return kubeletplugin.PrepareResult{Err: fmt.Errorf("claim %q would exhaust the shared CPU pool while shared containers are running", claim.UID)}
-	}
-
 	// Reserve before CDI I/O so concurrent Prepare calls cannot select the same CPUs.
-	if err := cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claim.UID, cpuAssignment); err != nil {
+	if err := cp.reserveResourceClaimAllocation(logger, claim.UID, cpuAssignment); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
 	}
 	result := cp.prepareDevices(logger, claim, cpuAssignment)
@@ -262,15 +262,8 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		}
 	}
 
-	// Refuse to exhaust the shared pool while shared containers are running: NRI
-	// cannot represent an empty CPUSet, so an emptied pool would leave shared
-	// containers with unsafe affinity (see #295).
-	if len(cp.podConfigStore.GetContainersWithSharedCPUs()) > 0 && allocatableCPUs.Difference(claimCPUSet).IsEmpty() {
-		return kubeletplugin.PrepareResult{Err: fmt.Errorf("claim %q would exhaust the shared CPU pool while shared containers are running", claim.UID)}
-	}
-
 	// Reserve before CDI I/O so concurrent Prepare calls cannot select the same CPUs.
-	if err := cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claim.UID, claimCPUSet); err != nil {
+	if err := cp.reserveResourceClaimAllocation(logger, claim.UID, claimCPUSet); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
 	}
 	result := cp.prepareDevices(logger, claim, claimCPUSet)

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -193,6 +193,13 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		return kubeletplugin.PrepareResult{}
 	}
 
+	// Refuse to exhaust the shared pool while shared containers are running: NRI
+	// cannot represent an empty CPUSet, so an emptied pool would leave shared
+	// containers with unsafe affinity (see #295).
+	if len(cp.podConfigStore.GetContainersWithSharedCPUs()) > 0 && allocatableCPUs.Difference(cpuAssignment).IsEmpty() {
+		return kubeletplugin.PrepareResult{Err: fmt.Errorf("claim %q would exhaust the shared CPU pool while shared containers are running", claim.UID)}
+	}
+
 	// Reserve before CDI I/O so concurrent Prepare calls cannot select the same CPUs.
 	if err := cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claim.UID, cpuAssignment); err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
@@ -253,6 +260,13 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		return kubeletplugin.PrepareResult{
 			Err: fmt.Errorf("claim %s/%s has overlapping device assignment with other claims", claim.Namespace, claim.Name),
 		}
+	}
+
+	// Refuse to exhaust the shared pool while shared containers are running: NRI
+	// cannot represent an empty CPUSet, so an emptied pool would leave shared
+	// containers with unsafe affinity (see #295).
+	if len(cp.podConfigStore.GetContainersWithSharedCPUs()) > 0 && allocatableCPUs.Difference(claimCPUSet).IsEmpty() {
+		return kubeletplugin.PrepareResult{Err: fmt.Errorf("claim %q would exhaust the shared CPU pool while shared containers are running", claim.UID)}
 	}
 
 	// Reserve before CDI I/O so concurrent Prepare calls cannot select the same CPUs.

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -104,7 +104,9 @@ func getCDIDeviceName(uid types.UID) string {
 }
 
 // reserveResourceClaimAllocation records a new claim allocation while applying
-// the shared-pool guard for currently running shared containers.
+// the shared-pool guard for currently running shared containers. A shared
+// container from the same pod may not have been created yet when this DRA hook
+// runs, so that case is detected later by the NRI CreateContainer check.
 func (cp *CPUDriver) reserveResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) error {
 	hasSharedContainers := len(cp.podConfigStore.GetContainersWithSharedCPUs()) > 0
 	return cp.cpuAllocationStore.ReserveResourceClaimAllocation(logger, claimUID, cpus, hasSharedContainers)

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -52,7 +52,7 @@ const (
 
 func requirePreparedResourceClaim(t testing.TB, logger logr.Logger, allocationStore *store.CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
 	t.Helper()
-	require.NoError(t, allocationStore.ReserveResourceClaimAllocation(logger, claimUID, cpus))
+	require.NoError(t, allocationStore.ReserveResourceClaimAllocation(logger, claimUID, cpus, false))
 }
 
 // testSysFS enables full isolation and full mocking from the host filesystem.

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -835,6 +835,74 @@ func TestPrepareResourceClaims(t *testing.T) {
 	}
 }
 
+func TestPrepareResourceClaimsRejectsExhaustingSharedPool(t *testing.T) {
+	logger := testr.New(t)
+
+	newDriver := func(grouped bool) *CPUDriver {
+		t.Helper()
+		prov := Providers{
+			CPUInfo: &cpuinfo.MockCPUInfoProvider{CPUInfos: mockCPUInfos_SingleSocket_4CPUS_HT},
+			SysFS:   testSysFS(mockCPUInfos_SingleSocket_4CPUS_HT),
+		}
+		conf := Config{
+			DriverName: testDriverName,
+			NodeName:   testNodeName,
+		}
+		if grouped {
+			conf.CPUDeviceMode = devattr.CPU_DEVICE_MODE_GROUPED
+			conf.CPUDeviceGroupBy = devattr.GROUP_BY_SOCKET
+		}
+		driver, err := New(logger, prov, &conf)
+		require.NoError(t, err)
+		driver.cdiMgr = newMockCdiMgr()
+		return driver
+	}
+
+	claimForAllCPUs := func(uid types.UID, grouped bool) *resourceapi.ResourceClaim {
+		if grouped {
+			return testClaim(uid, testDriverName, testNodeName, map[string]int64{"cpudevsocket000": 4})
+		}
+		return testClaimWithResults(uid, []resourceapi.DeviceRequestAllocationResult{
+			{Driver: testDriverName, Pool: testNodeName, Device: "cpudev000"},
+			{Driver: testDriverName, Pool: testNodeName, Device: "cpudev001"},
+			{Driver: testDriverName, Pool: testNodeName, Device: "cpudev002"},
+			{Driver: testDriverName, Pool: testNodeName, Device: "cpudev003"},
+		})
+	}
+
+	for _, grouped := range []bool{false, true} {
+		mode := "individual"
+		if grouped {
+			mode = "grouped"
+		}
+
+		t.Run(mode+": rejects a claim that would exhaust the shared pool while shared containers exist", func(t *testing.T) {
+			driver := newDriver(grouped)
+			driver.podConfigStore.SetContainerState("shared-pod", store.NewContainerState("shared-ctr", "shared-uid"))
+
+			prepared, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{claimForAllCPUs("claim-full", grouped)})
+			require.NoError(t, err)
+			result := prepared[types.UID("claim-full")]
+			require.ErrorContains(t, result.Err, "would exhaust the shared CPU pool")
+			_, ok := driver.cpuAllocationStore.GetResourceClaimAllocation("claim-full")
+			require.False(t, ok, "rejected claim must not be recorded")
+			require.False(t, driver.cpuAllocationStore.GetSharedCPUs().IsEmpty(), "rejected claim must not shrink the shared pool")
+		})
+
+		t.Run(mode+": allows a claim that would exhaust the shared pool when no shared containers exist", func(t *testing.T) {
+			driver := newDriver(grouped)
+
+			prepared, err := driver.PrepareResourceClaims(context.Background(), []*resourceapi.ResourceClaim{claimForAllCPUs("claim-full", grouped)})
+			require.NoError(t, err)
+			result := prepared[types.UID("claim-full")]
+			require.NoError(t, result.Err)
+			_, ok := driver.cpuAllocationStore.GetResourceClaimAllocation("claim-full")
+			require.True(t, ok)
+			require.True(t, driver.cpuAllocationStore.GetSharedCPUs().IsEmpty())
+		})
+	}
+}
+
 func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) {
 	logger := testr.New(t)
 	claimUID := types.UID("claim-cdi-fails")
@@ -855,6 +923,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 				},
 			},
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+			podConfigStore:     store.NewPodConfig(),
 		}
 		if withExistingAllocation {
 			requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
@@ -876,6 +945,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 				deviceNameToNUMANodeID: map[string]int{},
 			},
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+			podConfigStore:     store.NewPodConfig(),
 		}
 		if withExistingAllocation {
 			requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
@@ -1514,6 +1584,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			},
 			cpuAllocationStore: cpuStore,
 			cdiMgr:             cdiMgr,
+			podConfigStore:     store.NewPodConfig(),
 		}, cpuStore, cdiMgr
 	}
 	makeNUMADriver := func(logger logr.Logger) (*CPUDriver, *store.CPUAllocation, *mockCdiMgr) {
@@ -1532,6 +1603,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			},
 			cpuAllocationStore: cpuStore,
 			cdiMgr:             cdiMgr,
+			podConfigStore:     store.NewPodConfig(),
 		}, cpuStore, cdiMgr
 	}
 
@@ -1730,6 +1802,7 @@ func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID type
 		cdiMgr:             mockCdiMgr,
 		cpuAllocationStore: cpuAllocationStore,
 		claimTracker:       claimTracker,
+		podConfigStore:     store.NewPodConfig(),
 	}, mockCdiMgr
 }
 
@@ -2128,6 +2201,7 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 	driver.topology.cpuTopology, _ = mockProvider.GetCPUTopology(logger)
 	driver.topology.onlineCPUs = driver.topology.cpuTopology.CPUDetails.CPUs()
 	driver.cpuAllocationStore = store.NewCPUAllocation(driver.topology.cpuTopology, reservedCPUs)
+	driver.podConfigStore = store.NewPodConfig()
 	for claimUID, cpus := range initialAllocations {
 		requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpus)
 	}

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -177,25 +177,18 @@ func validateSynchronizedClaimAllocation(logger logr.Logger, uid types.UID, cpus
 	return nil
 }
 
-func validateSharedCPUAvailability(sharedCPUs, preparedCPUs cpuset.CPUSet, sharedCPUContainers []types.UID) error {
+func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) ([]*api.ContainerUpdate, error) {
+	updates := []*api.ContainerUpdate{}
+	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
+	preparedCPUs := cp.cpuAllocationStore.GetPreparedCPUs()
+	sharedCPUContainers := cp.podConfigStore.GetContainersWithSharedCPUs()
 	// An empty CPUSet is serialized by NRI as Cpus="", which means "do not
 	// change the current CPUSet" rather than "clear the CPUSet". Never emit
 	// that update while a prepared DRA allocation has exhausted the pool and
 	// shared containers still exist. An empty pool with no prepared allocation
 	// is valid when the node has no driver-managed CPUs.
 	if sharedCPUs.IsEmpty() && !preparedCPUs.IsEmpty() && len(sharedCPUContainers) > 0 {
-		return fmt.Errorf("cannot update shared containers: no shared CPUs available")
-	}
-	return nil
-}
-
-func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) ([]*api.ContainerUpdate, error) {
-	updates := []*api.ContainerUpdate{}
-	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
-	preparedCPUs := cp.cpuAllocationStore.GetPreparedCPUs()
-	sharedCPUContainers := cp.podConfigStore.GetContainersWithSharedCPUs()
-	if err := validateSharedCPUAvailability(sharedCPUs, preparedCPUs, sharedCPUContainers); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot update shared containers: no shared CPUs available")
 	}
 	logger.V(2).Info("updating CPU allocation for containers without guaranteed CPUs", "sharedCPUs", sharedCPUs.String())
 	for _, containerUID := range sharedCPUContainers {
@@ -264,19 +257,14 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		logger.V(2).Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
 		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
 		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
-		// A new owner means this is the first CreateContainer after Prepare. On restart,
-		// the owner already exists and the shared cpuset has not changed.
+		// A new owner means this is the first CreateContainer after Prepare, so
+		// existing shared containers must be moved off the newly claimed CPUs.
+		// On restart the owner already exists and no shared-container updates are
+		// needed.
 		if len(newOwners) > 0 {
 			updates, err = cp.getSharedContainerUpdates(logger, containerId)
 			if err != nil {
 				cp.claimTracker.Cleanup(newOwners...)
-				return nil, nil, err
-			}
-		} else {
-			// A restarted container normally does not need shared-container updates,
-			// but it must not be admitted into an already inconsistent state left by
-			// an empty shared pool and running shared containers.
-			if err := validateSharedCPUAvailability(cp.cpuAllocationStore.GetSharedCPUs(), cp.cpuAllocationStore.GetPreparedCPUs(), cp.podConfigStore.GetContainersWithSharedCPUs()); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -82,7 +82,9 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 					caLogger.Error(err, "ignoring invalid claim allocation during synchronize")
 					continue
 				}
-				if err := cpuAllocationStore.ReserveResourceClaimAllocation(caLogger, uid, cpus); err != nil {
+				// Synchronize restores an allocation that already exists in the runtime;
+				// the shared-pool guard applies only to new reservations.
+				if err := cpuAllocationStore.ReserveResourceClaimAllocation(caLogger, uid, cpus, false); err != nil {
 					return nil, err
 				}
 

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -123,7 +123,10 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 	// Reconcile container CPU masks to handle cases where the NRI plugin might have crashed
 	// or restarted and missed updating the cgroup settings.
 	// See: https://github.com/containerd/nri/issues/282
-	sharedContainerUpdates := cp.getSharedContainerUpdates(logger, types.UID(""))
+	sharedContainerUpdates, err := cp.getSharedContainerUpdates(logger, types.UID(""))
+	if err != nil {
+		return nil, err
+	}
 	containerUpdates = append(containerUpdates, sharedContainerUpdates...)
 	return containerUpdates, nil
 }
@@ -173,10 +176,27 @@ func validateSynchronizedClaimAllocation(logger logr.Logger, uid types.UID, cpus
 	}
 	return nil
 }
-func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) []*api.ContainerUpdate {
+
+func validateSharedCPUAvailability(sharedCPUs, preparedCPUs cpuset.CPUSet, sharedCPUContainers []types.UID) error {
+	// An empty CPUSet is serialized by NRI as Cpus="", which means "do not
+	// change the current CPUSet" rather than "clear the CPUSet". Never emit
+	// that update while a prepared DRA allocation has exhausted the pool and
+	// shared containers still exist. An empty pool with no prepared allocation
+	// is valid when the node has no driver-managed CPUs.
+	if sharedCPUs.IsEmpty() && !preparedCPUs.IsEmpty() && len(sharedCPUContainers) > 0 {
+		return fmt.Errorf("cannot update shared containers: no shared CPUs available")
+	}
+	return nil
+}
+
+func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID types.UID) ([]*api.ContainerUpdate, error) {
 	updates := []*api.ContainerUpdate{}
 	sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
+	preparedCPUs := cp.cpuAllocationStore.GetPreparedCPUs()
 	sharedCPUContainers := cp.podConfigStore.GetContainersWithSharedCPUs()
+	if err := validateSharedCPUAvailability(sharedCPUs, preparedCPUs, sharedCPUContainers); err != nil {
+		return nil, err
+	}
 	logger.V(2).Info("updating CPU allocation for containers without guaranteed CPUs", "sharedCPUs", sharedCPUs.String())
 	for _, containerUID := range sharedCPUContainers {
 		if containerUID == excludeID {
@@ -190,7 +210,7 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 		containerUpdate.SetLinuxCPUSetCPUs(sharedCPUs.String())
 		updates = append(updates, containerUpdate)
 	}
-	return updates
+	return updates, nil
 }
 
 // CreateContainer handles container creation requests from the NRI.
@@ -213,10 +233,15 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 
 	if len(claimAllocations) == 0 {
 		// This is a shared container.
+		sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
+		if sharedCPUs.IsEmpty() && !cp.cpuAllocationStore.GetPreparedCPUs().IsEmpty() {
+			// NRI cannot represent an empty CPUSet as a ContainerAdjustment. Fail
+			// closed instead of allowing the runtime to keep its default affinity.
+			return nil, nil, fmt.Errorf("cannot create shared container: no shared CPUs available")
+		}
 		state := store.NewContainerState(ctr.GetName(), containerId)
 		cp.podConfigStore.SetContainerState(podUID, state)
 
-		sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 		logger.V(2).Info("no guaranteed CPUs found, using shared CPUs", "sharedCPUs", sharedCPUs.String())
 		adjust.SetLinuxCPUSetCPUs(sharedCPUs.String())
 	} else {
@@ -239,12 +264,23 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 		logger.V(2).Info("guaranteed CPUs found", "cpus", guaranteedCPUs.String())
 		state := store.NewContainerState(ctr.GetName(), containerId, claimUIDs...)
 		adjust.SetLinuxCPUSetCPUs(guaranteedCPUs.String())
-		cp.podConfigStore.SetContainerState(podUID, state)
 		// A new owner means this is the first CreateContainer after Prepare. On restart,
 		// the owner already exists and the shared cpuset has not changed.
 		if len(newOwners) > 0 {
-			updates = cp.getSharedContainerUpdates(logger, containerId)
+			updates, err = cp.getSharedContainerUpdates(logger, containerId)
+			if err != nil {
+				cp.claimTracker.Cleanup(newOwners...)
+				return nil, nil, err
+			}
+		} else {
+			// A restarted container normally does not need shared-container updates,
+			// but it must not be admitted into an already inconsistent state left by
+			// an empty shared pool and running shared containers.
+			if err := validateSharedCPUAvailability(cp.cpuAllocationStore.GetSharedCPUs(), cp.cpuAllocationStore.GetPreparedCPUs(), cp.podConfigStore.GetContainersWithSharedCPUs()); err != nil {
+				return nil, nil, err
+			}
 		}
+		cp.podConfigStore.SetContainerState(podUID, state)
 	}
 
 	return adjust, updates, nil
@@ -286,7 +322,12 @@ func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, c
 	}
 	if len(claimUIDs) > 0 {
 		// this serves only for debugging purposes. We should never get here
-		logger.Info("RemoveContainer spurious updates needed (unexpected, please file a bug)", "updates", cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId())))
+		updates, err := cp.getSharedContainerUpdates(logger, types.UID(ctr.GetId()))
+		if err != nil {
+			logger.Error(err, "unable to calculate shared container updates after RemoveContainer")
+		} else {
+			logger.Info("RemoveContainer spurious updates needed (unexpected, please file a bug)", "updates", updates)
+		}
 	}
 	return nil
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -450,7 +450,7 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 }
 
-func TestGuaranteedContainerRestartRejectsInconsistentEmptySharedPool(t *testing.T) {
+func TestGuaranteedContainerRestartNotBlockedByEmptySharedPool(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3)
 	infos := make([]cpuinfo.CPUInfo, 0, allCPUs.Size())
@@ -482,11 +482,13 @@ func TestGuaranteedContainerRestartRejectsInconsistentEmptySharedPool(t *testing
 		Env:          []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, allCPUs.String())},
 	}
 
+	// An existing exclusive container may restart even if the shared pool is
+	// empty: restart does not emit shared-container updates, and exhausting the
+	// shared pool is rejected earlier during DRA claim preparation.
 	adjustment, updates, err := driver.CreateContainer(context.Background(), pod, container)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot update shared containers: no shared CPUs available")
-	require.Nil(t, adjustment)
-	require.Nil(t, updates)
+	require.NoError(t, err)
+	require.NotNil(t, adjustment)
+	require.Empty(t, updates)
 	require.Equal(t, 1, claimTracker.Len(), "an existing owner must not be removed on restart rejection")
 }
 

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -177,6 +177,18 @@ func TestCreateContainer(t *testing.T) {
 			expectedContainerUpdates: []*api.ContainerUpdate{},
 		},
 		{
+			name:           "shared container is rejected when shared pool is empty",
+			podConfigStore: store.NewPodConfig(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				allocation := store.NewCPUAllocation(topo, cpuset.New())
+				requirePreparedResourceClaim(t, logger, allocation, types.UID(claimUID), allCPUs)
+				return allocation
+			}(),
+			claimTracker:          store.NewClaimTracker(),
+			container:             newTestContainer("", ""),
+			expectedErrorContains: "cannot create shared container: no shared CPUs available",
+		},
+		{
 			name: "guaranteed container triggers container adjustment and update for other shared container",
 			podConfigStore: func() *store.PodConfig {
 				conf := store.NewPodConfig()
@@ -204,6 +216,37 @@ func TestCreateContainer(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-1,4-7"}}},
 				},
 			},
+		},
+		{
+			name: "guaranteed container is rejected when it would empty an existing shared pool",
+			podConfigStore: func() *store.PodConfig {
+				conf := store.NewPodConfig()
+				conf.SetContainerState("shared-pod", store.NewContainerState("shared-ctr", "shared-uid"))
+				return conf
+			}(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				allocation := store.NewCPUAllocation(topo, cpuset.New())
+				requirePreparedResourceClaim(t, logger, allocation, types.UID(claimUID), allCPUs)
+				return allocation
+			}(),
+			claimTracker:          store.NewClaimTracker(),
+			container:             newTestContainer(claimUID, "0-7"),
+			expectedErrorContains: "cannot update shared containers: no shared CPUs available",
+		},
+		{
+			name:           "guaranteed container may consume the full pool when no shared containers exist",
+			podConfigStore: store.NewPodConfig(),
+			cpuAllocationStore: func() *store.CPUAllocation {
+				allocation := store.NewCPUAllocation(topo, cpuset.New())
+				requirePreparedResourceClaim(t, logger, allocation, types.UID(claimUID), allCPUs)
+				return allocation
+			}(),
+			claimTracker: store.NewClaimTracker(),
+			container:    newTestContainer(claimUID, "0-7"),
+			expectedContainerAdjustment: &api.ContainerAdjustment{
+				Linux: &api.LinuxContainerAdjustment{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
+			},
+			expectedContainerUpdates: []*api.ContainerUpdate{},
 		},
 		{
 			name:               "guaranteed container with malformed env fails closed",
@@ -262,6 +305,7 @@ func TestCreateContainer(t *testing.T) {
 				require.Nil(t, adjust)
 				require.Nil(t, updates)
 				require.Zero(t, tc.claimTracker.Len(), "failed CreateContainer must not retain claim owners")
+				require.Nil(t, tc.podConfigStore.GetContainerState(types.UID(pod.Uid), tc.container.Name), "failed CreateContainer must not retain container state")
 				return
 			}
 
@@ -406,6 +450,46 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 	require.True(t, cpuStore.GetSharedCPUs().Equals(cpuset.New(2, 3)))
 }
 
+func TestGuaranteedContainerRestartRejectsInconsistentEmptySharedPool(t *testing.T) {
+	logger := testr.New(t)
+	allCPUs := cpuset.New(0, 1, 2, 3)
+	infos := make([]cpuinfo.CPUInfo, 0, allCPUs.Size())
+	for _, cpuID := range allCPUs.UnsortedList() {
+		infos = append(infos, cpuinfo.CPUInfo{CpuID: cpuID, CoreID: cpuID, SocketID: 0, NUMANodeID: 0})
+	}
+	topo, err := (&cpuinfo.MockCPUInfoProvider{CPUInfos: infos}).GetCPUTopology(logger)
+	require.NoError(t, err)
+
+	claimUID := types.UID("claim-full")
+	cpuStore := store.NewCPUAllocation(topo, cpuset.New())
+	require.NoError(t, cpuStore.ReserveResourceClaimAllocation(logger, claimUID, allCPUs))
+	claimTracker := store.NewClaimTracker()
+	pod := &api.PodSandbox{Id: "sandbox", Uid: "pod", Name: "pod", Namespace: "ns"}
+	_, err = claimTracker.SetOwner(logger, types.UID(pod.Uid), "app", claimUID)
+	require.NoError(t, err)
+
+	driver := &CPUDriver{
+		podConfigStore:     store.NewPodConfig(),
+		cpuAllocationStore: cpuStore,
+		claimTracker:       claimTracker,
+		topology:           deviceTopology{cpuTopology: topo},
+	}
+	driver.podConfigStore.SetContainerState("shared-pod", store.NewContainerState("shared", "shared-container"))
+	container := &api.Container{
+		Id:           "replacement",
+		PodSandboxId: pod.Id,
+		Name:         "app",
+		Env:          []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, allCPUs.String())},
+	}
+
+	adjustment, updates, err := driver.CreateContainer(context.Background(), pod, container)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot update shared containers: no shared CPUs available")
+	require.Nil(t, adjustment)
+	require.Nil(t, updates)
+	require.Equal(t, 1, claimTracker.Len(), "an existing owner must not be removed on restart rejection")
+}
+
 func TestNRISynchronize(t *testing.T) {
 	logger := testr.New(t)
 	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
@@ -502,6 +586,25 @@ func TestNRISynchronize(t *testing.T) {
 					Linux:       &api.LinuxContainerUpdate{Resources: &api.LinuxResources{Cpu: &api.LinuxCPU{Cpus: "0-7"}}},
 				},
 			},
+		},
+		{
+			name: "synchronize rejects an empty shared pool with existing shared containers",
+			driver: &CPUDriver{
+				podConfigStore:     store.NewPodConfig(),
+				cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
+				claimTracker:       store.NewClaimTracker(),
+				cdiMgr: newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+					"claim-full": allCPUs,
+				}),
+				topology: deviceTopology{cpuTopology: topo},
+			},
+			runtimePods: []*api.PodSandbox{pod1},
+			runtimeCtrs: []*api.Container{
+				{Id: "p1-guaranteed", PodSandboxId: pod1.Id, Name: "guaranteed-ctr", Env: []string{fmt.Sprintf("%s_claim-full=%s", cdiEnvVarPrefix, allCPUs.String())}},
+				{Id: "p1-shared", PodSandboxId: pod1.Id, Name: "shared-ctr"},
+			},
+			expectedError:        "cannot update shared containers: no shared CPUs available",
+			expectedRefreshCalls: 1,
 		},
 		{
 			name: "only guaranteed containers",

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -389,7 +389,7 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 	claimUID := types.UID("claim-restart")
 	claimCPUs := cpuset.New(0, 1)
 	cpuStore := store.NewCPUAllocation(topo, cpuset.New())
-	require.NoError(t, cpuStore.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs))
+	require.NoError(t, cpuStore.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs, false))
 	driver := &CPUDriver{
 		podConfigStore:     store.NewPodConfig(),
 		cpuAllocationStore: cpuStore,
@@ -462,7 +462,7 @@ func TestGuaranteedContainerRestartNotBlockedByEmptySharedPool(t *testing.T) {
 
 	claimUID := types.UID("claim-full")
 	cpuStore := store.NewCPUAllocation(topo, cpuset.New())
-	require.NoError(t, cpuStore.ReserveResourceClaimAllocation(logger, claimUID, allCPUs))
+	require.NoError(t, cpuStore.ReserveResourceClaimAllocation(logger, claimUID, allCPUs, false))
 	claimTracker := store.NewClaimTracker()
 	pod := &api.PodSandbox{Id: "sandbox", Uid: "pod", Name: "pod", Namespace: "ns"}
 	_, err = claimTracker.SetOwner(logger, types.UID(pod.Uid), "app", claimUID)

--- a/pkg/store/cpu_allocation.go
+++ b/pkg/store/cpu_allocation.go
@@ -61,8 +61,10 @@ func NewCPUAllocation(cpuTopology *cpuinfo.CPUTopology, reservedCPUs cpuset.CPUS
 }
 
 // ReserveResourceClaimAllocation records a prepared claim. Its CPUs remain unavailable
-// to shared containers and other exclusive claims until Unprepare.
-func (s *CPUAllocation) ReserveResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet) error {
+// to shared containers and other exclusive claims until Unprepare. When shared
+// containers are present, the reservation must leave at least one CPU in the
+// shared pool because NRI cannot represent an empty CPUSet.
+func (s *CPUAllocation) ReserveResourceClaimAllocation(logger logr.Logger, claimUID types.UID, cpus cpuset.CPUSet, hasSharedContainers bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if allocation, ok := s.resourceClaimAllocations[claimUID]; ok {
@@ -71,8 +73,12 @@ func (s *CPUAllocation) ReserveResourceClaimAllocation(logger logr.Logger, claim
 		}
 		return fmt.Errorf("claim %q is already prepared with CPUs %q (requested %q)", claimUID, allocation.String(), cpus.String())
 	}
-	if !cpus.IsSubsetOf(s.availableCPUs.Difference(s.preparedCPUs)) {
+	sharedCPUs := s.availableCPUs.Difference(s.preparedCPUs)
+	if !cpus.IsSubsetOf(sharedCPUs) {
 		return fmt.Errorf("claim %q has overlapping CPU assignment %q", claimUID, cpus.String())
+	}
+	if hasSharedContainers && !cpus.IsEmpty() && sharedCPUs.Difference(cpus).IsEmpty() {
+		return fmt.Errorf("claim %q would exhaust the shared CPU pool while shared containers are running", claimUID)
 	}
 	s.resourceClaimAllocations[claimUID] = cpus
 	s.preparedCPUs = s.preparedCPUs.Union(cpus)

--- a/pkg/store/cpu_allocation_test.go
+++ b/pkg/store/cpu_allocation_test.go
@@ -40,7 +40,7 @@ func newTestCPUAllocation(logger logr.Logger, allCPUs, reserved cpuset.CPUSet) *
 
 func requirePreparedAllocation(t testing.TB, logger logr.Logger, store *CPUAllocation, claimUID types.UID, cpus cpuset.CPUSet) {
 	t.Helper()
-	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, cpus))
+	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, cpus, false))
 }
 
 func TestCPUAllocationPreparedLifecycle(t *testing.T) {
@@ -50,9 +50,9 @@ func TestCPUAllocationPreparedLifecycle(t *testing.T) {
 	claimCPUs := cpuset.New(0, 1)
 	store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 
-	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs))
+	require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, claimCPUs, false))
 	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
-	require.Error(t, store.ReserveResourceClaimAllocation(logger, "claim-2", claimCPUs))
+	require.Error(t, store.ReserveResourceClaimAllocation(logger, "claim-2", claimCPUs, false))
 
 	require.NoError(t, store.ValidateResourceClaimAllocations(map[types.UID]cpuset.CPUSet{claimUID: claimCPUs}))
 	require.True(t, store.GetSharedCPUs().Equals(cpuset.New(2, 3)))
@@ -175,8 +175,8 @@ func TestReserveResourceClaimAllocationRepeatedCalls(t *testing.T) {
 			store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
 			claimUID := types.UID("claim-uid-1")
 
-			require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, tc.firstCPUs))
-			err := store.ReserveResourceClaimAllocation(logger, claimUID, tc.secondCPUs)
+			require.NoError(t, store.ReserveResourceClaimAllocation(logger, claimUID, tc.firstCPUs, false))
+			err := store.ReserveResourceClaimAllocation(logger, claimUID, tc.secondCPUs, false)
 			if tc.expectError {
 				require.Error(t, err)
 			} else {
@@ -187,6 +187,51 @@ func TestReserveResourceClaimAllocationRepeatedCalls(t *testing.T) {
 			require.True(t, ok)
 			require.True(t, tc.firstCPUs.Equals(gotCPUs), "claim cpus mismatch: got %s, want %s", gotCPUs, tc.firstCPUs)
 			require.True(t, allCPUs.Difference(tc.firstCPUs).Equals(store.GetSharedCPUs()))
+		})
+	}
+}
+
+func TestReserveResourceClaimAllocationSharedPoolGuard(t *testing.T) {
+	logger := testr.New(t)
+	allCPUs := cpuset.New(0, 1, 2, 3)
+
+	tests := []struct {
+		name                string
+		cpus                cpuset.CPUSet
+		hasSharedContainers bool
+		wantErr             bool
+	}{
+		{
+			name:                "rejects exhausting pool with shared containers",
+			cpus:                allCPUs,
+			hasSharedContainers: true,
+			wantErr:             true,
+		},
+		{
+			name:                "allows exhausting pool without shared containers",
+			cpus:                allCPUs,
+			hasSharedContainers: false,
+		},
+		{
+			name:                "allows reservation that leaves shared CPUs",
+			cpus:                cpuset.New(0, 1),
+			hasSharedContainers: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newTestCPUAllocation(logger, allCPUs, cpuset.New())
+			err := store.ReserveResourceClaimAllocation(logger, "claim", test.cpus, test.hasSharedContainers)
+			if test.wantErr {
+				require.ErrorContains(t, err, "would exhaust the shared CPU pool")
+				_, ok := store.GetResourceClaimAllocation("claim")
+				require.False(t, ok)
+				require.True(t, store.GetSharedCPUs().Equals(allCPUs))
+			} else {
+				require.NoError(t, err)
+				require.True(t, store.GetSharedCPUs().Equals(allCPUs.Difference(test.cpus)))
+			}
 		})
 	}
 }

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
@@ -243,12 +242,15 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				verifySharedPoolMatches(ctx, fxt, shrPod2, expectedSharedCPUs)
 			})
 
-			ginkgo.It("should reject a shared container when the shared pool becomes empty", ginkgo.Label("negative"), func(ctx context.Context) {
+			ginkgo.It("should reject a claim that would exhaust the shared pool while shared containers exist", ginkgo.Label("negative"), func(ctx context.Context) {
 				if cpuDeviceMode == "grouped" && groupBy == "machine" {
 					ginkgo.Skip("skipping this test in machine grouping mode as we do not configure opaque config in claim")
 				}
 				if availableCPUs.IsEmpty() {
 					ginkgo.Skip("need at least one driver-managed CPU for this test")
+				}
+				if publishNodeAllocatableMapping {
+					ginkgo.Skip("skipping this test with node allocatable mapping enabled: scheduler-side accounting prevents exhausting the shared pool")
 				}
 
 				fixture.By("creating ResourceClaims which consume all driver-managed CPUs")
@@ -279,6 +281,7 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				}
 
 				exclusiveAllocation := cpuset.New()
+				var blockedPod *v1.Pod
 				for i, claimSize := range claimSizes {
 					claimTemplate := resourcev1.ResourceClaimTemplate{
 						ObjectMeta: metav1.ObjectMeta{
@@ -293,20 +296,12 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 
 					exclusivePod := makeTesterPodWithExclusiveCPUClaimWithoutCPURequest(fxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, targetNode.Name)
 					if i == len(claimSizes)-1 {
-						// The last claim exhausts the shared pool. Existing kube-system
-						// containers are shared containers, so the driver must reject the
-						// exclusive container instead of sending an empty CPUSet update.
+						// The last claim would exhaust the shared pool. Existing kube-system
+						// containers are shared containers, so the driver must reject the claim
+						// during Prepare instead of letting NRI send an empty CPUSet update.
 						createdExclusivePod, err := fxt.K8SClientset.CoreV1().Pods(exclusivePod.Namespace).Create(ctx, exclusivePod, metav1.CreateOptions{})
 						gomega.Expect(err).ToNot(gomega.HaveOccurred())
-						gomega.Eventually(func() bool {
-							pod, getErr := fxt.K8SClientset.CoreV1().Pods(createdExclusivePod.Namespace).Get(ctx, createdExclusivePod.Name, metav1.GetOptions{})
-							if getErr != nil || pod.Status.Phase == v1.PodRunning || len(pod.Status.ContainerStatuses) == 0 || len(pod.Status.ResourceClaimStatuses) == 0 {
-								return false
-							}
-							waiting := pod.Status.ContainerStatuses[0].State.Waiting
-							return waiting != nil && strings.Contains(waiting.Message, "no shared CPUs available")
-						}).WithTimeout(time.Minute).WithPolling(2*time.Second).Should(gomega.BeTrue(), "an exclusive container which exhausts the shared pool must not start")
-						gomega.Expect(exclusiveAllocation.Size()+claimSize).To(gomega.Equal(availableCPUs.Size()), "the rejected Claim should account for the final driver-managed CPUs")
+						blockedPod = createdExclusivePod
 						continue
 					}
 					createdExclusivePod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, exclusivePod)
@@ -320,22 +315,26 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				}
 				gomega.Expect(exclusiveAllocation.Size()+claimSizes[len(claimSizes)-1]).To(gomega.Equal(availableCPUs.Size()), "the DRA Claims should consume the complete driver-managed CPU pool")
 
-				// The driver must reject this container. Applying an empty shared
-				// CPUSet through NRI would be a no-op and could restore the default
-				// affinity, overlapping the exclusive allocation.
-				fixture.By("creating a shared pod after the shared pool becomes empty")
+				// The claim is rejected during Prepare, so the pod stays Pending and
+				// never starts: preparing it would leave no CPUs for the shared pool,
+				// which NRI cannot represent.
+				fixture.By("verifying the claim that would exhaust the shared pool stays blocked")
+				gomega.Consistently(func() v1.PodPhase {
+					pod, getErr := fxt.K8SClientset.CoreV1().Pods(blockedPod.Namespace).Get(ctx, blockedPod.Name, metav1.GetOptions{})
+					if getErr != nil {
+						return v1.PodUnknown
+					}
+					return pod.Status.Phase
+				}).WithTimeout(45*time.Second).WithPolling(2*time.Second).ShouldNot(gomega.Equal(v1.PodRunning), "a claim which would exhaust the shared pool must stay blocked")
+
+				// Because the exhausting claim is never prepared, the shared pool keeps
+				// its CPUs: existing and new shared containers must keep working.
+				fixture.By("creating a shared pod while the exhausting claim stays blocked")
 				sharedAfter := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
 				sharedAfter = e2epod.PinToNode(sharedAfter, targetNode.Name)
-				createdSharedAfter, err := fxt.K8SClientset.CoreV1().Pods(sharedAfter.Namespace).Create(ctx, sharedAfter, metav1.CreateOptions{})
+				createdSharedAfter, err := e2epod.CreateSync(ctx, fxt.K8SClientset, sharedAfter)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Eventually(func() bool {
-					pod, getErr := fxt.K8SClientset.CoreV1().Pods(createdSharedAfter.Namespace).Get(ctx, createdSharedAfter.Name, metav1.GetOptions{})
-					if getErr != nil || pod.Status.Phase == v1.PodRunning || len(pod.Status.ContainerStatuses) == 0 {
-						return false
-					}
-					waiting := pod.Status.ContainerStatuses[0].State.Waiting
-					return waiting != nil && strings.Contains(waiting.Message, "no shared CPUs available")
-				}).WithTimeout(time.Minute).WithPolling(2*time.Second).Should(gomega.BeTrue(), "a shared pod created with an empty shared pool must be rejected by the driver")
+				verifySharedPoolMatches(ctx, fxt, createdSharedAfter, availableCPUs.Difference(exclusiveAllocation))
 			})
 
 			ginkgo.It("should allocate non-overlapping CPUs for multiple requests in the same grouped claim", func(ctx context.Context) {

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
@@ -239,6 +240,84 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				ginkgo.By("checking existing shared containers keep their last cpuset until the next CreateContainer or Synchronize")
 				verifySharedPoolMatches(ctx, fxt, shrPod1, expectedSharedCPUs)
 				verifySharedPoolMatches(ctx, fxt, shrPod2, expectedSharedCPUs)
+			})
+
+			ginkgo.It("should reproduce shared CPU overlap when the shared pool becomes empty", ginkgo.Label("negative"), func(ctx context.Context) {
+				if cpuDeviceMode == "grouped" && groupBy == "machine" {
+					ginkgo.Skip("skipping this test in machine grouping mode as we do not configure opaque config in claim")
+				}
+				if availableCPUs.IsEmpty() {
+					ginkgo.Skip("need at least one driver-managed CPU for this test")
+				}
+
+				fixture.By("creating a shared pod before any DRA CPUs are allocated")
+				sharedPod := mustCreateBestEffortPod(ctx, fxt, targetNode.Name, dracpuTesterImage)
+				sharedBefore := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPod)
+				nodeCPUs := makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
+				gomega.Expect(sharedBefore.CPUAssigned).To(cpusetmatchers.BeSubsetOf(nodeCPUs), "the initial shared pod should use CPUs visible on the node")
+
+				fixture.By("creating ResourceClaims which consume all driver-managed CPUs")
+				claimSizes := []int{availableCPUs.Size()}
+				if cpuDeviceMode == "grouped" && (groupBy == "numanode" || groupBy == "socket") {
+					byGroup := map[int]int{}
+					for _, cpu := range targetNodeCPUInfo.CPUs {
+						if availableCPUs.Contains(cpu.CpuID) {
+							groupID := cpu.NUMANodeID
+							if groupBy == "socket" {
+								groupID = cpu.SocketID
+							}
+							byGroup[groupID]++
+						}
+					}
+					groupIDs := make([]int, 0, len(byGroup))
+					for groupID := range byGroup {
+						groupIDs = append(groupIDs, groupID)
+					}
+					sort.Ints(groupIDs)
+					claimSizes = claimSizes[:0]
+					for _, groupID := range groupIDs {
+						claimSizes = append(claimSizes, byGroup[groupID])
+					}
+					// Allocate the largest group request first so the scheduler cannot
+					// consume a large device for a smaller request.
+					sort.Sort(sort.Reverse(sort.IntSlice(claimSizes)))
+				}
+
+				exclusiveAllocation := cpuset.New()
+				for i, claimSize := range claimSizes {
+					claimTemplate := resourcev1.ResourceClaimTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("cpu-request-all-excl-%d", i),
+						},
+						Spec: resourcev1.ResourceClaimTemplateSpec{
+							Spec: makeResourceClaimSpec(claimSize, cpuDeviceMode == "grouped"),
+						},
+					}
+					createdClaimTemplate, err := fxt.K8SClientset.ResourceV1().ResourceClaimTemplates(fxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+					exclusivePod := makeTesterPodWithExclusiveCPUClaim(fxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, int64(claimSize), targetNode.Name, nodeAllocatableMapping)
+					createdExclusivePod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, exclusivePod)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+					allocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdExclusivePod)
+					gomega.Expect(allocation.CPUAssigned).To(cpusetmatchers.HaveSize(claimSize), "the DRA pod should consume its requested CPU pool")
+					gomega.Expect(allocation.CPUAssigned).To(cpusetmatchers.BeSubsetOf(availableCPUs), "the DRA pod should consume only driver-managed CPUs")
+					gomega.Expect(allocation.CPUAssigned).To(cpusetmatchers.HaveNoOverlapWith(exclusiveAllocation), "DRA pod allocations must not overlap")
+					exclusiveAllocation = exclusiveAllocation.Union(allocation.CPUAssigned)
+					expectNodeAllocClaimStatus(ctx, fxt.K8SClientset, createdExclusivePod, int64(claimSize), nodeAllocatableMapping)
+				}
+				gomega.Expect(exclusiveAllocation).To(cpusetmatchers.Equal(availableCPUs), "the DRA pods should consume the complete driver-managed CPU pool")
+
+				fixture.By("creating a second shared pod after the shared pool becomes empty")
+				sharedAfter := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
+				sharedAfter = e2epod.PinToNode(sharedAfter, targetNode.Name)
+				createdSharedAfter, err := fxt.K8SClientset.CoreV1().Pods(sharedAfter.Namespace).Create(ctx, sharedAfter, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				gomega.Expect(e2epod.WaitToBeRunning(ctx, fxt.K8SClientset, createdSharedAfter.Namespace, createdSharedAfter.Name)).To(gomega.Succeed())
+				gomega.Eventually(func() bool {
+					allocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdSharedAfter).CPUAssigned
+					return !allocation.Intersection(exclusiveAllocation).IsEmpty()
+				}).WithTimeout(time.Minute).WithPolling(2*time.Second).Should(gomega.BeTrue(), "a shared pod created with an empty shared pool must overlap the DRA allocation")
 			})
 
 			ginkgo.It("should allocate non-overlapping CPUs for multiple requests in the same grouped claim", func(ctx context.Context) {

--- a/test/e2e/cpu_assignment_test.go
+++ b/test/e2e/cpu_assignment_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/kubernetes-sigs/dra-driver-cpu/test/pkg/discovery"
@@ -242,19 +243,13 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 				verifySharedPoolMatches(ctx, fxt, shrPod2, expectedSharedCPUs)
 			})
 
-			ginkgo.It("should reproduce shared CPU overlap when the shared pool becomes empty", ginkgo.Label("negative"), func(ctx context.Context) {
+			ginkgo.It("should reject a shared container when the shared pool becomes empty", ginkgo.Label("negative"), func(ctx context.Context) {
 				if cpuDeviceMode == "grouped" && groupBy == "machine" {
 					ginkgo.Skip("skipping this test in machine grouping mode as we do not configure opaque config in claim")
 				}
 				if availableCPUs.IsEmpty() {
 					ginkgo.Skip("need at least one driver-managed CPU for this test")
 				}
-
-				fixture.By("creating a shared pod before any DRA CPUs are allocated")
-				sharedPod := mustCreateBestEffortPod(ctx, fxt, targetNode.Name, dracpuTesterImage)
-				sharedBefore := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, sharedPod)
-				nodeCPUs := makeCPUSetFromDiscoveredCPUInfo(targetNodeCPUInfo)
-				gomega.Expect(sharedBefore.CPUAssigned).To(cpusetmatchers.BeSubsetOf(nodeCPUs), "the initial shared pod should use CPUs visible on the node")
 
 				fixture.By("creating ResourceClaims which consume all driver-managed CPUs")
 				claimSizes := []int{availableCPUs.Size()}
@@ -296,7 +291,24 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 					createdClaimTemplate, err := fxt.K8SClientset.ResourceV1().ResourceClaimTemplates(fxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-					exclusivePod := makeTesterPodWithExclusiveCPUClaim(fxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, int64(claimSize), targetNode.Name, nodeAllocatableMapping)
+					exclusivePod := makeTesterPodWithExclusiveCPUClaimWithoutCPURequest(fxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, targetNode.Name)
+					if i == len(claimSizes)-1 {
+						// The last claim exhausts the shared pool. Existing kube-system
+						// containers are shared containers, so the driver must reject the
+						// exclusive container instead of sending an empty CPUSet update.
+						createdExclusivePod, err := fxt.K8SClientset.CoreV1().Pods(exclusivePod.Namespace).Create(ctx, exclusivePod, metav1.CreateOptions{})
+						gomega.Expect(err).ToNot(gomega.HaveOccurred())
+						gomega.Eventually(func() bool {
+							pod, getErr := fxt.K8SClientset.CoreV1().Pods(createdExclusivePod.Namespace).Get(ctx, createdExclusivePod.Name, metav1.GetOptions{})
+							if getErr != nil || pod.Status.Phase == v1.PodRunning || len(pod.Status.ContainerStatuses) == 0 || len(pod.Status.ResourceClaimStatuses) == 0 {
+								return false
+							}
+							waiting := pod.Status.ContainerStatuses[0].State.Waiting
+							return waiting != nil && strings.Contains(waiting.Message, "no shared CPUs available")
+						}).WithTimeout(time.Minute).WithPolling(2*time.Second).Should(gomega.BeTrue(), "an exclusive container which exhausts the shared pool must not start")
+						gomega.Expect(exclusiveAllocation.Size()+claimSize).To(gomega.Equal(availableCPUs.Size()), "the rejected Claim should account for the final driver-managed CPUs")
+						continue
+					}
 					createdExclusivePod, err := e2epod.CreateSync(ctx, fxt.K8SClientset, exclusivePod)
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 					allocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdExclusivePod)
@@ -304,20 +316,26 @@ var _ = ginkgo.Describe("CPU Allocation", ginkgo.Serial, ginkgo.Ordered, ginkgo.
 					gomega.Expect(allocation.CPUAssigned).To(cpusetmatchers.BeSubsetOf(availableCPUs), "the DRA pod should consume only driver-managed CPUs")
 					gomega.Expect(allocation.CPUAssigned).To(cpusetmatchers.HaveNoOverlapWith(exclusiveAllocation), "DRA pod allocations must not overlap")
 					exclusiveAllocation = exclusiveAllocation.Union(allocation.CPUAssigned)
-					expectNodeAllocClaimStatus(ctx, fxt.K8SClientset, createdExclusivePod, int64(claimSize), nodeAllocatableMapping)
+					expectNodeAllocatableClaimStatus(ctx, fxt.K8SClientset, createdExclusivePod, int64(claimSize), publishNodeAllocatableMapping)
 				}
-				gomega.Expect(exclusiveAllocation).To(cpusetmatchers.Equal(availableCPUs), "the DRA pods should consume the complete driver-managed CPU pool")
+				gomega.Expect(exclusiveAllocation.Size()+claimSizes[len(claimSizes)-1]).To(gomega.Equal(availableCPUs.Size()), "the DRA Claims should consume the complete driver-managed CPU pool")
 
-				fixture.By("creating a second shared pod after the shared pool becomes empty")
+				// The driver must reject this container. Applying an empty shared
+				// CPUSet through NRI would be a no-op and could restore the default
+				// affinity, overlapping the exclusive allocation.
+				fixture.By("creating a shared pod after the shared pool becomes empty")
 				sharedAfter := makeTesterPodBestEffort(fxt.Namespace.Name, dracpuTesterImage)
 				sharedAfter = e2epod.PinToNode(sharedAfter, targetNode.Name)
 				createdSharedAfter, err := fxt.K8SClientset.CoreV1().Pods(sharedAfter.Namespace).Create(ctx, sharedAfter, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Expect(e2epod.WaitToBeRunning(ctx, fxt.K8SClientset, createdSharedAfter.Namespace, createdSharedAfter.Name)).To(gomega.Succeed())
 				gomega.Eventually(func() bool {
-					allocation := getTesterPodCPUAllocation(fxt.K8SClientset, ctx, createdSharedAfter).CPUAssigned
-					return !allocation.Intersection(exclusiveAllocation).IsEmpty()
-				}).WithTimeout(time.Minute).WithPolling(2*time.Second).Should(gomega.BeTrue(), "a shared pod created with an empty shared pool must overlap the DRA allocation")
+					pod, getErr := fxt.K8SClientset.CoreV1().Pods(createdSharedAfter.Namespace).Get(ctx, createdSharedAfter.Name, metav1.GetOptions{})
+					if getErr != nil || pod.Status.Phase == v1.PodRunning || len(pod.Status.ContainerStatuses) == 0 {
+						return false
+					}
+					waiting := pod.Status.ContainerStatuses[0].State.Waiting
+					return waiting != nil && strings.Contains(waiting.Message, "no shared CPUs available")
+				}).WithTimeout(time.Minute).WithPolling(2*time.Second).Should(gomega.BeTrue(), "a shared pod created with an empty shared pool must be rejected by the driver")
 			})
 
 			ginkgo.It("should allocate non-overlapping CPUs for multiple requests in the same grouped claim", func(ctx context.Context) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -216,6 +216,27 @@ func claimContainerResources(numCPUs int64, nodeAllocatableMapping bool) (reques
 func makeTesterPodWithExclusiveCPUClaim(ns, image, cpuClaimTemplateName string, numCPUs int64, nodeName string, nodeAllocatableMapping bool) *v1.Pod {
 	ginkgo.GinkgoHelper()
 	requests, limits := claimContainerResources(numCPUs, nodeAllocatableMapping)
+	return makeTesterPodWithExclusiveCPUClaimResources(ns, image, cpuClaimTemplateName, nodeName, requests, limits)
+}
+
+// makeTesterPodWithExclusiveCPUClaimWithoutCPURequest deliberately omits the
+// ordinary CPU request/limit. This allows the scheduler to place all DRA
+// claims, so the test can exercise the driver's NRI handling when the shared
+// pool is exhausted. The mirrored CPU request/limit behavior is covered by
+// the regular claim tests and is expected to be scheduler-safe.
+func makeTesterPodWithExclusiveCPUClaimWithoutCPURequest(ns, image, cpuClaimTemplateName, nodeName string) *v1.Pod {
+	ginkgo.GinkgoHelper()
+	memQty, err := resource.ParseQuantity("256Mi")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	return makeTesterPodWithExclusiveCPUClaimResources(
+		ns, image, cpuClaimTemplateName, nodeName,
+		v1.ResourceList{v1.ResourceMemory: memQty},
+		v1.ResourceList{v1.ResourceMemory: memQty},
+	)
+}
+
+func makeTesterPodWithExclusiveCPUClaimResources(ns, image, cpuClaimTemplateName, nodeName string, requests, limits v1.ResourceList) *v1.Pod {
+	ginkgo.GinkgoHelper()
 
 	podWithClaim := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

- Fail closed when a prepared DRA allocation leaves no CPUs for shared containers.
- Reject a shared container instead of passing an empty CPUSet to NRI.
- Reject an exclusive container when its allocation would exhaust the shared pool while shared containers still exist.
- Roll back newly recorded claim ownership when container creation is rejected.
- Apply the same empty-pool validation during container restart and NRI synchronization.
- Add unit and focused E2E coverage for the failure paths.

## Background

An empty CPUSet is serialized through NRI as an empty Cpus value. The runtime treats that value as no CPUSet update, so a shared container may retain or receive unrestricted CPU affinity and overlap CPUs assigned exclusively through a DRA claim.

The scheduler-side accounting changes prevent this during normal scheduling when node allocatable resource mapping is enabled. This change adds a node-local fail-closed check so the driver does not apply an unsafe empty CPUSet if the condition is still encountered.

A node with no driver-managed CPUs and no prepared DRA allocation keeps the existing kubelet-managed behavior.

## Testing

```text
go test ./pkg/... ./internal/...
go test ./test/e2e -run "^$"
```

Focused E2E test against an amd64 Kind cluster with Kubernetes v1.36.0, 24 CPUs, Node.Status.Allocatable.cpu=23, reservedCPUs=0, and driver-managed CPUs 1-23:

```text
Ran 1 of 17 Specs in 54.764 seconds
SUCCESS! -- 1 Passed | 0 Failed
```

The E2E test consumes all driver-managed CPUs through DRA claims and verifies that the container which exhausts the shared pool and a subsequent shared container are rejected without applying an overlapping CPUSet.

Fixes #295.