### PR TITLE
feat: publish standard resource.kubernetes.io/numaNode attribute

### DIFF
--- a/pkg/device/attributes.go
+++ b/pkg/device/attributes.go
@@ -37,7 +37,6 @@ const (
 )
 
 const (
-	AttributeNUMANodeID resourceapi.QualifiedName = "dra.cpu/numaNodeID"
 	AttributeSocketID   resourceapi.QualifiedName = "dra.cpu/socketID"
 	AttributeSMTEnabled resourceapi.QualifiedName = "dra.cpu/smtEnabled"
 	AttributeCacheL3ID  resourceapi.QualifiedName = "dra.cpu/cacheL3ID"
@@ -56,4 +55,5 @@ const (
 // This is the "staging area" which enables attribute sharing until (or before) they become standard.
 func SetCompatibilityAttributes(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaID int64) {
 	attrs["dra.net/numaNode"] = resourceapi.DeviceAttribute{IntValue: new(numaID)}
+	attrs["dra.cpu/numaNodeID"] = resourceapi.DeviceAttribute{IntValue: new(numaID)}
 }

--- a/pkg/device/attributes.go
+++ b/pkg/device/attributes.go
@@ -50,10 +50,10 @@ const (
 	AttributeAllocatedNumCPUs resourceapi.QualifiedName = "dra.cpu/allocatedNumCPUs"
 )
 
-// SetCompatibilityAttributes add attributes to enable compatibility (e.g. alignment) with other
+// addCompatibilityAttributes add attributes to enable compatibility (e.g. alignment) with other
 // DRA resource drivers leveraging attributes which are not kubernetes standard.
 // This is the "staging area" which enables attribute sharing until (or before) they become standard.
-func SetCompatibilityAttributes(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaID int64) {
+func addCompatibilityAttributes(attrs map[resourceapi.QualifiedName]resourceapi.DeviceAttribute, numaID int64) {
 	attrs["dra.net/numaNode"] = resourceapi.DeviceAttribute{IntValue: new(numaID)}
 	attrs["dra.cpu/numaNodeID"] = resourceapi.DeviceAttribute{IntValue: new(numaID)}
 }

--- a/pkg/device/builder.go
+++ b/pkg/device/builder.go
@@ -242,7 +242,7 @@ func createGroupedCPUDeviceSlices(logger logr.Logger, groupBy string, deviceInfo
 				AttributeSMTEnabled: {BoolValue: new(smtEnabled)},
 				AttributeNumCPUs:    {IntValue: new(availableCPUs)},
 			}
-			SetCompatibilityAttributes(deviceAttrs, int64(deviceInfo.numaNodeID))
+			addCompatibilityAttributes(deviceAttrs, int64(deviceInfo.numaNodeID))
 			addPCIeRootsAttribute(pcieRootMapper, deviceAttrs, deviceInfo.cpus.UnsortedList()...)
 
 			devices = append(devices, resourceapi.Device{
@@ -290,7 +290,7 @@ func createCPUDeviceSlices(deviceInfos []cpuDeviceInfo, pcieRootMapper *store.PC
 			AttributeCoreID:     {IntValue: new(int64(cpu.CoreID))},
 			AttributeCPUID:      {IntValue: new(int64(cpu.CpuID))},
 		}
-		SetCompatibilityAttributes(deviceAttrs, int64(cpu.NUMANodeID))
+		addCompatibilityAttributes(deviceAttrs, int64(cpu.NUMANodeID))
 		addPCIeRootsAttribute(pcieRootMapper, deviceAttrs, cpu.CpuID)
 
 		cpuDevice := resourceapi.Device{

--- a/pkg/device/builder.go
+++ b/pkg/device/builder.go
@@ -235,7 +235,9 @@ func createGroupedCPUDeviceSlices(logger logr.Logger, groupBy string, deviceInfo
 			})
 		case GROUP_BY_NUMA_NODE:
 			deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-				AttributeNUMANodeID: {IntValue: new(int64(deviceInfo.numaNodeID))},
+				// DRA standard attributes first
+				deviceattribute.StandardDeviceAttributeNUMANode: {IntValue: new(int64(deviceInfo.numaNodeID))},
+				// Driver-specific/non-standard attributes next
 				AttributeSocketID:   {IntValue: new(int64(deviceInfo.socketID))},
 				AttributeSMTEnabled: {BoolValue: new(smtEnabled)},
 				AttributeNumCPUs:    {IntValue: new(availableCPUs)},
@@ -278,7 +280,9 @@ func createCPUDeviceSlices(deviceInfos []cpuDeviceInfo, pcieRootMapper *store.PC
 	for _, deviceInfo := range deviceInfos {
 		cpu := deviceInfo.cpu
 		deviceAttrs := map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
-			AttributeNUMANodeID: {IntValue: new(int64(cpu.NUMANodeID))},
+			// DRA standard attributes first
+			deviceattribute.StandardDeviceAttributeNUMANode: {IntValue: new(int64(cpu.NUMANodeID))},
+			// Driver-specific/non-standard attributes next
 			AttributeSocketID:   {IntValue: new(int64(cpu.SocketID))},
 			AttributeSMTEnabled: {BoolValue: new(smtEnabled)},
 			AttributeCacheL3ID:  {IntValue: new(int64(cpu.UncoreCacheID))},

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/deviceattribute"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
@@ -449,7 +450,7 @@ func TestPublishResources(t *testing.T) {
 					coreType := cpuInfo.CoreType.String()
 					socketID := int64(cpuInfo.SocketID)
 
-					require.Equal(t, numaNode, *device.Attributes[devattr.AttributeNUMANodeID].IntValue)
+					require.Equal(t, numaNode, *device.Attributes[deviceattribute.StandardDeviceAttributeNUMANode].IntValue)
 					require.Equal(t, CacheL3ID, *device.Attributes[devattr.AttributeCacheL3ID].IntValue)
 					require.Equal(t, coreType, *device.Attributes[devattr.AttributeCoreType].StringValue)
 					require.Equal(t, socketID, *device.Attributes[devattr.AttributeSocketID].IntValue)
@@ -2151,14 +2152,17 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 // independent of production code paths.
 func metadataFromCPUInfo(cpu cpuinfo.CPUInfo, smtEnabled bool) *kubeletplugin.DeviceMetadata {
 	attrs := map[string]resourceapi.DeviceAttribute{
+		// DRA standard attributes first
+		string(deviceattribute.StandardDeviceAttributeNUMANode): {IntValue: new(int64(cpu.NUMANodeID))},
+		// Driver specific attributes next
 		string(devattr.AttributeCPUID):      {IntValue: new(int64(cpu.CpuID))},
 		string(devattr.AttributeCoreID):     {IntValue: new(int64(cpu.CoreID))},
 		string(devattr.AttributeSocketID):   {IntValue: new(int64(cpu.SocketID))},
-		string(devattr.AttributeNUMANodeID): {IntValue: new(int64(cpu.NUMANodeID))},
 		string(devattr.AttributeCacheL3ID):  {IntValue: new(int64(cpu.UncoreCacheID))},
 		string(devattr.AttributeCoreType):   {StringValue: new(cpu.CoreType.String())},
 		string(devattr.AttributeSMTEnabled): {BoolValue: new(smtEnabled)},
 		"dra.net/numaNode":                  {IntValue: new(int64(cpu.NUMANodeID))},
+		"dra.cpu/numaNodeID":                {IntValue: new(int64(cpu.NUMANodeID))},
 	}
 	return &kubeletplugin.DeviceMetadata{Attributes: attrs}
 }
@@ -2193,11 +2197,14 @@ func expectedGroupMetadata(groupBy string, cpuInfos []cpuinfo.CPUInfo, reservedC
 				socketID = ci.SocketID
 			}
 		}
-		attrs[string(devattr.AttributeNUMANodeID)] = resourceapi.DeviceAttribute{IntValue: new(int64(numaID))}
+		// DRA standard attributes first
+		attrs[string(deviceattribute.StandardDeviceAttributeNUMANode)] = resourceapi.DeviceAttribute{IntValue: new(int64(numaID))}
+		// Driver specific attributes next
 		attrs[string(devattr.AttributeSocketID)] = resourceapi.DeviceAttribute{IntValue: new(int64(socketID))}
 		attrs[string(devattr.AttributeNumCPUs)] = resourceapi.DeviceAttribute{IntValue: new(numCPUs)}
 		attrs[string(devattr.AttributeSMTEnabled)] = resourceapi.DeviceAttribute{BoolValue: new(smtEnabled)}
 		attrs["dra.net/numaNode"] = resourceapi.DeviceAttribute{IntValue: new(int64(numaID))}
+		attrs["dra.cpu/numaNodeID"] = resourceapi.DeviceAttribute{IntValue: new(int64(numaID))}
 
 	case devattr.GROUP_BY_MACHINE:
 		var numCPUs int64

--- a/test/e2e/resource_slice_test.go
+++ b/test/e2e/resource_slice_test.go
@@ -88,7 +88,9 @@ var _ = ginkgo.Describe("Resource Attributes", ginkgo.Ordered, ginkgo.ContinueOn
 		switch cpuDeviceMode {
 		case device.CPU_DEVICE_MODE_INDIVIDUAL:
 			checks = []attrCheck{
-				{device.AttributeNUMANodeID, isInt},
+				// DRA standard attributes first
+				{deviceattribute.StandardDeviceAttributeNUMANode, isInt},
+				// Driver specific attributes next
 				{device.AttributeSocketID, isInt},
 				{device.AttributeSMTEnabled, isBool},
 				{device.AttributeCacheL3ID, isInt},
@@ -105,7 +107,9 @@ var _ = ginkgo.Describe("Resource Attributes", ginkgo.Ordered, ginkgo.ContinueOn
 				}
 			case device.GROUP_BY_NUMA_NODE:
 				checks = []attrCheck{
-					{device.AttributeNUMANodeID, isInt},
+					// DRA standard attributes first
+					{deviceattribute.StandardDeviceAttributeNUMANode, isInt},
+					// Driver specific attributes next
 					{device.AttributeSocketID, isInt},
 					{device.AttributeSMTEnabled, isBool},
 					{device.AttributeNumCPUs, isInt},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

After we rebased on top of kubernetes 1.37, we can now expose the standard kubernetes NUMANode attribute,
keeping our legacy ones as deprecated backward compatibility. We will remove around the 0.4.0/0.5.0 timeframe.

#### Which issue(s) this PR is related to

Fixes: #219 

#### Special notes for reviewers

N/A

#### Release note

```release-note
The driver now publishes the standard NUMA node ID attribute, as available since kubernetes 1.37
```

#### Documentation updates

N/A