### PR TITLE
docs: prefer standard NUMA device attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ spec:
         selectors:
         # Only allocate CPUs on NUMA node 0
         - cel:
-            expression: device.attributes["dra.cpu"].numaNodeID == 0
+            expression: device.attributes["resource.kubernetes.io"].numaNode == 0
 ---
 apiVersion: v1
 kind: Pod
@@ -138,9 +138,11 @@ spec:
 ```
 
 PCIe root attributes are opt-in — see
-[Feature Support](docs/user/feature-support.md#exposing-pcie-roots). CPUs and DraNet NICs
-can also be aligned per NUMA node through the shared `dra.net/numaNode` attribute. For all
-selectable attributes and more example claims, see
+[Feature Support](docs/user/feature-support.md#exposing-pcie-roots). CPUs and other
+DRA-managed devices can also be aligned per NUMA node through the standard
+`resource.kubernetes.io/numaNode` attribute. The driver-specific `dra.cpu/numaNodeID` and
+`dra.net/numaNode` attributes remain available for compatibility. For all selectable
+attributes and more example claims, see
 [Device Attributes and Selectors](docs/user/device-attributes.md). Coming from the kubelet
 CPU Manager? See the
 [option-by-option mapping](docs/user/feature-support.md#matching-cpu-manager-options).

--- a/docs/user/device-attributes.md
+++ b/docs/user/device-attributes.md
@@ -19,11 +19,12 @@ CPU group, `individual` one device per CPU.
 
 | Attribute                         | Type    | Description                                                                                                    |
 | --------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
-| `dra.cpu/numaNodeID`              | int     | NUMA node of the group (published when grouping by NUMA node)                                                  |
+| `resource.kubernetes.io/numaNode` | int     | Standard NUMA node of the group (published when grouping by NUMA node)                                         |
+| `dra.cpu/numaNodeID`              | int     | Legacy driver-specific NUMA node attribute (NUMA grouping)                                                     |
 | `dra.cpu/socketID`                | int     | CPU socket of the group (published when grouping by NUMA node or socket)                                       |
 | `dra.cpu/numCPUs`                 | int     | CPUs available in the group                                                                                    |
 | `dra.cpu/smtEnabled`              | bool    | Whether SMT/hyper-threading is enabled on the node                                                             |
-| `dra.net/numaNode`                | int     | Cross-driver NUMA alignment, shared with e.g. NIC drivers (NUMA grouping)                                      |
+| `dra.net/numaNode`                | int     | Legacy cross-driver NUMA alignment attribute (NUMA grouping)                                                  |
 | `resource.kubernetes.io/pcieRoot` | strings | PCIe roots local to the group's CPUs; needs `--expose-pcie-roots` and the `DRAListTypeAttributes` feature gate |
 
 Grouped devices also expose the consumable capacity `dra.cpu/cpu` — the number of CPUs
@@ -38,15 +39,20 @@ claimable from the group. With `groupBy: machine`, only `numCPUs`, `smtEnabled`,
 | `dra.cpu/coreID`                  | int     | Physical core ID (shared by SMT siblings)                                                             |
 | `dra.cpu/coreType`                | string  | `standard`, `p-core`, or `e-core`                                                                     |
 | `dra.cpu/cacheL3ID`               | int     | L3 (last-level/uncore) cache group                                                                    |
-| `dra.cpu/numaNodeID`              | int     | NUMA node                                                                                             |
+| `resource.kubernetes.io/numaNode` | int     | Standard NUMA node                                                                                    |
+| `dra.cpu/numaNodeID`              | int     | Legacy driver-specific NUMA node attribute                                                            |
 | `dra.cpu/socketID`                | int     | CPU socket                                                                                            |
 | `dra.cpu/smtEnabled`              | bool    | Whether SMT/hyper-threading is enabled on the node                                                    |
-| `dra.net/numaNode`                | int     | Cross-driver NUMA alignment, shared with e.g. NIC drivers                                             |
+| `dra.net/numaNode`                | int     | Legacy cross-driver NUMA alignment attribute                                                          |
 | `resource.kubernetes.io/pcieRoot` | strings | PCIe roots local to the CPU; needs `--expose-pcie-roots` and the `DRAListTypeAttributes` feature gate |
 
 `resource.kubernetes.io/pcieRoot` is intended for cross-driver co-location via
 `matchAttribute` — see [Feature Support](feature-support.md#exposing-pcie-roots) for details
 and current limitations.
+
+Use `resource.kubernetes.io/numaNode` for new workloads. The driver-specific
+`dra.cpu/numaNodeID` and `dra.net/numaNode` attributes are retained as deprecated
+compatibility attributes while the migration timeline is decided in [#299](https://github.com/kubernetes-sigs/dra-driver-cpu/issues/299).
 
 ## Example ResourceSlices
 
@@ -76,11 +82,13 @@ spec:
         bool: true
       dra.cpu/numCPUs:
         int: 64
-      dra.cpu/numaNodeID:
+      resource.kubernetes.io/numaNode:
         int: 0
       dra.cpu/socketID:
         int: 0
       dra.net/numaNode:
+        int: 0
+      dra.cpu/numaNodeID:
         int: 0
       # Only populated if the driver is run with --expose-pcie-roots=true
       resource.kubernetes.io/pcieRoot:
@@ -97,11 +105,13 @@ spec:
         bool: true
       dra.cpu/numCPUs:
         int: 64
-      dra.cpu/numaNodeID:
+      resource.kubernetes.io/numaNode:
         int: 1
       dra.cpu/socketID:
         int: 0
       dra.net/numaNode:
+        int: 1
+      dra.cpu/numaNodeID:
         int: 1
       # Only populated if the driver is run with --expose-pcie-roots=true
       resource.kubernetes.io/pcieRoot:
@@ -141,13 +151,15 @@ spec:
         string: standard
       dra.cpu/cpuID:
         int: 1
-      dra.cpu/numaNodeID:
+      resource.kubernetes.io/numaNode:
         int: 0
       dra.cpu/smtEnabled:
         bool: true
       dra.cpu/socketID:
         int: 0
       dra.net/numaNode:
+        int: 0
+      dra.cpu/numaNodeID:
         int: 0
       # Only populated if the driver is run with --expose-pcie-roots=true
       resource.kubernetes.io/pcieRoot:
@@ -163,13 +175,15 @@ spec:
         string: standard
       dra.cpu/cpuID:
         int: 33
-      dra.cpu/numaNodeID:
+      resource.kubernetes.io/numaNode:
         int: 0
       dra.cpu/smtEnabled:
         bool: true
       dra.cpu/socketID:
         int: 0
       dra.net/numaNode:
+        int: 0
+      dra.cpu/numaNodeID:
         int: 0
       # Only populated if the driver is run with --expose-pcie-roots=true
       resource.kubernetes.io/pcieRoot:
@@ -237,7 +251,7 @@ spec:
             dra.cpu/cpu: "8"
         selectors:
         - cel:
-            expression: device.attributes["dra.cpu"].numaNodeID == 0
+            expression: device.attributes["resource.kubernetes.io"].numaNode == 0
 ```
 
 In `individual` mode, each CPU is its own device, so claims request a `count` of devices and
@@ -320,7 +334,7 @@ spec:
             dra.cpu/cpu: "8"
     constraints:
     - requests: ["cpus-a", "cpus-b"]
-      distinctAttribute: dra.cpu/numaNodeID
+      distinctAttribute: resource.kubernetes.io/numaNode
 ```
 
 `distinctAttribute` is gated by `DRAConsumableCapacity` — the same feature gate the default

--- a/docs/user/device-attributes.md
+++ b/docs/user/device-attributes.md
@@ -17,21 +17,32 @@ CPU group, `individual` one device per CPU.
 
 ### Grouped mode (default)
 
+#### Currently supported attributes
+
 | Attribute                         | Type    | Description                                                                                                    |
 | --------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
 | `resource.kubernetes.io/numaNode` | int     | Standard NUMA node of the group (published when grouping by NUMA node)                                         |
-| `dra.cpu/numaNodeID`              | int     | Legacy driver-specific NUMA node attribute (NUMA grouping)                                                     |
 | `dra.cpu/socketID`                | int     | CPU socket of the group (published when grouping by NUMA node or socket)                                       |
 | `dra.cpu/numCPUs`                 | int     | CPUs available in the group                                                                                    |
 | `dra.cpu/smtEnabled`              | bool    | Whether SMT/hyper-threading is enabled on the node                                                             |
-| `dra.net/numaNode`                | int     | Legacy cross-driver NUMA alignment attribute (NUMA grouping)                                                  |
 | `resource.kubernetes.io/pcieRoot` | strings | PCIe roots local to the group's CPUs; needs `--expose-pcie-roots` and the `DRAListTypeAttributes` feature gate |
+
+#### Legacy attributes (deprecated)
+
+These compatibility attributes will be removed in a future version:
+
+| Attribute            | Type | Description                                                    |
+| -------------------- | ---- | -------------------------------------------------------------- |
+| `dra.cpu/numaNodeID` | int  | Driver-specific NUMA node attribute (NUMA grouping)            |
+| `dra.net/numaNode`   | int  | Cross-driver NUMA alignment attribute (NUMA grouping)          |
 
 Grouped devices also expose the consumable capacity `dra.cpu/cpu` — the number of CPUs
 claimable from the group. With `groupBy: machine`, only `numCPUs`, `smtEnabled`, and — when
 `--expose-pcie-roots` is enabled — `resource.kubernetes.io/pcieRoot` are published.
 
 ### Individual mode
+
+#### Currently supported attributes
 
 | Attribute                         | Type    | Description                                                                                           |
 | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
@@ -40,11 +51,18 @@ claimable from the group. With `groupBy: machine`, only `numCPUs`, `smtEnabled`,
 | `dra.cpu/coreType`                | string  | `standard`, `p-core`, or `e-core`                                                                     |
 | `dra.cpu/cacheL3ID`               | int     | L3 (last-level/uncore) cache group                                                                    |
 | `resource.kubernetes.io/numaNode` | int     | Standard NUMA node                                                                                    |
-| `dra.cpu/numaNodeID`              | int     | Legacy driver-specific NUMA node attribute                                                            |
 | `dra.cpu/socketID`                | int     | CPU socket                                                                                            |
 | `dra.cpu/smtEnabled`              | bool    | Whether SMT/hyper-threading is enabled on the node                                                    |
-| `dra.net/numaNode`                | int     | Legacy cross-driver NUMA alignment attribute                                                          |
 | `resource.kubernetes.io/pcieRoot` | strings | PCIe roots local to the CPU; needs `--expose-pcie-roots` and the `DRAListTypeAttributes` feature gate |
+
+#### Legacy attributes (deprecated)
+
+These compatibility attributes will be removed in a future version:
+
+| Attribute            | Type | Description                           |
+| -------------------- | ---- | ------------------------------------- |
+| `dra.cpu/numaNodeID` | int  | Driver-specific NUMA node attribute   |
+| `dra.net/numaNode`   | int  | Cross-driver NUMA alignment attribute |
 
 `resource.kubernetes.io/pcieRoot` is intended for cross-driver co-location via
 `matchAttribute` — see [Feature Support](feature-support.md#exposing-pcie-roots) for details

--- a/docs/user/feature-support.md
+++ b/docs/user/feature-support.md
@@ -74,7 +74,7 @@ spec:
             dra.cpu/cpu: "10"
         selectors:
         - cel:
-            expression: device.attributes["dra.cpu"].numaNodeID == 0
+            expression: device.attributes["resource.kubernetes.io"].numaNode == 0
     - name: numa1-cpus
       exactly:
         deviceClassName: dra.cpu
@@ -83,7 +83,7 @@ spec:
             dra.cpu/cpu: "10"
         selectors:
         - cel:
-            expression: device.attributes["dra.cpu"].numaNodeID == 1
+            expression: device.attributes["resource.kubernetes.io"].numaNode == 1
 ```
 
 However, this is only a partial replacement of the corresponding CPU Manager option. The main problem of this approach is that it leaks assumptions about machine properties.
@@ -144,7 +144,7 @@ spec:
     attributes:
       dra.cpu/numCPUs:
         int: 31
-      dra.cpu/numaNodeID:
+      resource.kubernetes.io/numaNode:
         int: 0
       resource.kubernetes.io/pcieRoot:
         strings:
@@ -154,6 +154,8 @@ spec:
       dra.cpu/socketID:
         int: 0
       dra.net/numaNode:
+        int: 0
+      dra.cpu/numaNodeID:
         int: 0
     capacity:
       dra.cpu/cpu:

--- a/test/e2e/metadata_test.go
+++ b/test/e2e/metadata_test.go
@@ -33,6 +33,7 @@ import (
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/dynamic-resource-allocation/deviceattribute"
 )
 
 type metadataEntry struct {
@@ -165,7 +166,9 @@ var _ = ginkgo.Describe("Device Metadata", ginkgo.Ordered, func() {
 				expectIntAttr(dev.Attributes, "dra.cpu/cpuID")
 				expectIntAttr(dev.Attributes, "dra.cpu/coreID")
 				expectIntAttr(dev.Attributes, "dra.cpu/socketID")
+				expectIntAttr(dev.Attributes, string(deviceattribute.StandardDeviceAttributeNUMANode))
 				expectIntAttr(dev.Attributes, "dra.cpu/numaNodeID")
+				expectIntAttr(dev.Attributes, "dra.net/numaNode")
 				expectIntAttr(dev.Attributes, "dra.cpu/cacheL3ID")
 				expectStringAttr(dev.Attributes, "dra.cpu/coreType")
 				expectBoolAttr(dev.Attributes, "dra.cpu/smtEnabled")
@@ -177,7 +180,9 @@ var _ = ginkgo.Describe("Device Metadata", ginkgo.Ordered, func() {
 				case device.GROUP_BY_SOCKET:
 					expectIntAttr(dev.Attributes, "dra.cpu/socketID")
 				default: // NUMA node (default when groupBy is "" or "numanode")
+					expectIntAttr(dev.Attributes, string(deviceattribute.StandardDeviceAttributeNUMANode))
 					expectIntAttr(dev.Attributes, "dra.cpu/numaNodeID")
+					expectIntAttr(dev.Attributes, "dra.net/numaNode")
 					expectIntAttr(dev.Attributes, "dra.cpu/socketID")
 				}
 			}


### PR DESCRIPTION
## Summary

- Update user-facing examples to prefer resource.kubernetes.io/numaNode.
- Document dra.cpu/numaNodeID and dra.net/numaNode as deprecated compatibility attributes.
- Extend the metadata e2e test to assert the standard NUMA attribute.
- Keep publishing and testing the legacy attributes for compatibility.

This does not remove any attributes or change the removal timeline.

## Testing

- make lint
- go test ./pkg/device ./pkg/driver
- go test -run ^$ ./test/e2e
- go vet ./...

Related to #299