### PR TITLE
helm: reject unknown top-level values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,7 @@ helm-schema: driverconfig-schema ## regenerate values.schema.json from values.ya
 	go run github.com/losisin/helm-values-schema-json/v2@v$(HELM_SCHEMA_VERSION) \
 		-f ${HELM_CHART}/values.yaml \
 		-o ${HELM_CHART}/values.schema.json \
+		--schema-root.additional-properties=false \
 		--use-helm-docs \
 		--bundle \
 		--bundle-root ${HELM_CHART} \

--- a/deployment/helm/dra-driver-cpu/values.schema.json
+++ b/deployment/helm/dra-driver-cpu/values.schema.json
@@ -76,6 +76,14 @@
       "description": "Override the full release name",
       "type": "string"
     },
+    "global": {
+      "description": "Global values shared between all subcharts",
+      "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "healthzPath": {
       "description": "Path for liveness and readiness probes",
       "type": "string"
@@ -210,6 +218,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "$defs": {
     "driverconfig.schema.json": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -141,6 +141,21 @@ hand exposes individual fields as explicit Helm values.
   single configuration mechanism. The driver logs the effective configuration at startup so you
   can verify which values are active.
 
+### Helm values validation and compatibility
+
+The chart rejects unknown top-level values, so a misspelled value name fails validation before
+anything is rendered rather than being ignored. Helm's reserved `global` table stays accepted,
+and values whose keys you pick, such as `podLabels` and `resources.limits`, are untouched.
+
+If a chart value is removed in a later release, an upgrade that carries the previous release's
+values forward can fail validation. Helm carries them when no new values are supplied at all,
+with `--reuse-values`, and with `--reset-then-reuse-values`. Validation runs before anything is
+rendered or applied, so the running release is untouched: drop the stale key and upgrade again,
+or pass `--reset-values` with the values you want in full.
+
+Values that only your own tooling reads belong outside the file you hand to Helm. They were
+never chart values, so they are rejected rather than ignored.
+
 ### Command-line flags
 
 **NOTE:** Command-line flags are kept mainly for backward compatibility. Prefer the


### PR DESCRIPTION
#### What type of PR is this?

<!-- Add one or more labels in the PR comments, for example:
/kind bug
/kind feature
/kind documentation
/kind cleanup
/kind deprecation
/kind regression
-->

/kind feature

#### What this PR does / why we need it

`args`, `image`, `rbac`, `resources` and the bundled `driverConfig` schema already refuse unknown keys. The values root was the one object left open, so a top-level value the chart never had was accepted and ignored, and the chart rendered as if it were unset. For `kubeletRootDir` that means the kubelet paths render at the default while the operator believes they were moved, which is #231 reached by a different route.

This is the Helm-side counterpart of what #213 did for the config file, where `applyMap` was changed to `DisallowUnknownFields()` so a misspelled key fails startup instead of silently falling back to defaults. @fmuyassarov noted there that Helm schema validation was the intended place to catch the same mistake at install time.

#### Which issue(s) this PR is related to

Fixes #308

#### Special notes for reviewers

**Root only, not `--no-additional-properties`.** That option closes every object that does not say otherwise. It would close the maps and item shapes whose keys come from Kubernetes rather than from this chart, among them `podLabels`, `podAnnotations`, `serviceAccount.annotations`, `nodeSelector`, `affinity`, `tolerations`, `resources.limits`, `extraVolumes` and `extraVolumeMounts`. It would also put a closed wrapper around the `driverConfig` `$ref`, whose real contract lives in the bundled definition. I generated both and diffed them before choosing.

**`global` needs no hand-written entry.** Helm gives a dependency its parent's values under that name, which a closed root would reject. The pinned generator adds the property itself once the root disallows additional properties, so Helm's reserved `global` table keeps working. The nine lines in `values.schema.json` are that plus the root setting; nothing in the schema is edited by hand.

That is the `global` table specifically, not every way a parent can wrap a chart. A parent using `condition: dra-driver-cpu.enabled` puts an `enabled` key in the subchart's values, and a closed root refuses it. Whether to expose `enabled` as a chart value is a separate decision, so this PR does not make one.

**No values are removed here.** `args.cpuDeviceMode`, `args.groupBy`, `args.reservedCPUs` and `args.hostnameOverride` stay valid with their current precedence.

**Dropped since the first revision.** An earlier version added a shell check under `hack/ci` that rendered the chart for a handful of values and asserted which ones the schema refuses. @fmuyassarov pointed out that matching on stderr text and juggling temp files is awkward to keep alive, and that helm-unittest is where those cases belong. It is gone, and with it the workflow trigger it needed, which leaves this PR at the generator flag, the regenerated schema and the documentation. I would rather put the cases back under helm-unittest than carry a second shape of them.

**Overlap with #282.** Both touch the `Makefile`, the generated `values.schema.json` and `docs/user/configuration.md`. I merged them locally: no conflicts, both sets of changes survive, the merged schema comes out identical to a fresh `make helm-schema`, and the chart checks pass on the merged tree.

#### Release note

```release-note
The Helm chart now rejects unknown top-level values. A misspelled value name fails validation before install or upgrade instead of being silently ignored. Existing deprecated chart values stay accepted, and Helm's reserved `global` values remain available for dependency use.
```

#### Documentation updates

- `docs/user/configuration.md` describes what the root now rejects, and what to do when an upgrade still carries a value the chart has since removed.
