### PR TITLE
chore: cosmetic changes as follow up to #249

### DIFF
--- a/docs/user/device-attributes.md
+++ b/docs/user/device-attributes.md
@@ -31,10 +31,10 @@ CPU group, `individual` one device per CPU.
 
 These compatibility attributes will be removed in a future version:
 
-| Attribute            | Type | Description                                                    |
-| -------------------- | ---- | -------------------------------------------------------------- |
-| `dra.cpu/numaNodeID` | int  | Driver-specific NUMA node attribute (NUMA grouping)            |
-| `dra.net/numaNode`   | int  | Cross-driver NUMA alignment attribute (NUMA grouping)          |
+| Attribute            | Type | Description                                           |
+| -------------------- | ---- | ----------------------------------------------------- |
+| `dra.cpu/numaNodeID` | int  | Driver-specific NUMA node attribute (NUMA grouping)   |
+| `dra.net/numaNode`   | int  | Cross-driver NUMA alignment attribute (NUMA grouping) |
 
 Grouped devices also expose the consumable capacity `dra.cpu/cpu` — the number of CPUs
 claimable from the group. With `groupBy: machine`, only `numCPUs`, `smtEnabled`, and — when

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -899,12 +899,12 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 	}
 
 	testCases := []struct {
-		name               string
-		driver             *CPUDriver
-		claim              *resourceapi.ResourceClaim
-		expectAllocation   bool
-		expectedAllocation cpuset.CPUSet
-		expectedSharedCPUs cpuset.CPUSet
+		name                       string
+		driver                     *CPUDriver
+		claim                      *resourceapi.ResourceClaim
+		expectExistingAllocation   bool
+		expectedExistingAllocation cpuset.CPUSet
+		expectedSharedCPUs         cpuset.CPUSet
 	}{
 		{
 			// New claim: the reservation is removed again on failure so the
@@ -913,33 +913,31 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			name:               "individual mode new claim",
 			driver:             individualDriver(false),
 			claim:              individualClaim("cpudev2", "cpudev3"),
-			expectAllocation:   false,
 			expectedSharedCPUs: cpuset.New(0, 1, 2, 3),
 		},
 		{
 			// Existing claim: prepare reuses the already-committed allocation
 			// and never reserves/removes it, so it must remain untouched.
-			name:               "individual mode existing claim",
-			driver:             individualDriver(true),
-			claim:              individualClaim("cpudev0", "cpudev1"),
-			expectAllocation:   true,
-			expectedAllocation: existingCPUs,
-			expectedSharedCPUs: cpuset.New(2, 3),
+			name:                       "individual mode existing claim",
+			driver:                     individualDriver(true),
+			claim:                      individualClaim("cpudev0", "cpudev1"),
+			expectExistingAllocation:   true,
+			expectedExistingAllocation: existingCPUs,
+			expectedSharedCPUs:         cpuset.New(2, 3),
 		},
 		{
 			name:               "grouped mode new claim",
 			driver:             groupedDriver(false),
 			claim:              groupedClaim(),
-			expectAllocation:   false,
 			expectedSharedCPUs: cpuset.New(0, 1, 2, 3),
 		},
 		{
-			name:               "grouped mode existing claim",
-			driver:             groupedDriver(true),
-			claim:              groupedClaim(),
-			expectAllocation:   true,
-			expectedAllocation: existingCPUs,
-			expectedSharedCPUs: cpuset.New(2, 3),
+			name:                       "grouped mode existing claim",
+			driver:                     groupedDriver(true),
+			claim:                      groupedClaim(),
+			expectExistingAllocation:   true,
+			expectedExistingAllocation: existingCPUs,
+			expectedSharedCPUs:         cpuset.New(2, 3),
 		},
 	}
 
@@ -956,9 +954,9 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			require.Empty(t, mockCdiMgr.devices)
 
 			gotCPUs, ok := tc.driver.cpuAllocationStore.GetResourceClaimAllocation(claimUID)
-			require.Equal(t, tc.expectAllocation, ok)
-			if tc.expectAllocation {
-				require.True(t, tc.expectedAllocation.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedAllocation)
+			require.Equal(t, tc.expectExistingAllocation, ok)
+			if tc.expectExistingAllocation {
+				require.True(t, tc.expectedExistingAllocation.Equals(gotCPUs), "claim cpus: got %s, want %s", gotCPUs, tc.expectedExistingAllocation)
 			}
 			require.True(t, tc.expectedSharedCPUs.Equals(tc.driver.cpuAllocationStore.GetSharedCPUs()), "shared cpus: got %s, want %s", tc.driver.cpuAllocationStore.GetSharedCPUs(), tc.expectedSharedCPUs)
 		})

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -358,7 +358,6 @@ func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
 	// periodically (every healthResendInterval) resend device health so
 	// the kubelet's lease on it does not expire (see WatchHealthStatus in
 	// health.go)
-	cp.health.wg.Add(1)
 	go cp.healthResendLoop(ctx)
 
 	return asyncErr, nil
@@ -366,8 +365,7 @@ func (cp *CPUDriver) Start(ctx context.Context) (<-chan error, error) {
 
 // Stop stops the CPUDriver.
 func (cp *CPUDriver) Stop() {
-	close(cp.health.stopCh)
-	cp.health.wg.Wait()
+	cp.health.Stop()
 	cp.nriPlugin.Stop()
 	cp.draPlugin.Stop()
 }

--- a/pkg/driver/health.go
+++ b/pkg/driver/health.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -30,19 +31,26 @@ import (
 // WatchHealthStatus subscribers it is streamed to. mu protects devices,
 // clientsMu protects clients.
 type healthTracker struct {
-	mu        sync.RWMutex
-	devices   map[string]*deviceHealthEntry
-	clientsMu sync.RWMutex
-	clients   []chan kubeletplugin.DeviceHealthReport
-	stopCh    chan struct{}
-	wg        sync.WaitGroup
+	mu         sync.RWMutex
+	devices    map[string]*deviceHealthEntry
+	clientsMu  sync.RWMutex
+	clients    []chan kubeletplugin.DeviceHealthReport
+	stopCh     chan struct{}
+	resendDone chan struct{}
 }
 
 func newHealthTracker() healthTracker {
 	return healthTracker{
-		devices: make(map[string]*deviceHealthEntry),
-		stopCh:  make(chan struct{}),
+		devices:    make(map[string]*deviceHealthEntry),
+		stopCh:     make(chan struct{}),
+		resendDone: make(chan struct{}),
 	}
+}
+
+// Stop stops all health goroutines.
+func (h *healthTracker) Stop() {
+	close(h.stopCh)
+	<-h.resendDone
 }
 
 // healthResendInterval is how often the driver resends the full device
@@ -82,15 +90,14 @@ func (cp *CPUDriver) markDevicesHealth(logger logr.Logger, deviceNames []string,
 		}
 	}
 	if anyChanged {
-		cp.notifyHealthClients()
+		cp.health.notifyClients(cp.nodeName)
 	}
 }
 
 // buildHealthReport snapshots the health of every device this driver
-// manages. All devices are published under a single pool named after this
-// node (see PublishResources), so PoolName is always cp.nodeName.
-func (cp *CPUDriver) buildHealthReport() kubeletplugin.DeviceHealthReport {
-	h := &cp.health
+// manages. All devices are published under a single pool named nodeName
+// (see PublishResources).
+func (h *healthTracker) buildHealthReport(nodeName string) kubeletplugin.DeviceHealthReport {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
@@ -101,7 +108,7 @@ func (cp *CPUDriver) buildHealthReport() kubeletplugin.DeviceHealthReport {
 	devices := make([]kubeletplugin.DeviceHealth, 0, len(h.devices))
 	for name, entry := range h.devices {
 		devices = append(devices, kubeletplugin.DeviceHealth{
-			PoolName:           cp.nodeName,
+			PoolName:           nodeName,
 			DeviceName:         name,
 			Health:             entry.status,
 			LastUpdated:        time.Now(),
@@ -112,14 +119,13 @@ func (cp *CPUDriver) buildHealthReport() kubeletplugin.DeviceHealthReport {
 	return kubeletplugin.DeviceHealthReport{Devices: devices}
 }
 
-// notifyHealthClients pushes the current health snapshot to every active
+// notifyClients pushes the current health snapshot to every active
 // WatchHealthStatus subscriber. Sends are best-effort. A subscriber whose
 // channel is full will simply pick up the next periodic resend instead of
 // blocking the caller that triggered the change.
-func (cp *CPUDriver) notifyHealthClients() {
-	report := cp.buildHealthReport()
+func (h *healthTracker) notifyClients(nodeName string) {
+	report := h.buildHealthReport(nodeName)
 
-	h := &cp.health
 	h.clientsMu.RLock()
 	defer h.clientsMu.RUnlock()
 	for _, ch := range h.clients {
@@ -136,7 +142,7 @@ func (cp *CPUDriver) notifyHealthClients() {
 // deliberately does not resend on its own: a wedged driver should decay to
 // Unknown instead of being kept alive artificially.
 func (cp *CPUDriver) healthResendLoop(ctx context.Context) {
-	defer cp.health.wg.Done()
+	defer close(cp.health.resendDone)
 
 	ticker := time.NewTicker(healthResendInterval)
 	defer ticker.Stop()
@@ -148,7 +154,7 @@ func (cp *CPUDriver) healthResendLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			cp.notifyHealthClients()
+			cp.health.notifyClients(cp.nodeName)
 		}
 	}
 }
@@ -168,7 +174,7 @@ func (cp *CPUDriver) WatchHealthStatus(ctx context.Context, reports chan<- kubel
 	defer logger.Info("stopped watching device health updates")
 
 	// Buffered so a burst of markDevicesHealth calls doesn't block on a slow
-	// consumer. notifyHealthClients drops reports rather than blocking.
+	// consumer. notifyClients drops reports rather than blocking.
 	clientCh := make(chan kubeletplugin.DeviceHealthReport, healthClientBufferSize)
 	h := &cp.health
 	h.clientsMu.Lock()
@@ -178,11 +184,8 @@ func (cp *CPUDriver) WatchHealthStatus(ctx context.Context, reports chan<- kubel
 	defer func() {
 		h.clientsMu.Lock()
 		defer h.clientsMu.Unlock()
-		for i, ch := range h.clients {
-			if ch == clientCh {
-				h.clients = append(h.clients[:i], h.clients[i+1:]...)
-				break
-			}
+		if i := slices.Index(h.clients, clientCh); i != -1 {
+			h.clients = slices.Delete(h.clients, i, i+1)
 		}
 	}()
 
@@ -191,7 +194,7 @@ func (cp *CPUDriver) WatchHealthStatus(ctx context.Context, reports chan<- kubel
 		return nil
 	case <-h.stopCh:
 		return nil
-	case reports <- cp.buildHealthReport():
+	case reports <- h.buildHealthReport(cp.nodeName):
 	}
 
 	for {

--- a/pkg/driver/health_test.go
+++ b/pkg/driver/health_test.go
@@ -40,64 +40,63 @@ func newHealthTestDriver(deviceNames ...string) *CPUDriver {
 	return cp
 }
 
-func TestMarkDevicesHealth(t *testing.T) {
+func TestMarkDevicesHealthUnknownDeviceIsIgnored(t *testing.T) {
 	logger := testr.New(t)
+	cp := newHealthTestDriver("cpudev0")
+	cp.markDevicesHealth(logger, []string{"does-not-exist"}, kubeletplugin.HealthStatusUnhealthy, "boom")
+	_, ok := cp.health.devices["does-not-exist"]
+	assert.False(t, ok, "unknown device must not be added to the health map")
+}
 
-	t.Run("unknown device is ignored", func(t *testing.T) {
-		cp := newHealthTestDriver("cpudev0")
-		cp.markDevicesHealth(logger, []string{"does-not-exist"}, kubeletplugin.HealthStatusUnhealthy, "boom")
-		_, ok := cp.health.devices["does-not-exist"]
-		assert.False(t, ok, "unknown device must not be added to the health map")
-	})
+func TestMarkDevicesHealthKnownDeviceIsUpdatedAndChangeIsReported(t *testing.T) {
+	logger := testr.New(t)
+	cp := newHealthTestDriver("cpudev0")
+	clientCh := make(chan kubeletplugin.DeviceHealthReport, 1)
+	cp.health.clientsMu.Lock()
+	cp.health.clients = append(cp.health.clients, clientCh)
+	cp.health.clientsMu.Unlock()
 
-	t.Run("known device is updated and change is reported", func(t *testing.T) {
-		cp := newHealthTestDriver("cpudev0")
-		clientCh := make(chan kubeletplugin.DeviceHealthReport, 1)
-		cp.health.clientsMu.Lock()
-		cp.health.clients = append(cp.health.clients, clientCh)
-		cp.health.clientsMu.Unlock()
+	cp.markDevicesHealth(logger, []string{"cpudev0"}, kubeletplugin.HealthStatusUnhealthy, "cdi write failed")
 
-		cp.markDevicesHealth(logger, []string{"cpudev0"}, kubeletplugin.HealthStatusUnhealthy, "cdi write failed")
+	entry := cp.health.devices["cpudev0"]
+	require.Equal(t, kubeletplugin.HealthStatusUnhealthy, entry.status)
+	require.Equal(t, "cdi write failed", entry.message)
 
-		entry := cp.health.devices["cpudev0"]
-		require.Equal(t, kubeletplugin.HealthStatusUnhealthy, entry.status)
-		require.Equal(t, "cdi write failed", entry.message)
+	select {
+	case report := <-clientCh:
+		require.Len(t, report.Devices, 1)
+		assert.Equal(t, "cpudev0", report.Devices[0].DeviceName)
+		assert.Equal(t, testNodeName, report.Devices[0].PoolName)
+		assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health)
+		assert.Equal(t, "cdi write failed", report.Devices[0].Message)
+	default:
+		t.Fatal("expected a health report to be sent to the client channel")
+	}
+}
 
-		select {
-		case report := <-clientCh:
-			require.Len(t, report.Devices, 1)
-			assert.Equal(t, "cpudev0", report.Devices[0].DeviceName)
-			assert.Equal(t, testNodeName, report.Devices[0].PoolName)
-			assert.Equal(t, kubeletplugin.HealthStatusUnhealthy, report.Devices[0].Health)
-			assert.Equal(t, "cdi write failed", report.Devices[0].Message)
-		default:
-			t.Fatal("expected a health report to be sent to the client channel")
-		}
-	})
+func TestMarkDevicesHealthNoOpUpdateDoesNotNotifyClients(t *testing.T) {
+	logger := testr.New(t)
+	cp := newHealthTestDriver("cpudev0")
+	clientCh := make(chan kubeletplugin.DeviceHealthReport, 1)
+	cp.health.clientsMu.Lock()
+	cp.health.clients = append(cp.health.clients, clientCh)
+	cp.health.clientsMu.Unlock()
 
-	t.Run("no-op update does not notify clients", func(t *testing.T) {
-		cp := newHealthTestDriver("cpudev0")
-		clientCh := make(chan kubeletplugin.DeviceHealthReport, 1)
-		cp.health.clientsMu.Lock()
-		cp.health.clients = append(cp.health.clients, clientCh)
-		cp.health.clientsMu.Unlock()
+	// Same status and message as the initial state set by newHealthTestDriver.
+	cp.markDevicesHealth(logger, []string{"cpudev0"}, kubeletplugin.HealthStatusHealthy, "device initialized")
 
-		// Same status and message as the initial state set by newHealthTestDriver.
-		cp.markDevicesHealth(logger, []string{"cpudev0"}, kubeletplugin.HealthStatusHealthy, "device initialized")
-
-		select {
-		case <-clientCh:
-			t.Fatal("did not expect a health report for a no-op update")
-		default:
-		}
-	})
+	select {
+	case <-clientCh:
+		t.Fatal("did not expect a health report for a no-op update")
+	default:
+	}
 }
 
 func TestBuildHealthReport(t *testing.T) {
 	cp := newHealthTestDriver("cpudev0", "cpudev1")
 	cp.markDevicesHealth(testr.New(t), []string{"cpudev1"}, kubeletplugin.HealthStatusUnhealthy, "broken")
 
-	report := cp.buildHealthReport()
+	report := cp.health.buildHealthReport(cp.nodeName)
 	require.Len(t, report.Devices, 2)
 
 	byName := map[string]kubeletplugin.DeviceHealth{}
@@ -202,7 +201,6 @@ func TestHealthResendLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cp.health.wg.Add(1)
 	go cp.healthResendLoop(ctx)
 
 	select {
@@ -213,5 +211,5 @@ func TestHealthResendLoop(t *testing.T) {
 	}
 
 	cancel()
-	cp.health.wg.Wait()
+	<-cp.health.resendDone
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
This is a followup to #249 (WatchHealthStatus patch). It does not change any behavior and it only adds idiomatic improvements and tidies up channel usage for device health tracking.

#### Which issue(s) this PR is related to
https://github.com/kubernetes-sigs/dra-driver-cpu/issues/218

#### Special notes for reviewers
this is follow up as promised in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/249#issuecomment-5353376239 
#### Release note

<!--
If this change is not user-facing, write:
NONE
-->

```release-note
NONE
```

#### Documentation updates

<!--
List docs changed by this PR or write NONE.
Example:
- README updates
- Helm chart docs
- release process docs
-->
