### PR TITLE
Fix machine grouped CPU capacity over-reporting

### DIFF
--- a/pkg/device/builder.go
+++ b/pkg/device/builder.go
@@ -136,7 +136,10 @@ func groupedCPUDeviceInfos(groupBy string, topo *cpuinfo.CPUTopology, onlineCPUs
 			})
 		}
 	case GROUP_BY_MACHINE:
-		allocatableCPUs := onlineCPUs.Difference(reservedCPUs)
+		// Use the topology-validated CPU set. GetCPUInfos filters online CPUs
+		// whose topology is incomplete, and the allocation store is built from
+		// the same CPUDetails map.
+		allocatableCPUs := topo.CPUDetails.CPUs().Difference(reservedCPUs)
 		devices = append(devices, groupedCPUDeviceInfo{
 			name: CPUDeviceMachineGrouped,
 			cpus: allocatableCPUs,

--- a/pkg/device/builder_test.go
+++ b/pkg/device/builder_test.go
@@ -136,3 +136,22 @@ func TestDeviceBuilderNodeAllocatableResourceMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestMachineGroupedUsesTopologyValidatedCPUs(t *testing.T) {
+	topo := fakeTopology()
+	// CPU 4 is online but was omitted from CPUDetails because topology
+	// discovery could not validate it.
+	online := cpuset.New(0, 1, 2, 3, 4)
+
+	devices, _ := device.BuildGrouped(
+		logr.Discard(), device.GROUP_BY_MACHINE, topo, online, cpuset.New(),
+		store.NewPCIeRootMapper(), false,
+	)
+	require.Len(t, devices, 1)
+
+	capacity := devices[0].Capacity[resourceapi.QualifiedName(device.CPUResourceQualifiedName)]
+	require.Equal(t, int64(4), capacity.Value.Value())
+	numCPUs := devices[0].Attributes[device.AttributeNumCPUs]
+	require.NotNil(t, numCPUs.IntValue)
+	require.Equal(t, int64(4), *numCPUs.IntValue)
+}


### PR DESCRIPTION
Fixes #311

## What changed

Use the topology-validated `CPUDetails` CPU set when building the machine-grouped device. This keeps ResourceSlice capacity aligned with the allocation store when topology discovery skips an online CPU.

Add a regression test covering an online CPU missing from `CPUDetails`.
