### PR TITLE
metrics: record NRI callbacks duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,11 @@ LOCAL_PLATFORM?=linux/$(ARCH)
 DRACPU_E2E_CPU_DEVICE_MODE ?= grouped
 DRACPU_E2E_CPU_GROUP_BY ?= numanode
 DRACPU_E2E_RESERVED_CPUS ?= 0
+DRACPU_E2E_LABEL_FILTER ?=
+GINKGO_LABEL_FILTER_ARG :=
+ifneq ($(strip $(DRACPU_E2E_LABEL_FILTER)),)
+GINKGO_LABEL_FILTER_ARG := --ginkgo.label-filter="$(DRACPU_E2E_LABEL_FILTER)"
+endif
 # Set to "true" to have ci-kind-setup deploy the driver with the
 # publishNodeAllocatableResourceMapping driverConfig option.
 # Also requires a cluster (KIND_K8S_VERSION node image) with the
@@ -229,7 +234,7 @@ build-test-dracpuinfo: ## build helper to expose hardware info in the internal d
 	go build -v -o "$(OUT_DIR)/dracpuinfo" ./test/image/dracpuinfo
 
 test-e2e: ## run e2e test against an existing configured cluster
-	env DRACPU_E2E_TEST_IMAGE=$(IMAGE_TEST) DRACPU_E2E_RESERVED_CPUS=$(DRACPU_E2E_RESERVED_CPUS) go test -v ./test/e2e/ --ginkgo.v
+	env DRACPU_E2E_TEST_IMAGE=$(IMAGE_TEST) DRACPU_E2E_RESERVED_CPUS=$(DRACPU_E2E_RESERVED_CPUS) go test -v ./test/e2e/ --ginkgo.v $(GINKGO_LABEL_FILTER_ARG)
 
 test-e2e-kind: ci-kind-setup test-e2e ## run e2e test against a purpose-built kind cluster
 

--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -13,15 +13,16 @@ dracpu introspect metrics
 
 The command prints JSON metadata for custom `dra_cpu_*` metrics only. It does not include default Go runtime, process, or Prometheus client metrics.
 
-| Metric                                   | Type      | Labels   | Description                                                                                |
-| ---------------------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------ |
-| `dra_cpu_allocated_cpus`                 | Gauge     | none     | CPUs currently allocated to prepared resource claims.                                      |
-| `dra_cpu_available_cpus`                 | Gauge     | none     | CPUs still available for allocation after reserved and active claim CPUs are excluded.     |
-| `dra_cpu_reserved_cpus`                  | Gauge     | none     | CPUs excluded from DRA management by driver configuration.                                 |
-| `dra_cpu_resource_claims_active`         | Gauge     | none     | Resource claims currently recorded as active by the allocation store.                      |
-| `dra_cpu_prepare_claims_total`           | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success`, `error`, or `unknown`.   |
-| `dra_cpu_unprepare_claims_total`         | Counter   | `result` | Per-claim `UnprepareResourceClaims` results. `result` is `success`, `error`, or `unknown`. |
-| `dra_cpu_prepare_claim_duration_seconds` | Histogram | none     | Per-claim prepare latency in seconds.                                                      |
-| `dra_cpu_claim_allocated_cpus`           | Histogram | none     | CPUs allocated for each newly successful claim allocation.                                 |
+| Metric                                     | Type      | Labels   | Description                                                                                |
+| ------------------------------------------ | --------- | -------- | ------------------------------------------------------------------------------------------ |
+| `dra_cpu_allocated_cpus`                   | Gauge     | none     | CPUs currently allocated to prepared resource claims.                                      |
+| `dra_cpu_available_cpus`                   | Gauge     | none     | CPUs still available for allocation after reserved and active claim CPUs are excluded.     |
+| `dra_cpu_reserved_cpus`                    | Gauge     | none     | CPUs excluded from DRA management by driver configuration.                                 |
+| `dra_cpu_resource_claims_active`           | Gauge     | none     | Resource claims currently recorded as active by the allocation store.                      |
+| `dra_cpu_prepare_claims_total`             | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success`, `error`, or `unknown`.   |
+| `dra_cpu_unprepare_claims_total`           | Counter   | `result` | Per-claim `UnprepareResourceClaims` results. `result` is `success`, `error`, or `unknown`. |
+| `dra_cpu_prepare_claim_duration_seconds`   | Histogram | none     | Per-claim prepare latency in seconds.                                                      |
+| `dra_cpu_unprepare_claim_duration_seconds` | Histogram | none     | Per-claim unprepare latency in seconds.                                                    |
+| `dra_cpu_claim_allocated_cpus`             | Histogram | none     | CPUs allocated for each newly successful claim allocation.                                 |
 
 The custom metrics intentionally avoid labels for namespace, pod, claim, device, node, socket, NUMA node, group mode, and error reason. Those labels would either be high-cardinality or need more API design before becoming part of the driver's metric surface. Node identity should come from scrape target labels.

--- a/docs/user/metrics.md
+++ b/docs/user/metrics.md
@@ -13,16 +13,30 @@ dracpu introspect metrics
 
 The command prints JSON metadata for custom `dra_cpu_*` metrics only. It does not include default Go runtime, process, or Prometheus client metrics.
 
-| Metric                                     | Type      | Labels   | Description                                                                                |
-| ------------------------------------------ | --------- | -------- | ------------------------------------------------------------------------------------------ |
-| `dra_cpu_allocated_cpus`                   | Gauge     | none     | CPUs currently allocated to prepared resource claims.                                      |
-| `dra_cpu_available_cpus`                   | Gauge     | none     | CPUs still available for allocation after reserved and active claim CPUs are excluded.     |
-| `dra_cpu_reserved_cpus`                    | Gauge     | none     | CPUs excluded from DRA management by driver configuration.                                 |
-| `dra_cpu_resource_claims_active`           | Gauge     | none     | Resource claims currently recorded as active by the allocation store.                      |
-| `dra_cpu_prepare_claims_total`             | Counter   | `result` | Per-claim `PrepareResourceClaims` results. `result` is `success`, `error`, or `unknown`.   |
-| `dra_cpu_unprepare_claims_total`           | Counter   | `result` | Per-claim `UnprepareResourceClaims` results. `result` is `success`, `error`, or `unknown`. |
-| `dra_cpu_prepare_claim_duration_seconds`   | Histogram | none     | Per-claim prepare latency in seconds.                                                      |
-| `dra_cpu_unprepare_claim_duration_seconds` | Histogram | none     | Per-claim unprepare latency in seconds.                                                    |
-| `dra_cpu_claim_allocated_cpus`             | Histogram | none     | CPUs allocated for each newly successful claim allocation.                                 |
+| Metric                                          | Type      | Labels                          | Description                                                                                                                                    |
+| ----------------------------------------------- | --------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dra_cpu_allocated_cpus`                        | Gauge     | none                            | CPUs currently allocated to prepared resource claims.                                                                                          |
+| `dra_cpu_available_cpus`                        | Gauge     | none                            | CPUs still available for allocation after reserved and active claim CPUs are excluded.                                                         |
+| `dra_cpu_reserved_cpus`                         | Gauge     | none                            | CPUs excluded from DRA management by driver configuration.                                                                                     |
+| `dra_cpu_resource_claims_active`                | Gauge     | none                            | Resource claims currently recorded as active by the allocation store.                                                                          |
+| `dra_cpu_prepare_claims_total`                  | Counter   | `result`                        | Per-claim `PrepareResourceClaims` results. `result` is `success`, `error`, or `unknown`.                                                       |
+| `dra_cpu_unprepare_claims_total`                | Counter   | `result`                        | Per-claim `UnprepareResourceClaims` results. `result` is `success`, `error`, or `unknown`.                                                     |
+| `dra_cpu_prepare_claim_duration_seconds`        | Histogram | none                            | Per-claim prepare latency in seconds.                                                                                                          |
+| `dra_cpu_unprepare_claim_duration_seconds`      | Histogram | none                            | Per-claim unprepare latency in seconds.                                                                                                        |
+| `dra_cpu_claim_allocated_cpus`                  | Histogram | none                            | CPUs allocated for each newly successful claim allocation.                                                                                     |
+| `dra_cpu_nri_synchronize_duration_seconds`      | Histogram | `result`                        | Duration of the NRI `Synchronize` callback in seconds. `result` is `success` or `error`.                                                       |
+| `dra_cpu_nri_create_container_duration_seconds` | Histogram | `result`, `cpu_allocation_mode` | Duration of the NRI `CreateContainer` callback in seconds. `result` is `success` or `error`; `cpu_allocation_mode` is `shared` or `exclusive`. |
+| `dra_cpu_nri_stop_container_duration_seconds`   | Histogram | `result`, `cpu_allocation_mode` | Duration of the NRI `StopContainer` callback in seconds. `result` is `success` or `error`; `cpu_allocation_mode` is `shared` or `exclusive`.   |
+| `dra_cpu_nri_remove_container_duration_seconds` | Histogram | `result`, `cpu_allocation_mode` | Duration of the NRI `RemoveContainer` callback in seconds. `result` is `success` or `error`; `cpu_allocation_mode` is `shared` or `exclusive`. |
 
-The custom metrics intentionally avoid labels for namespace, pod, claim, device, node, socket, NUMA node, group mode, and error reason. Those labels would either be high-cardinality or need more API design before becoming part of the driver's metric surface. Node identity should come from scrape target labels.
+Note about `dra_cpu_nri_remove_container_duration_seconds`: due to how the driver is implemented and how it uses the NRI APIs, this metric reports
+cases on which the hook recovered an internal faulty state. The cleanup action should be carried at the `StopContainer` stage and the real work
+should be reflected in `dra_cpu_nri_stop_container_duration_seconds`.
+Note this is a current implementation detail which leaks in the metrics, and it is subject to change in the next releases.
+
+The custom metrics intentionally avoid labels for namespace, pod, claim, device, node, socket, NUMA node, group mode, and error reason. Those labels would either be
+high-cardinality or need more API design before becoming part of the driver's metric surface. Node identity should come from scrape target labels.
+
+The NRI callback histograms use bucket boundaries tailored to the NRI plugin request timeout.
+This serves both performance and reliability concerns, because the runtime close the plugin connection if a callback does not return within the configured
+request timeout (2 seconds by default).

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -342,13 +342,14 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 		// note kubeletplugin.NamespacedObject doesn't implement KMetadata
 		cLogger := logger.WithValues("claim", claim.String(), "claimUID", claim.UID)
 		cLogger.V(2).Info("unpreparing resource claim")
+		start := time.Now()
 		err := cp.unprepareResourceClaim(cLogger, claim)
 		result[claim.UID] = err
 		if err != nil {
 			cLogger.Error(err, "error unpreparing resources for claim")
-			cp.metrics.RecordUnprepare(cpumetrics.ResultError)
+			cp.metrics.RecordUnprepare(cpumetrics.ResultError, time.Since(start))
 		} else {
-			cp.metrics.RecordUnprepare(cpumetrics.ResultSuccess)
+			cp.metrics.RecordUnprepare(cpumetrics.ResultSuccess, time.Since(start))
 			cp.refreshAllocationMetrics()
 		}
 	}

--- a/pkg/driver/dra_hooks.go
+++ b/pkg/driver/dra_hooks.go
@@ -94,7 +94,7 @@ func (cp *CPUDriver) PrepareResourceClaims(ctx context.Context, claims []*resour
 		if result[claim.UID].Err != nil {
 			prepareResult = cpumetrics.ResultError
 		}
-		cp.metricsRecorder().RecordPrepare(prepareResult, time.Since(start))
+		cp.metrics.RecordPrepare(prepareResult, time.Since(start))
 	}
 	return result, nil
 }
@@ -211,7 +211,7 @@ func (cp *CPUDriver) prepareGroupedResourceClaim(logger logr.Logger, claim *reso
 		cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
 		return result
 	}
-	cp.metricsRecorder().RecordClaimAllocatedCPUs(cpuAssignment.Size())
+	cp.metrics.RecordClaimAllocatedCPUs(cpuAssignment.Size())
 	cp.refreshAllocationMetrics()
 	return result
 }
@@ -273,7 +273,7 @@ func (cp *CPUDriver) prepareResourceClaim(logger logr.Logger, claim *resourceapi
 		cp.cpuAllocationStore.RemoveResourceClaimAllocation(logger, claim.UID)
 		return result
 	}
-	cp.metricsRecorder().RecordClaimAllocatedCPUs(claimCPUSet.Size())
+	cp.metrics.RecordClaimAllocatedCPUs(claimCPUSet.Size())
 	cp.refreshAllocationMetrics()
 	return result
 }
@@ -346,33 +346,13 @@ func (cp *CPUDriver) UnprepareResourceClaims(ctx context.Context, claims []kubel
 		result[claim.UID] = err
 		if err != nil {
 			cLogger.Error(err, "error unpreparing resources for claim")
-			cp.metricsRecorder().RecordUnprepare(cpumetrics.ResultError)
+			cp.metrics.RecordUnprepare(cpumetrics.ResultError)
 		} else {
-			cp.metricsRecorder().RecordUnprepare(cpumetrics.ResultSuccess)
+			cp.metrics.RecordUnprepare(cpumetrics.ResultSuccess)
 			cp.refreshAllocationMetrics()
 		}
 	}
 	return result, nil
-}
-
-func (cp *CPUDriver) metricsRecorder() cpumetrics.Recorder {
-	if cp.metrics == nil {
-		return cpumetrics.Noop()
-	}
-	return cp.metrics
-}
-
-func (cp *CPUDriver) refreshAllocationMetrics() {
-	if cp.cpuAllocationStore == nil {
-		return
-	}
-	snapshot := cp.cpuAllocationStore.Snapshot()
-	cp.metricsRecorder().SetAllocationState(cpumetrics.AllocationState{
-		AllocatedCPUs:        snapshot.AllocatedCPUs,
-		AvailableCPUs:        snapshot.AvailableCPUs,
-		ReservedCPUs:         snapshot.ReservedCPUs,
-		ActiveResourceClaims: snapshot.ActiveResourceClaims,
-	})
 }
 
 func (cp *CPUDriver) unprepareResourceClaim(logger logr.Logger, claim kubeletplugin.NamespacedObject) error {

--- a/pkg/driver/dra_hooks_test.go
+++ b/pkg/driver/dra_hooks_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
 	devattr "github.com/kubernetes-sigs/dra-driver-cpu/pkg/device"
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -924,6 +925,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			},
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 			podConfigStore:     store.NewPodConfig(),
+			metrics:            cpumetrics.Noop(),
 		}
 		if withExistingAllocation {
 			requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
@@ -946,6 +948,7 @@ func TestPrepareResourceClaimsDoesNotCommitAllocationWhenCDIFails(t *testing.T) 
 			},
 			cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 			podConfigStore:     store.NewPodConfig(),
+			metrics:            cpumetrics.Noop(),
 		}
 		if withExistingAllocation {
 			requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, existingCPUs)
@@ -1590,6 +1593,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			cpuAllocationStore: cpuStore,
 			cdiMgr:             cdiMgr,
 			podConfigStore:     store.NewPodConfig(),
+			metrics:            cpumetrics.Noop(),
 		}, cpuStore, cdiMgr
 	}
 	makeNUMADriver := func(logger logr.Logger) (*CPUDriver, *store.CPUAllocation, *mockCdiMgr) {
@@ -1609,6 +1613,7 @@ func TestPrepareGroupedResourceClaimsRepeatedCalls(t *testing.T) {
 			cpuAllocationStore: cpuStore,
 			cdiMgr:             cdiMgr,
 			podConfigStore:     store.NewPodConfig(),
+			metrics:            cpumetrics.Noop(),
 		}, cpuStore, cdiMgr
 	}
 
@@ -1808,6 +1813,7 @@ func newDriverWithAllocatedClaim(t *testing.T, logger logr.Logger, claimUID type
 		cpuAllocationStore: cpuAllocationStore,
 		claimTracker:       claimTracker,
 		podConfigStore:     store.NewPodConfig(),
+		metrics:            cpumetrics.Noop(),
 	}, mockCdiMgr
 }
 
@@ -2196,6 +2202,7 @@ func createCPUDriverForTest(t *testing.T, groupBy string, cpuInfos []cpuinfo.CPU
 	t.Helper()
 	logger := testr.New(t)
 	driver := &CPUDriver{}
+	driver.metrics = cpumetrics.Noop()
 	driver.cdiMgr = cdiMgr
 	driver.driverName = testDriverName
 	driver.cpuDeviceMode = devattr.CPU_DEVICE_MODE_GROUPED

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -91,7 +91,7 @@ type CPUDriver struct {
 	claimTracker            *store.ClaimTracker
 	pcieRootMapper          *store.PCIeRootMapper
 	devicesPerResourceSlice int
-	metrics                 cpumetrics.Recorder
+	metrics                 Recorder
 	health                  healthTracker
 
 	kubeletRootDir string
@@ -144,7 +144,7 @@ type Config struct {
 	CPUDeviceMode    string
 	CPUDeviceGroupBy string
 	ExposePCIeRoots  bool
-	Metrics          cpumetrics.Recorder
+	Metrics          Recorder
 	// KubeletRootDir is the kubelet root directory, from which the registrar
 	// and plugin data directories are derived. Required and absolute:
 	// driverconfig.Resolve refuses an empty or relative value, and New takes it as

--- a/pkg/driver/metrics.go
+++ b/pkg/driver/metrics.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"time"
+
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
+)
+
+type Recorder interface {
+	SetAllocationState(cpumetrics.AllocationState)
+	RecordPrepare(result cpumetrics.Result, duration time.Duration)
+	RecordUnprepare(result cpumetrics.Result)
+	RecordClaimAllocatedCPUs(cpus int)
+}
+
+func (cp *CPUDriver) refreshAllocationMetrics() {
+	if cp.cpuAllocationStore == nil {
+		return
+	}
+	snapshot := cp.cpuAllocationStore.Snapshot()
+	cp.metrics.SetAllocationState(cpumetrics.AllocationState{
+		AllocatedCPUs:        snapshot.AllocatedCPUs,
+		AvailableCPUs:        snapshot.AvailableCPUs,
+		ReservedCPUs:         snapshot.ReservedCPUs,
+		ActiveResourceClaims: snapshot.ActiveResourceClaims,
+	})
+}

--- a/pkg/driver/metrics.go
+++ b/pkg/driver/metrics.go
@@ -25,7 +25,7 @@ import (
 type Recorder interface {
 	SetAllocationState(cpumetrics.AllocationState)
 	RecordPrepare(result cpumetrics.Result, duration time.Duration)
-	RecordUnprepare(result cpumetrics.Result)
+	RecordUnprepare(result cpumetrics.Result, duration time.Duration)
 	RecordClaimAllocatedCPUs(cpus int)
 }
 

--- a/pkg/driver/metrics.go
+++ b/pkg/driver/metrics.go
@@ -27,6 +27,10 @@ type Recorder interface {
 	RecordPrepare(result cpumetrics.Result, duration time.Duration)
 	RecordUnprepare(result cpumetrics.Result, duration time.Duration)
 	RecordClaimAllocatedCPUs(cpus int)
+	RecordNRISynchronize(err error, elapsed time.Duration)
+	RecordNRICreateContainer(err error, claimCount int, elapsed time.Duration)
+	RecordNRIStopContainer(err error, claimCount int, elapsed time.Duration)
+	RecordNRIRemoveContainer(err error, claimCount int, elapsed time.Duration)
 }
 
 func (cp *CPUDriver) refreshAllocationMetrics() {

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -216,4 +216,5 @@ func TestMetricsUnprepareResults(t *testing.T) {
 	require.NoError(t, err)
 	require.Error(t, unprepared["claim-error"])
 	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultError.String()}))
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_unprepare_claim_duration_seconds", nil))
 }

--- a/pkg/driver/metrics_test.go
+++ b/pkg/driver/metrics_test.go
@@ -67,6 +67,44 @@ func newMetricsTestDriver(t *testing.T) (*CPUDriver, *prometheus.Registry) {
 	return driver, reg
 }
 
+type workload struct {
+	claims []*resourceapi.ResourceClaim
+	pod    *api.PodSandbox
+	ctrs   []*api.Container
+}
+
+// keep these physically close to newMetricsTestDeiver because of the hidden
+// dependency on the machine topology we use to define the minimal test workloads.
+var minimalWorkloads = []workload{
+	{
+		claims: []*resourceapi.ResourceClaim{
+			individualMetricsClaim(types.UID("app-0"), "cpudev1"),
+		},
+		pod: &api.PodSandbox{Id: "sandbox-0", Uid: "pod-uid-0", Name: "pod-0"},
+		ctrs: []*api.Container{
+			{
+				Id: "container-0", PodSandboxId: "sandbox-0", Name: "app",
+				Env: []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, "app-0", "1")},
+			},
+		},
+	},
+	{
+		claims: []*resourceapi.ResourceClaim{
+			individualMetricsClaim(types.UID("app-1"), "cpudev2", "cpudev3"),
+		},
+		pod: &api.PodSandbox{Id: "sandbox-1", Uid: "pod-uid-1", Name: "pod-1"},
+		ctrs: []*api.Container{
+			{
+				Id: "container-1", PodSandboxId: "sandbox-1", Name: "app-1",
+				Env: []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, "app-1", "2,3")},
+			},
+			{
+				Id: "sidecar-1", PodSandboxId: "sandbox-1", Name: "sidecar-1",
+			},
+		},
+	},
+}
+
 func individualMetricsClaim(uid types.UID, devices ...string) *resourceapi.ResourceClaim {
 	results := make([]resourceapi.DeviceRequestAllocationResult, 0, len(devices))
 	for _, device := range devices {
@@ -217,4 +255,197 @@ func TestMetricsUnprepareResults(t *testing.T) {
 	require.Error(t, unprepared["claim-error"])
 	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_unprepare_claims_total", map[string]string{"result": cpumetrics.ResultError.String()}))
 	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_unprepare_claim_duration_seconds", nil))
+}
+
+func TestMetricsNRISynchronizeSuccess(t *testing.T) {
+	driver, reg := newMetricsTestDriver(t)
+	driver.cdiMgr = newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+		"app-0": cpuset.New(1),
+		"app-1": cpuset.New(2, 3),
+	})
+
+	pods := []*api.PodSandbox{
+		{Id: "sandbox-0", Uid: "pod-uid-0", Name: "pod-0"},
+		{Id: "sandbox-1", Uid: "pod-uid-1", Name: "pod-1"},
+	}
+	containers := []*api.Container{
+		{
+			Id: "container-0", PodSandboxId: "sandbox-0", Name: "app",
+			Env: []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, "app-0", "1")},
+		},
+		{
+			Id: "container-1", PodSandboxId: "sandbox-1", Name: "app-1",
+			Env: []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, "app-1", "2,3")},
+		},
+		{
+			Id: "sidecar-1", PodSandboxId: "sandbox-1", Name: "sidecar-1",
+		},
+	}
+	_, err := driver.Synchronize(context.Background(), pods, containers)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_nri_synchronize_duration_seconds", map[string]string{"result": cpumetrics.ResultSuccess.String()}))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_synchronize_duration_seconds", map[string]string{"result": cpumetrics.ResultError.String()}))
+}
+
+func TestMetricsNRISynchronizeFailure(t *testing.T) {
+	driver, reg := newMetricsTestDriver(t)
+	// intentionally exhausting the shared pool CPUs is both the simplest and
+	// a realistic scenario to trigger and verify a Synchronize failure.
+	driver.cdiMgr = newMockCdiMgrWithAllocations(map[types.UID]cpuset.CPUSet{
+		"app-0": cpuset.New(0, 1),
+		"app-1": cpuset.New(2, 3),
+	})
+
+	pods := []*api.PodSandbox{
+		{Id: "sandbox-0", Uid: "pod-uid-0", Name: "pod-0"},
+		{Id: "sandbox-1", Uid: "pod-uid-1", Name: "pod-1"},
+	}
+	containers := []*api.Container{
+		{
+			Id: "container-0", PodSandboxId: "sandbox-0", Name: "app",
+			Env: []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, "app-0", "0,1")},
+		},
+		{
+			Id: "container-1", PodSandboxId: "sandbox-1", Name: "app-1",
+			Env: []string{fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, "app-1", "2,3")},
+		},
+		{
+			Id: "sidecar-1", PodSandboxId: "sandbox-1", Name: "sidecar-1",
+		},
+	}
+	_, err := driver.Synchronize(context.Background(), pods, containers)
+	require.Error(t, err)
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_synchronize_duration_seconds", map[string]string{"result": cpumetrics.ResultSuccess.String()}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_nri_synchronize_duration_seconds", map[string]string{"result": cpumetrics.ResultError.String()}))
+}
+
+func TestMetricsNRICreateContainerSuccess(t *testing.T) {
+	driver, reg := newMetricsTestDriver(t)
+
+	for _, workload := range minimalWorkloads {
+		_, err := driver.PrepareResourceClaims(context.Background(), workload.claims)
+		require.NoError(t, err)
+
+		for _, ctr := range workload.ctrs {
+			_, _, err := driver.CreateContainer(context.Background(), workload.pod, ctr)
+			require.NoError(t, err)
+		}
+	}
+	for _, alloc := range []cpumetrics.CPUAllocation{cpumetrics.CPUAllocationExclusive, cpumetrics.CPUAllocationShared} {
+		labels := map[string]string{
+			"result":              cpumetrics.ResultError.String(),
+			"cpu_allocation_mode": alloc.String(),
+		}
+		require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_create_container_duration_seconds", labels))
+	}
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_nri_create_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationExclusive.String(),
+	}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_nri_create_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationShared.String(),
+	}))
+}
+
+func TestMetricsNRICreateContainerFailure(t *testing.T) {
+	// one of the simplest failure model is intentionally skip to prepare claims
+	driver, reg := newMetricsTestDriver(t)
+
+	for _, workload := range minimalWorkloads {
+		for _, ctr := range workload.ctrs {
+			_, _, err := driver.CreateContainer(context.Background(), workload.pod, ctr)
+			if len(ctr.Env) > 0 { // crude proxy for "expects exclusive CPUs"
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		}
+	}
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_create_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationExclusive.String(),
+	}))
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_nri_create_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultError.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationExclusive.String(),
+	}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_nri_create_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationShared.String(),
+	}))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_create_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultError.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationShared.String(),
+	}))
+}
+
+func TestMetricsNRIStopContainer(t *testing.T) {
+	// we abuse the fact StopContainer can't fail (nor it should, in the current code shape)
+	driver, reg := newMetricsTestDriver(t)
+
+	for _, workload := range minimalWorkloads {
+		_, err := driver.PrepareResourceClaims(context.Background(), workload.claims)
+		require.NoError(t, err)
+
+		for _, ctr := range workload.ctrs {
+			// necessary prep to make sure the accounting is correct
+			_, _, err := driver.CreateContainer(context.Background(), workload.pod, ctr)
+			require.NoError(t, err)
+
+			_, err = driver.StopContainer(context.Background(), workload.pod, ctr)
+			require.NoError(t, err)
+		}
+	}
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_nri_stop_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationExclusive.String(),
+	}))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_stop_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultError.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationExclusive.String(),
+	}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_nri_stop_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationShared.String(),
+	}))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_stop_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultError.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationShared.String(),
+	}))
+}
+
+func TestMetricsNRIRemoveContainer(t *testing.T) {
+	// we abuse the fact RemoveContainer can't fail (nor it should, in the current code shape)
+	driver, reg := newMetricsTestDriver(t)
+
+	for _, workload := range minimalWorkloads {
+		_, err := driver.PrepareResourceClaims(context.Background(), workload.claims)
+		require.NoError(t, err)
+
+		for _, ctr := range workload.ctrs {
+			// necessary prep to make sure the accounting is correct
+			_, _, err := driver.CreateContainer(context.Background(), workload.pod, ctr)
+			require.NoError(t, err)
+
+			err = driver.RemoveContainer(context.Background(), workload.pod, ctr)
+			require.NoError(t, err)
+		}
+	}
+	require.Equal(t, float64(2), metricValue(t, reg, "dra_cpu_nri_remove_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationExclusive.String(),
+	}))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_remove_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultError.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationExclusive.String(),
+	}))
+	require.Equal(t, float64(1), metricValue(t, reg, "dra_cpu_nri_remove_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultSuccess.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationShared.String(),
+	}))
+	require.Equal(t, float64(0), metricValue(t, reg, "dra_cpu_nri_remove_container_duration_seconds", map[string]string{
+		"result":              cpumetrics.ResultError.String(),
+		"cpu_allocation_mode": cpumetrics.CPUAllocationShared.String(),
+	}))
 }

--- a/pkg/driver/nri_hooks.go
+++ b/pkg/driver/nri_hooks.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/containerd/nri/pkg/api"
 	"github.com/go-logr/logr"
@@ -30,12 +31,14 @@ import (
 )
 
 // Synchronize is called by the NRI to synchronize the state of the driver during bootstrap.
-func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) ([]*api.ContainerUpdate, error) {
+func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, containers []*api.Container) (rupdates []*api.ContainerUpdate, rerr error) {
+	startTime := time.Now()
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen))
-
 	// this happens once at startup and it's critical enough that we always want to see it.
 	logger.Info("begin: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
 	defer logger.Info("end: synchronize state with the runtime", "numPods", len(pods), "numContainers", len(containers))
+
+	defer func() { cp.metrics.RecordNRISynchronize(rerr, time.Since(startTime)) }()
 
 	cpuAllocationStore := store.NewCPUAllocation(cp.topology.cpuTopology, cp.topology.reservedCPUs)
 	podConfigStore := store.NewPodConfig()
@@ -114,6 +117,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 				containerUpdates = append(containerUpdates, guaranteedUpdate)
 			}
 			podConfigStore.SetContainerState(types.UID(pod.GetUid()), state)
+			cLogger.V(6).Info("set container state", "claims", len(claimUIDs))
 		}
 	}
 
@@ -130,6 +134,7 @@ func (cp *CPUDriver) Synchronize(ctx context.Context, pods []*api.PodSandbox, co
 		return nil, err
 	}
 	containerUpdates = append(containerUpdates, sharedContainerUpdates...)
+	logger.V(6).Info("synchronization complete", "updatesCount", len(containerUpdates))
 	return containerUpdates, nil
 }
 
@@ -209,7 +214,9 @@ func (cp *CPUDriver) getSharedContainerUpdates(logger logr.Logger, excludeID typ
 }
 
 // CreateContainer handles container creation requests from the NRI.
-func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (radjust *api.ContainerAdjustment, rupdates []*api.ContainerUpdate, rerr error) {
+	startTime := time.Now()
+
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: CreateContainer")
 	defer logger.V(2).Info("end: CreateContainer")
@@ -217,16 +224,19 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 	adjust := &api.ContainerAdjustment{}
 	var updates []*api.ContainerUpdate
 
+	claimCount := -1
 	claimAllocations, err := parseDRAEnvToClaimAllocations(logger, ctr.Env)
+	defer func() { cp.metrics.RecordNRICreateContainer(rerr, claimCount, time.Since(startTime)) }()
 	if err != nil {
 		logger.Error(err, "error parsing DRA env for container")
 		return nil, nil, err
 	}
+	claimCount = len(claimAllocations)
 
 	containerId := types.UID(ctr.GetId())
 	podUID := types.UID(pod.GetUid())
 
-	if len(claimAllocations) == 0 {
+	if claimCount == 0 {
 		// This is a shared container.
 		sharedCPUs := cp.cpuAllocationStore.GetSharedCPUs()
 		if sharedCPUs.IsEmpty() && !cp.cpuAllocationStore.GetPreparedCPUs().IsEmpty() {
@@ -286,21 +296,28 @@ func (cp *CPUDriver) CreateContainer(ctx context.Context, pod *api.PodSandbox, c
 //   - UnprepareResourceClaims (DRA) is the authoritative release point for the allocation and owner.
 //   - Synchronize (NRI, on restart) rebuilds the stores from the running containers' CDI env.
 func (cp *CPUDriver) StopContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+	startTime := time.Now()
+
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: StopContainer")
 	defer logger.V(2).Info("end: StopContainer")
 
 	updates := []*api.ContainerUpdate{}
-	_, removed := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName(), types.UID(ctr.GetId()))
+	claimUIDs, removed := cp.podConfigStore.RemoveContainerState(types.UID(pod.GetUid()), ctr.GetName(), types.UID(ctr.GetId()))
 	if !removed {
 		logger.V(2).Info("ignoring stale or unknown StopContainer event")
 		return updates, nil
 	}
+
+	// leverage the fact the hook can't fail in our current design
+	cp.metrics.RecordNRIStopContainer(nil, len(claimUIDs), time.Since(startTime))
 	return updates, nil
 }
 
 // RemoveContainer handles container removal requests from the NRI.
 func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
+	startTime := time.Now()
+
 	_, logger := ctxlog.WithValues(ctx, "opID", generateShortID(opIDLen), "pod", ctxlog.KObj(pod), "podUID", pod.Uid, "container", ctr.Name, "containerID", ctr.Id)
 	logger.V(2).Info("begin: RemoveContainer")
 	defer logger.V(2).Info("end: RemoveContainer")
@@ -319,5 +336,10 @@ func (cp *CPUDriver) RemoveContainer(ctx context.Context, pod *api.PodSandbox, c
 			logger.Info("RemoveContainer spurious updates needed (unexpected, please file a bug)", "updates", updates)
 		}
 	}
+
+	// leverage the fact the hook can't fail in our current design
+	// **NOTE** because of the flow (see comment before StopContainer) this metric becomes a signal
+	// we leaked state and StopContainer didn't clean up properly.
+	cp.metrics.RecordNRIRemoveContainer(nil, len(claimUIDs), time.Since(startTime))
 	return nil
 }

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/nri/pkg/api"
 	"github.com/go-logr/logr/testr"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/cpuinfo"
+	cpumetrics "github.com/kubernetes-sigs/dra-driver-cpu/pkg/metrics"
 	"github.com/kubernetes-sigs/dra-driver-cpu/pkg/store"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -523,6 +524,7 @@ func TestNRISynchronize(t *testing.T) {
 					claimTracker:       store.NewClaimTracker(),
 					cdiMgr:             newMockCdiMgr(),
 					topology:           deviceTopology{cpuTopology: topo},
+					metrics:            cpumetrics.Noop(),
 				}
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState("stale-ctr", "stale-id", types.UID("stale-claim")))
 				return driver
@@ -541,6 +543,7 @@ func TestNRISynchronize(t *testing.T) {
 					"claim-A": cpuset.New(0, 1),
 				}),
 				topology: deviceTopology{cpuTopology: topo},
+				metrics:  cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -572,6 +575,7 @@ func TestNRISynchronize(t *testing.T) {
 				claimTracker:       store.NewClaimTracker(),
 				cdiMgr:             newMockCdiMgr(),
 				topology:           deviceTopology{cpuTopology: topo},
+				metrics:            cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -599,6 +603,7 @@ func TestNRISynchronize(t *testing.T) {
 					"claim-full": allCPUs,
 				}),
 				topology: deviceTopology{cpuTopology: topo},
+				metrics:  cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -619,6 +624,7 @@ func TestNRISynchronize(t *testing.T) {
 					"claim-B": cpuset.New(2, 3),
 				}),
 				topology: deviceTopology{cpuTopology: topo},
+				metrics:  cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -648,6 +654,7 @@ func TestNRISynchronize(t *testing.T) {
 					"claim-B": cpuset.New(2, 3),
 				}),
 				topology: deviceTopology{cpuTopology: topo},
+				metrics:  cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -671,6 +678,7 @@ func TestNRISynchronize(t *testing.T) {
 					"claim-A": cpuset.New(0, 1),
 				}),
 				topology: deviceTopology{cpuTopology: topo},
+				metrics:  cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -699,6 +707,7 @@ func TestNRISynchronize(t *testing.T) {
 					claimTracker:       store.NewClaimTracker(),
 					cdiMgr:             cdiMgr,
 					topology:           deviceTopology{cpuTopology: topo},
+					metrics:            cpumetrics.Noop(),
 				}
 			}(),
 			runtimePods: []*api.PodSandbox{pod1},
@@ -723,6 +732,7 @@ func TestNRISynchronize(t *testing.T) {
 					"claim-B": cpuset.New(2, 3),
 				}),
 				topology: deviceTopology{cpuTopology: topo},
+				metrics:  cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1, pod2},
 			runtimeCtrs: []*api.Container{
@@ -751,6 +761,7 @@ func TestNRISynchronize(t *testing.T) {
 					"claim-A": cpuset.New(2, 3),
 				}),
 				topology: deviceTopology{cpuTopology: topo},
+				metrics:  cpumetrics.Noop(),
 			},
 			runtimePods: []*api.PodSandbox{pod1},
 			runtimeCtrs: []*api.Container{
@@ -809,6 +820,7 @@ func TestStopContainerKeepsClaimOutOfSharedPoolUntilUnprepare(t *testing.T) {
 		cpuAllocationStore: cpuAllocationStore,
 		claimTracker:       store.NewClaimTracker(),
 		topology:           deviceTopology{cpuTopology: topo},
+		metrics:            cpumetrics.Noop(),
 	}
 	driver.cdiMgr.(*mockCdiMgr).devices[getCDIDeviceName(claimUID)] = fmt.Sprintf("%s_%s=%s", cdiEnvVarPrefix, claimUID, claimedCPUs.String())
 	_, err := driver.claimTracker.SetOwner(logger, types.UID(guaranteedPod.Uid), guaranteedCtr.Name, claimUID)

--- a/pkg/driver/nri_hooks_test.go
+++ b/pkg/driver/nri_hooks_test.go
@@ -298,6 +298,7 @@ func TestCreateContainer(t *testing.T) {
 				podConfigStore:     tc.podConfigStore,
 				cpuAllocationStore: tc.cpuAllocationStore,
 				claimTracker:       tc.claimTracker,
+				metrics:            cpumetrics.Noop(),
 			}
 			adjust, updates, err := driver.CreateContainer(context.Background(), pod, tc.container)
 			if tc.expectedErrorContains != "" {
@@ -344,6 +345,7 @@ func TestStopContainer(t *testing.T) {
 					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 					claimTracker:       store.NewClaimTracker(),
 					topology:           deviceTopology{cpuTopology: topo},
+					metrics:            cpumetrics.Noop(),
 				}
 				claimUID := types.UID("claim-uid-1")
 				requirePreparedResourceClaim(t, logger, driver.cpuAllocationStore, claimUID, cpuset.New(0, 1))
@@ -360,6 +362,7 @@ func TestStopContainer(t *testing.T) {
 					cpuAllocationStore: store.NewCPUAllocation(topo, cpuset.New()),
 					claimTracker:       store.NewClaimTracker(),
 					topology:           deviceTopology{cpuTopology: topo},
+					metrics:            cpumetrics.Noop(),
 				}
 				driver.podConfigStore.SetContainerState(types.UID(pod1.Uid), store.NewContainerState(ctr1.Name, types.UID(ctr1.Id)))
 				driver.podConfigStore.SetContainerState(types.UID(pod2.Uid), store.NewContainerState(ctr2.Name, types.UID(ctr2.Id)))
@@ -396,6 +399,7 @@ func TestGuaranteedContainerRestartWithoutReprepare(t *testing.T) {
 		cpuAllocationStore: cpuStore,
 		claimTracker:       store.NewClaimTracker(),
 		topology:           deviceTopology{cpuTopology: topo},
+		metrics:            cpumetrics.Noop(),
 	}
 	driver.podConfigStore.SetContainerState("shared-pod", store.NewContainerState("shared", "shared-container"))
 
@@ -474,6 +478,7 @@ func TestGuaranteedContainerRestartNotBlockedByEmptySharedPool(t *testing.T) {
 		cpuAllocationStore: cpuStore,
 		claimTracker:       claimTracker,
 		topology:           deviceTopology{cpuTopology: topo},
+		metrics:            cpumetrics.Noop(),
 	}
 	driver.podConfigStore.SetContainerState("shared-pod", store.NewContainerState("shared", "shared-container"))
 	container := &api.Container{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,10 +71,11 @@ type Metrics struct {
 	availableCPUs        prometheus.Gauge
 	reservedCPUs         prometheus.Gauge
 	activeResourceClaims prometheus.Gauge
-	prepareClaims        *prometheus.CounterVec
-	unprepareClaims      *prometheus.CounterVec
-	prepareClaimDuration prometheus.Histogram
-	claimAllocatedCPUs   prometheus.Histogram
+	prepareClaims          *prometheus.CounterVec
+	unprepareClaims        *prometheus.CounterVec
+	prepareClaimDuration   prometheus.Histogram
+	unprepareClaimDuration prometheus.Histogram
+	claimAllocatedCPUs     prometheus.Histogram
 }
 
 type metricKind string
@@ -132,6 +133,12 @@ var (
 		help:    "Duration of per-claim prepare operations in seconds.",
 		buckets: prometheus.DefBuckets,
 	}
+	unprepareClaimDurationSpec = metricSpec{
+		name:    "dra_cpu_unprepare_claim_duration_seconds",
+		kind:    metricHistogram,
+		help:    "Duration of per-claim unprepare operations in seconds.",
+		buckets: prometheus.DefBuckets,
+	}
 	claimAllocatedCPUsSpec = metricSpec{
 		name:    "dra_cpu_claim_allocated_cpus",
 		kind:    metricHistogram,
@@ -148,6 +155,7 @@ var metricSpecs = []metricSpec{
 	prepareClaimsSpec,
 	unprepareClaimsSpec,
 	prepareClaimDurationSpec,
+	unprepareClaimDurationSpec,
 	claimAllocatedCPUsSpec,
 }
 
@@ -180,14 +188,15 @@ func New(reg prometheus.Registerer) *Metrics {
 	}
 
 	m := &Metrics{
-		allocatedCPUs:        newGauge(allocatedCPUsSpec),
-		availableCPUs:        newGauge(availableCPUsSpec),
-		reservedCPUs:         newGauge(reservedCPUsSpec),
-		activeResourceClaims: newGauge(activeResourceClaimsSpec),
-		prepareClaims:        newCounterVec(prepareClaimsSpec),
-		unprepareClaims:      newCounterVec(unprepareClaimsSpec),
-		prepareClaimDuration: newHistogram(prepareClaimDurationSpec),
-		claimAllocatedCPUs:   newHistogram(claimAllocatedCPUsSpec),
+		allocatedCPUs:          newGauge(allocatedCPUsSpec),
+		availableCPUs:          newGauge(availableCPUsSpec),
+		reservedCPUs:           newGauge(reservedCPUsSpec),
+		activeResourceClaims:   newGauge(activeResourceClaimsSpec),
+		prepareClaims:          newCounterVec(prepareClaimsSpec),
+		unprepareClaims:        newCounterVec(unprepareClaimsSpec),
+		prepareClaimDuration:   newHistogram(prepareClaimDurationSpec),
+		unprepareClaimDuration: newHistogram(unprepareClaimDurationSpec),
+		claimAllocatedCPUs:     newHistogram(claimAllocatedCPUsSpec),
 	}
 
 	reg.MustRegister(
@@ -198,6 +207,7 @@ func New(reg prometheus.Registerer) *Metrics {
 		m.prepareClaims,
 		m.unprepareClaims,
 		m.prepareClaimDuration,
+		m.unprepareClaimDuration,
 		m.claimAllocatedCPUs,
 	)
 	for _, result := range []Result{ResultSuccess, ResultError, ResultUnknown} {
@@ -241,8 +251,9 @@ func (m *Metrics) RecordPrepare(result Result, duration time.Duration) {
 	m.prepareClaimDuration.Observe(duration.Seconds())
 }
 
-func (m *Metrics) RecordUnprepare(result Result) {
+func (m *Metrics) RecordUnprepare(result Result, duration time.Duration) {
 	m.unprepareClaims.WithLabelValues(result.String()).Inc()
+	m.unprepareClaimDuration.Observe(duration.Seconds())
 }
 
 func (m *Metrics) RecordClaimAllocatedCPUs(cpus int) {
@@ -256,7 +267,7 @@ func Noop() noopRecorder {
 	return noopRecorder{}
 }
 
-func (noopRecorder) SetAllocationState(AllocationState)  {}
-func (noopRecorder) RecordPrepare(Result, time.Duration) {}
-func (noopRecorder) RecordUnprepare(Result)              {}
-func (noopRecorder) RecordClaimAllocatedCPUs(int)        {}
+func (noopRecorder) SetAllocationState(AllocationState)    {}
+func (noopRecorder) RecordPrepare(Result, time.Duration)   {}
+func (noopRecorder) RecordUnprepare(Result, time.Duration) {}
+func (noopRecorder) RecordClaimAllocatedCPUs(int)          {}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -65,14 +65,6 @@ type AllocationState struct {
 	ActiveResourceClaims int
 }
 
-// Recorder records driver metrics.
-type Recorder interface {
-	SetAllocationState(AllocationState)
-	RecordPrepare(result Result, duration time.Duration)
-	RecordUnprepare(result Result)
-	RecordClaimAllocatedCPUs(cpus int)
-}
-
 // Metrics owns all custom Prometheus collectors for the CPU driver.
 type Metrics struct {
 	allocatedCPUs        prometheus.Gauge
@@ -260,7 +252,7 @@ func (m *Metrics) RecordClaimAllocatedCPUs(cpus int) {
 type noopRecorder struct{}
 
 // Noop returns a recorder that discards all metric observations.
-func Noop() Recorder {
+func Noop() noopRecorder {
 	return noopRecorder{}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,6 +48,27 @@ func (r Result) String() string {
 	}
 }
 
+type CPUAllocation string
+
+const (
+	CPUAllocationUnknown   CPUAllocation = "unknown"
+	CPUAllocationShared    CPUAllocation = "shared"
+	CPUAllocationExclusive CPUAllocation = "exclusive"
+)
+
+func (c CPUAllocation) String() string {
+	switch c {
+	case CPUAllocationShared:
+		return string(CPUAllocationShared)
+	case CPUAllocationExclusive:
+		return string(CPUAllocationExclusive)
+	case CPUAllocationUnknown:
+		return string(CPUAllocationUnknown)
+	default:
+		return string(CPUAllocationUnknown)
+	}
+}
+
 // Descriptor describes a custom driver metric for programmatic introspection.
 type Descriptor struct {
 	Name      string   `json:"name"`
@@ -67,15 +88,19 @@ type AllocationState struct {
 
 // Metrics owns all custom Prometheus collectors for the CPU driver.
 type Metrics struct {
-	allocatedCPUs        prometheus.Gauge
-	availableCPUs        prometheus.Gauge
-	reservedCPUs         prometheus.Gauge
-	activeResourceClaims prometheus.Gauge
-	prepareClaims          *prometheus.CounterVec
-	unprepareClaims        *prometheus.CounterVec
-	prepareClaimDuration   prometheus.Histogram
-	unprepareClaimDuration prometheus.Histogram
-	claimAllocatedCPUs     prometheus.Histogram
+	allocatedCPUs              prometheus.Gauge
+	availableCPUs              prometheus.Gauge
+	reservedCPUs               prometheus.Gauge
+	activeResourceClaims       prometheus.Gauge
+	prepareClaims              *prometheus.CounterVec
+	unprepareClaims            *prometheus.CounterVec
+	prepareClaimDuration       prometheus.Histogram
+	unprepareClaimDuration     prometheus.Histogram
+	claimAllocatedCPUs         prometheus.Histogram
+	nriSynchronizeDuration     *prometheus.HistogramVec
+	nriCreateContainerDuration *prometheus.HistogramVec
+	nriStopContainerDuration   *prometheus.HistogramVec
+	nriRemoveContainerDuration *prometheus.HistogramVec
 }
 
 type metricKind string
@@ -93,6 +118,14 @@ type metricSpec struct {
 	labels  []string
 	buckets []float64
 }
+
+// nriBuckets are the histogram buckets for NRI hook duration.
+// - 100us-1ms: expected steady state of in-memory operations. We expect the vast majority of samples to land here.
+// - 2.5ms-50ms: estimated range for Synchronize call with a non-trivial container count.
+// - 100ms-500ms: heavy load for any hook, would require further investigation.
+// - 1s, 1.5s, 2s: coarser and coarser before the hard deadline, precursor of hard disconnect which we hit if we cross the hard deadline.
+// - 5s: overflow bucket for pathological cases. Tracks "how bad it was".
+var nriBuckets = []float64{0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 5}
 
 var (
 	allocatedCPUsSpec = metricSpec{
@@ -145,6 +178,34 @@ var (
 		help:    "Number of CPUs allocated for each newly successful claim allocation.",
 		buckets: []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024},
 	}
+	nriSynchronizeDurationSpec = metricSpec{
+		name:    "dra_cpu_nri_synchronize_duration_seconds",
+		kind:    metricHistogram,
+		help:    "Duration of the NRI Synchronize callbacks in seconds.",
+		labels:  []string{"result"},
+		buckets: nriBuckets,
+	}
+	nriCreateContainerDurationSpec = metricSpec{
+		name:    "dra_cpu_nri_create_container_duration_seconds",
+		kind:    metricHistogram,
+		help:    "Duration of the NRI CreateContainer callbacks in seconds.",
+		labels:  []string{"result", "cpu_allocation_mode"},
+		buckets: nriBuckets,
+	}
+	nriStopContainerDurationSpec = metricSpec{
+		name:    "dra_cpu_nri_stop_container_duration_seconds",
+		kind:    metricHistogram,
+		help:    "Duration of the NRI StopContainer callbacks in seconds.",
+		labels:  []string{"result", "cpu_allocation_mode"},
+		buckets: nriBuckets,
+	}
+	nriRemoveContainerDurationSpec = metricSpec{
+		name:    "dra_cpu_nri_remove_container_duration_seconds",
+		kind:    metricHistogram,
+		help:    "Duration of the NRI RemoveContainer callbacks in seconds.",
+		labels:  []string{"result", "cpu_allocation_mode"},
+		buckets: nriBuckets,
+	}
 )
 
 var metricSpecs = []metricSpec{
@@ -157,6 +218,10 @@ var metricSpecs = []metricSpec{
 	prepareClaimDurationSpec,
 	unprepareClaimDurationSpec,
 	claimAllocatedCPUsSpec,
+	nriSynchronizeDurationSpec,
+	nriCreateContainerDurationSpec,
+	nriStopContainerDurationSpec,
+	nriRemoveContainerDurationSpec,
 }
 
 // Descriptors returns metadata for custom CPU driver metrics.
@@ -188,15 +253,19 @@ func New(reg prometheus.Registerer) *Metrics {
 	}
 
 	m := &Metrics{
-		allocatedCPUs:          newGauge(allocatedCPUsSpec),
-		availableCPUs:          newGauge(availableCPUsSpec),
-		reservedCPUs:           newGauge(reservedCPUsSpec),
-		activeResourceClaims:   newGauge(activeResourceClaimsSpec),
-		prepareClaims:          newCounterVec(prepareClaimsSpec),
-		unprepareClaims:        newCounterVec(unprepareClaimsSpec),
-		prepareClaimDuration:   newHistogram(prepareClaimDurationSpec),
-		unprepareClaimDuration: newHistogram(unprepareClaimDurationSpec),
-		claimAllocatedCPUs:     newHistogram(claimAllocatedCPUsSpec),
+		allocatedCPUs:              newGauge(allocatedCPUsSpec),
+		availableCPUs:              newGauge(availableCPUsSpec),
+		reservedCPUs:               newGauge(reservedCPUsSpec),
+		activeResourceClaims:       newGauge(activeResourceClaimsSpec),
+		prepareClaims:              newCounterVec(prepareClaimsSpec),
+		unprepareClaims:            newCounterVec(unprepareClaimsSpec),
+		prepareClaimDuration:       newHistogram(prepareClaimDurationSpec),
+		unprepareClaimDuration:     newHistogram(unprepareClaimDurationSpec),
+		claimAllocatedCPUs:         newHistogram(claimAllocatedCPUsSpec),
+		nriSynchronizeDuration:     newHistogramVec(nriSynchronizeDurationSpec),
+		nriCreateContainerDuration: newHistogramVec(nriCreateContainerDurationSpec),
+		nriStopContainerDuration:   newHistogramVec(nriStopContainerDurationSpec),
+		nriRemoveContainerDuration: newHistogramVec(nriRemoveContainerDurationSpec),
 	}
 
 	reg.MustRegister(
@@ -209,10 +278,22 @@ func New(reg prometheus.Registerer) *Metrics {
 		m.prepareClaimDuration,
 		m.unprepareClaimDuration,
 		m.claimAllocatedCPUs,
+		m.nriSynchronizeDuration,
+		m.nriCreateContainerDuration,
+		m.nriStopContainerDuration,
+		m.nriRemoveContainerDuration,
 	)
 	for _, result := range []Result{ResultSuccess, ResultError, ResultUnknown} {
 		m.prepareClaims.WithLabelValues(result.String())
 		m.unprepareClaims.WithLabelValues(result.String())
+		m.nriSynchronizeDuration.WithLabelValues(result.String())
+	}
+	for _, result := range []Result{ResultSuccess, ResultError, ResultUnknown} {
+		for _, alloc := range []CPUAllocation{CPUAllocationShared, CPUAllocationExclusive} {
+			m.nriCreateContainerDuration.WithLabelValues(result.String(), alloc.String())
+			m.nriStopContainerDuration.WithLabelValues(result.String(), alloc.String())
+			m.nriRemoveContainerDuration.WithLabelValues(result.String(), alloc.String())
+		}
 	}
 	return m
 }
@@ -239,6 +320,14 @@ func newHistogram(spec metricSpec) prometheus.Histogram {
 	})
 }
 
+func newHistogramVec(spec metricSpec) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    spec.name,
+		Help:    spec.help,
+		Buckets: spec.buckets,
+	}, spec.labels)
+}
+
 func (m *Metrics) SetAllocationState(state AllocationState) {
 	m.allocatedCPUs.Set(float64(state.AllocatedCPUs))
 	m.availableCPUs.Set(float64(state.AvailableCPUs))
@@ -260,6 +349,46 @@ func (m *Metrics) RecordClaimAllocatedCPUs(cpus int) {
 	m.claimAllocatedCPUs.Observe(float64(cpus))
 }
 
+func (m *Metrics) RecordNRISynchronize(err error, elapsed time.Duration) {
+	res := determineResult(err)
+	m.nriSynchronizeDuration.WithLabelValues(res.String()).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordNRICreateContainer(err error, claimCount int, elapsed time.Duration) {
+	res := determineResult(err)
+	alloc := determineAllocation(claimCount)
+	m.nriCreateContainerDuration.WithLabelValues(res.String(), alloc.String()).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordNRIStopContainer(err error, claimCount int, elapsed time.Duration) {
+	res := determineResult(err)
+	alloc := determineAllocation(claimCount)
+	m.nriStopContainerDuration.WithLabelValues(res.String(), alloc.String()).Observe(elapsed.Seconds())
+}
+
+func (m *Metrics) RecordNRIRemoveContainer(err error, claimCount int, elapsed time.Duration) {
+	res := determineResult(err)
+	alloc := determineAllocation(claimCount)
+	m.nriRemoveContainerDuration.WithLabelValues(res.String(), alloc.String()).Observe(elapsed.Seconds())
+}
+
+func determineResult(err error) Result {
+	if err != nil {
+		return ResultError
+	}
+	return ResultSuccess
+}
+
+func determineAllocation(claimCount int) CPUAllocation {
+	if claimCount < 0 {
+		return CPUAllocationUnknown
+	}
+	if claimCount == 0 {
+		return CPUAllocationShared
+	}
+	return CPUAllocationExclusive
+}
+
 type noopRecorder struct{}
 
 // Noop returns a recorder that discards all metric observations.
@@ -267,7 +396,11 @@ func Noop() noopRecorder {
 	return noopRecorder{}
 }
 
-func (noopRecorder) SetAllocationState(AllocationState)    {}
-func (noopRecorder) RecordPrepare(Result, time.Duration)   {}
-func (noopRecorder) RecordUnprepare(Result, time.Duration) {}
-func (noopRecorder) RecordClaimAllocatedCPUs(int)          {}
+func (noopRecorder) SetAllocationState(AllocationState)                 {}
+func (noopRecorder) RecordPrepare(Result, time.Duration)                {}
+func (noopRecorder) RecordUnprepare(Result, time.Duration)              {}
+func (noopRecorder) RecordClaimAllocatedCPUs(int)                       {}
+func (noopRecorder) RecordNRISynchronize(error, time.Duration)          {}
+func (noopRecorder) RecordNRICreateContainer(error, int, time.Duration) {}
+func (noopRecorder) RecordNRIStopContainer(error, int, time.Duration)   {}
+func (noopRecorder) RecordNRIRemoveContainer(error, int, time.Duration) {}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestDescriptors(t *testing.T) {
 	descriptors := Descriptors()
-	require.Len(t, descriptors, 8)
+	require.Len(t, descriptors, 9)
 
 	names := make([]string, 0, len(descriptors))
 	for _, desc := range descriptors {
@@ -48,6 +48,7 @@ func TestDescriptors(t *testing.T) {
 		"dra_cpu_prepare_claims_total",
 		"dra_cpu_unprepare_claims_total",
 		"dra_cpu_prepare_claim_duration_seconds",
+		"dra_cpu_unprepare_claim_duration_seconds",
 		"dra_cpu_claim_allocated_cpus",
 	}, names)
 	require.Equal(t, []string{"result"}, descriptors[4].Labels)
@@ -85,6 +86,7 @@ func TestNewRegistersExpectedMetricFamilies(t *testing.T) {
 		"dra_cpu_prepare_claims_total",
 		"dra_cpu_reserved_cpus",
 		"dra_cpu_resource_claims_active",
+		"dra_cpu_unprepare_claim_duration_seconds",
 		"dra_cpu_unprepare_claims_total",
 	}, names)
 }
@@ -101,7 +103,7 @@ func TestMetricsRecordsCollectors(t *testing.T) {
 	})
 	m.RecordPrepare(ResultSuccess, 150*time.Millisecond)
 	m.RecordPrepare(ResultError, 250*time.Millisecond)
-	m.RecordUnprepare(ResultSuccess)
+	m.RecordUnprepare(ResultSuccess, 100*time.Millisecond)
 	m.RecordClaimAllocatedCPUs(2)
 
 	require.InDelta(t, 2, testutil.ToFloat64(m.allocatedCPUs), 0.01)
@@ -116,6 +118,7 @@ func TestMetricsRecordsCollectors(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, families)
 	require.Equal(t, 1, testutil.CollectAndCount(m.prepareClaimDuration))
+	require.Equal(t, 1, testutil.CollectAndCount(m.unprepareClaimDuration))
 	require.Equal(t, 1, testutil.CollectAndCount(m.claimAllocatedCPUs))
 }
 
@@ -125,8 +128,8 @@ func TestDescriptorsMatchRegisteredCollectors(t *testing.T) {
 	m.SetAllocationState(AllocationState{})
 	m.RecordPrepare(ResultSuccess, time.Second)
 	m.RecordPrepare(ResultError, time.Second)
-	m.RecordUnprepare(ResultSuccess)
-	m.RecordUnprepare(ResultError)
+	m.RecordUnprepare(ResultSuccess, time.Second)
+	m.RecordUnprepare(ResultError, time.Second)
 	m.RecordClaimAllocatedCPUs(1)
 
 	families, err := reg.Gather()
@@ -148,7 +151,7 @@ func TestMetricsRejectsUnboundedResultLabels(t *testing.T) {
 	m := New(reg)
 
 	m.RecordPrepare(Result("timeout"), time.Second)
-	m.RecordUnprepare(Result("permission-denied"))
+	m.RecordUnprepare(Result("permission-denied"), time.Second)
 
 	require.InDelta(t, 1, testutil.ToFloat64(m.prepareClaims.WithLabelValues(ResultUnknown.String())), 0.01)
 	require.InDelta(t, 1, testutil.ToFloat64(m.unprepareClaims.WithLabelValues(ResultUnknown.String())), 0.01)
@@ -162,7 +165,7 @@ func TestNoopRecorder(t *testing.T) {
 	require.NotPanics(t, func() {
 		recorder.SetAllocationState(AllocationState{})
 		recorder.RecordPrepare(ResultSuccess, time.Second)
-		recorder.RecordUnprepare(ResultError)
+		recorder.RecordUnprepare(ResultError, time.Second)
 		recorder.RecordClaimAllocatedCPUs(4)
 	})
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestDescriptors(t *testing.T) {
 	descriptors := Descriptors()
-	require.Len(t, descriptors, 9)
+	require.Len(t, descriptors, 13)
 
 	names := make([]string, 0, len(descriptors))
 	for _, desc := range descriptors {
@@ -50,6 +50,10 @@ func TestDescriptors(t *testing.T) {
 		"dra_cpu_prepare_claim_duration_seconds",
 		"dra_cpu_unprepare_claim_duration_seconds",
 		"dra_cpu_claim_allocated_cpus",
+		"dra_cpu_nri_synchronize_duration_seconds",
+		"dra_cpu_nri_create_container_duration_seconds",
+		"dra_cpu_nri_stop_container_duration_seconds",
+		"dra_cpu_nri_remove_container_duration_seconds",
 	}, names)
 	require.Equal(t, []string{"result"}, descriptors[4].Labels)
 	require.Equal(t, []string{"result"}, descriptors[5].Labels)
@@ -82,6 +86,10 @@ func TestNewRegistersExpectedMetricFamilies(t *testing.T) {
 		"dra_cpu_allocated_cpus",
 		"dra_cpu_available_cpus",
 		"dra_cpu_claim_allocated_cpus",
+		"dra_cpu_nri_create_container_duration_seconds",
+		"dra_cpu_nri_remove_container_duration_seconds",
+		"dra_cpu_nri_stop_container_duration_seconds",
+		"dra_cpu_nri_synchronize_duration_seconds",
 		"dra_cpu_prepare_claim_duration_seconds",
 		"dra_cpu_prepare_claims_total",
 		"dra_cpu_reserved_cpus",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -32,6 +32,11 @@ honor these settings, where applicable.
   Please use the go logging configuration for the e2e tests proper.
   There's no support for verbosity levels.
 
+- `DRACPU_E2E_LABEL_FILTER`: (optional) a [Ginkgo label-filter expression](https://onsi.github.io/ginkgo/#spec-labels)
+  used by the Makefile `test-e2e` target to select which specs to run. For example,
+  set it to `metrics` to run only metrics specs, or `!negative` to exclude specs
+  labeled `negative`.
+
 - `DRACPU_E2E_TEST_IMAGE`: (mandatory) the full pullSpec of the test image the suite should
   use as container image to run test containers. The default CI configuration sets this
   value automatically.
@@ -76,6 +81,17 @@ make test-e2e-kind
 ```
 
 This creates a kind cluster from scratch, deploys the driver, and runs the full suite.
+To run only specs labeled `metrics`, use:
+
+```bash
+DRACPU_E2E_LABEL_FILTER=metrics make test-e2e-kind
+```
+
+To run all specs except those labeled `negative` against an existing configured cluster:
+
+```bash
+DRACPU_E2E_LABEL_FILTER='!negative' make test-e2e
+```
 
 To run against an existing cluster with the driver already deployed:
 

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -73,32 +73,44 @@ func (s allocationMetricSnapshot) String() string {
 // This serial spec complements the unit coverage in pkg/driver/metrics_test.go
 // with a real-cluster check that gauge state survives NRI restart and is released
 // again when the workload stops.
-var _ = ginkgo.Describe("Metrics", ginkgo.Serial, func() {
-	ginkgo.It("reconciles allocation metrics across driver restart and workload deletion", func(ctx context.Context) {
-		dracpuTesterImage := os.Getenv("DRACPU_E2E_TEST_IMAGE")
+var _ = ginkgo.When("checking metrics", ginkgo.Serial, ginkgo.Label("metrics"), func() {
+
+	var dracpuTesterImage string
+	var rootFxt *fixture.Fixture
+	var metricsFxt *fixture.Fixture
+	var targetNode *v1.Node
+	var daemonSet *appsv1.DaemonSet
+	var orgDaemonSet *appsv1.DaemonSet
+	var cfgValues driverConfigValues
+	var claimSpec resourcev1.ResourceClaimSpec
+	var rawMetrics string
+	var allocBaseline allocationMetricSnapshot
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		dracpuTesterImage = os.Getenv("DRACPU_E2E_TEST_IMAGE")
 		gomega.Expect(dracpuTesterImage).ToNot(gomega.BeEmpty(), "missing environment variable DRACPU_E2E_TEST_IMAGE")
 
-		rootFxt, err := fixture.ForGinkgo()
+		var err error
+		rootFxt, err = fixture.ForGinkgo()
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot create root fixture: %v", err)
-		metricsFxt := rootFxt.WithPrefix("metrics")
+		metricsFxt = rootFxt.WithPrefix("metrics")
 		gomega.Expect(metricsFxt.Setup(ctx)).To(gomega.Succeed())
 		ginkgo.DeferCleanup(metricsFxt.Teardown)
 
-		targetNode, err := e2enode.PickWorker(ctx, metricsFxt.K8SClientset, 5*time.Second, 1*time.Minute, metricsFxt.Log)
+		targetNode, err = e2enode.PickWorker(ctx, metricsFxt.K8SClientset, 5*time.Second, 1*time.Minute, metricsFxt.Log)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		metricsFxt.Log.Info("using worker node", "nodeName", targetNode.Name)
 
-		daemonSet, err := rootFxt.K8SClientset.AppsV1().DaemonSets(daemonSetNamespace).Get(ctx, driverDaemonSetName, metav1.GetOptions{})
+		daemonSet, err = rootFxt.K8SClientset.AppsV1().DaemonSets(daemonSetNamespace).Get(ctx, driverDaemonSetName, metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get dracpu daemonset")
 		gomega.Expect(daemonSet.Spec.Template.Spec.Containers).ToNot(gomega.BeEmpty(), "no containers in dracpu daemonset")
-		orgDaemonSet := daemonSet.DeepCopy()
+		orgDaemonSet = daemonSet.DeepCopy()
 
-		cfgValues, err := getDriverConfigValues(ctx, rootFxt.K8SClientset, daemonSetNamespace, daemonSet)
+		cfgValues, err = getDriverConfigValues(ctx, rootFxt.K8SClientset, daemonSetNamespace, daemonSet)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot read dracpu driver config values")
 		cpuDeviceMode := cfgValues.CPUDeviceMode
 		groupBy := cfgValues.GroupBy
 
-		var claimSpec resourcev1.ResourceClaimSpec
 		if cpuDeviceMode == "grouped" && groupBy == "machine" {
 			var reservedCPUs cpuset.CPUSet
 			if len(cfgValues.ReservedCPUs) > 0 {
@@ -117,72 +129,85 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Serial, func() {
 			claimSpec = makeResourceClaimSpec(1, cpuDeviceMode == "grouped")
 		}
 
-		baseline, err := getDriverAllocationMetrics(ctx, metricsFxt.K8SClientset, targetNode.Name)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot get baseline allocation metrics")
-		expectBasicMetricPropertiesNow(baseline)
-		if baseline.AvailableCPUs < 1 {
-			ginkgo.Skip(fmt.Sprintf("no available CPUs reported on node %q: %s", targetNode.Name, baseline.String()))
+		rawMetrics, err = getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch raw allocation metrics")
+		allocBaseline, err = parseAllocationMetricSnapshot(rawMetrics)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse baseline allocation metrics")
+		expectBasicMetricPropertiesNow(allocBaseline)
+		if allocBaseline.AvailableCPUs < 1 {
+			ginkgo.Skip(fmt.Sprintf("no available CPUs reported on node %q: %s", targetNode.Name, allocBaseline.String()))
 		}
 
-		claimTemplate := resourcev1.ResourceClaimTemplate{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cpu-claim-metrics",
-			},
-			Spec: resourcev1.ResourceClaimTemplateSpec{
-				Spec: claimSpec,
-			},
-		}
-		createdClaimTemplate, err := metricsFxt.K8SClientset.ResourceV1().ResourceClaimTemplates(metricsFxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
 
-		testerPod := makeTesterPodWithExclusiveCPUClaim(metricsFxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, 1, targetNode.Name, getDriverConfig(ctx, metricsFxt.K8SClientset).PublishNodeAllocatableResourceMapping)
-		createdPod, err := e2epod.CreateSync(ctx, metricsFxt.K8SClientset, testerPod)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	ginkgo.Context("generic", ginkgo.Label("generic"), func() {
+		ginkgo.It("reconciles allocation metrics across driver restart and workload deletion", func(ctx context.Context) {
+			claimTemplate := resourcev1.ResourceClaimTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cpu-claim-metrics",
+				},
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: claimSpec,
+				},
+			}
+			createdClaimTemplate, err := metricsFxt.K8SClientset.ResourceV1().ResourceClaimTemplates(metricsFxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		ginkgo.By("verifying allocation metrics reflect the new claim")
-		gomega.Eventually(func(g gomega.Gomega) {
-			snapshot, err := getDriverAllocationMetrics(ctx, metricsFxt.K8SClientset, targetNode.Name)
-			g.Expect(err).ToNot(gomega.HaveOccurred())
-			expectBasicMetricProperties(g, snapshot)
-			g.Expect(snapshot.TotalCPUs()).To(gomega.Equal(baseline.TotalCPUs()))
-			g.Expect(snapshot.AllocatedCPUs).To(gomega.Equal(baseline.AllocatedCPUs + 1))
-			g.Expect(snapshot.AvailableCPUs).To(gomega.Equal(baseline.AvailableCPUs - 1))
-			g.Expect(snapshot.ReservedCPUs).To(gomega.Equal(baseline.ReservedCPUs))
-			g.Expect(snapshot.ActiveResourceClaims).To(gomega.Equal(baseline.ActiveResourceClaims + 1))
-		}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
+			testerPod := makeTesterPodWithExclusiveCPUClaim(metricsFxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, 1, targetNode.Name, getDriverConfig(ctx, metricsFxt.K8SClientset).PublishNodeAllocatableResourceMapping)
+			createdPod, err := e2epod.CreateSync(ctx, metricsFxt.K8SClientset, testerPod)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		ginkgo.DeferCleanup(func(ctx context.Context) {
+			ginkgo.By("verifying allocation metrics reflect the new claim")
+			gomega.Eventually(func(g gomega.Gomega) {
+				rawMetrics, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch raw allocation metrics")
+				snapshot, err := parseAllocationMetricSnapshot(rawMetrics)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse baseline allocation metrics")
+				expectBasicMetricProperties(g, snapshot)
+				g.Expect(snapshot.TotalCPUs()).To(gomega.Equal(allocBaseline.TotalCPUs()))
+				g.Expect(snapshot.AllocatedCPUs).To(gomega.Equal(allocBaseline.AllocatedCPUs + 1))
+				g.Expect(snapshot.AvailableCPUs).To(gomega.Equal(allocBaseline.AvailableCPUs - 1))
+				g.Expect(snapshot.ReservedCPUs).To(gomega.Equal(allocBaseline.ReservedCPUs))
+				g.Expect(snapshot.ActiveResourceClaims).To(gomega.Equal(allocBaseline.ActiveResourceClaims + 1))
+			}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
+
+			ginkgo.DeferCleanup(func(ctx context.Context) {
+				restoreDriverDaemonSet(ctx, rootFxt.K8SClientset, orgDaemonSet)
+			})
+
+			ginkgo.By("stopping the driver on the target node")
+			excludeNodeFromDriverDaemonSet(ctx, rootFxt.K8SClientset, targetNode.Name)
+			waitForDriverPodTerminationOnNode(ctx, rootFxt.K8SClientset, targetNode.Name)
+
+			ginkgo.By("restoring the driver on the target node")
 			restoreDriverDaemonSet(ctx, rootFxt.K8SClientset, orgDaemonSet)
+			waitForDriverPodReadyOnNode(ctx, rootFxt.K8SClientset, targetNode.Name)
+
+			ginkgo.By("verifying allocation metrics were rebuilt after restart")
+			gomega.Eventually(func(g gomega.Gomega) {
+				rawMetrics, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch raw allocation metrics")
+				snapshot, err := parseAllocationMetricSnapshot(rawMetrics)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse baseline allocation metrics")
+				expectBasicMetricProperties(g, snapshot)
+				g.Expect(snapshot.TotalCPUs()).To(gomega.Equal(allocBaseline.TotalCPUs()))
+				g.Expect(snapshot.AllocatedCPUs).To(gomega.Equal(allocBaseline.AllocatedCPUs + 1))
+				g.Expect(snapshot.AvailableCPUs).To(gomega.Equal(allocBaseline.AvailableCPUs - 1))
+				g.Expect(snapshot.ReservedCPUs).To(gomega.Equal(allocBaseline.ReservedCPUs))
+				g.Expect(snapshot.ActiveResourceClaims).To(gomega.Equal(allocBaseline.ActiveResourceClaims + 1))
+			}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
+
+			ginkgo.By("deleting the workload and verifying allocation metrics return to baseline")
+			gomega.Expect(e2epod.DeleteSync(ctx, metricsFxt.K8SClientset, createdPod)).To(gomega.Succeed(), "cannot delete tester pod %s", e2epod.Identify(createdPod))
+			gomega.Eventually(func(g gomega.Gomega) {
+				rawMetrics, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch raw allocation metrics")
+				snapshot, err := parseAllocationMetricSnapshot(rawMetrics)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse baseline allocation metrics")
+				expectBasicMetricProperties(g, snapshot)
+				g.Expect(snapshot).To(gomega.Equal(allocBaseline))
+			}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
 		})
-
-		ginkgo.By("stopping the driver on the target node")
-		excludeNodeFromDriverDaemonSet(ctx, rootFxt.K8SClientset, targetNode.Name)
-		waitForDriverPodTerminationOnNode(ctx, rootFxt.K8SClientset, targetNode.Name)
-
-		ginkgo.By("restoring the driver on the target node")
-		restoreDriverDaemonSet(ctx, rootFxt.K8SClientset, orgDaemonSet)
-		waitForDriverPodReadyOnNode(ctx, rootFxt.K8SClientset, targetNode.Name)
-
-		ginkgo.By("verifying allocation metrics were rebuilt after restart")
-		gomega.Eventually(func(g gomega.Gomega) {
-			snapshot, err := getDriverAllocationMetrics(ctx, metricsFxt.K8SClientset, targetNode.Name)
-			g.Expect(err).ToNot(gomega.HaveOccurred())
-			expectBasicMetricProperties(g, snapshot)
-			g.Expect(snapshot.TotalCPUs()).To(gomega.Equal(baseline.TotalCPUs()))
-			g.Expect(snapshot.AllocatedCPUs).To(gomega.Equal(baseline.AllocatedCPUs + 1))
-			g.Expect(snapshot.AvailableCPUs).To(gomega.Equal(baseline.AvailableCPUs - 1))
-			g.Expect(snapshot.ReservedCPUs).To(gomega.Equal(baseline.ReservedCPUs))
-			g.Expect(snapshot.ActiveResourceClaims).To(gomega.Equal(baseline.ActiveResourceClaims + 1))
-		}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
-
-		ginkgo.By("deleting the workload and verifying allocation metrics return to baseline")
-		gomega.Expect(e2epod.DeleteSync(ctx, metricsFxt.K8SClientset, createdPod)).To(gomega.Succeed(), "cannot delete tester pod %s", e2epod.Identify(createdPod))
-		gomega.Eventually(func(g gomega.Gomega) {
-			snapshot, err := getDriverAllocationMetrics(ctx, metricsFxt.K8SClientset, targetNode.Name)
-			g.Expect(err).ToNot(gomega.HaveOccurred())
-			expectBasicMetricProperties(g, snapshot)
-			g.Expect(snapshot).To(gomega.Equal(baseline))
-		}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
 	})
 })
 
@@ -208,22 +233,22 @@ func discoverAvailableCPUs(ctx context.Context, fxt *fixture.Fixture, nodeName, 
 	return allocatableCPUs.Difference(reservedCPUs), nil
 }
 
-func getDriverAllocationMetrics(ctx context.Context, cs kubernetes.Interface, nodeName string) (allocationMetricSnapshot, error) {
-	dracpuPod, err := e2epod.GetDRACPUPod(ctx, cs, nodeName)
+func getDriverRawMetrics(ctx context.Context, fxt *fixture.Fixture, nodeName string) (string, error) {
+	dracpuPod, err := e2epod.GetDRACPUPod(ctx, fxt.K8SClientset, nodeName)
 	if err != nil {
-		return allocationMetricSnapshot{}, err
+		return "", err
 	}
 
-	podIP, err := waitForPodIP(ctx, cs, dracpuPod.Name)
+	podIP, err := waitForPodIP(ctx, fxt.K8SClientset, dracpuPod.Name)
 	if err != nil {
-		return allocationMetricSnapshot{}, err
+		return "", err
 	}
 
 	rawMetrics, err := getMetricsFromPodIP(podIP)
 	if err != nil {
-		return allocationMetricSnapshot{}, fmt.Errorf("cannot get metrics from the dracpu pod: %w", err)
+		return "", fmt.Errorf("cannot get metrics from the dracpu pod: %w", err)
 	}
-	return parseAllocationMetricSnapshot(rawMetrics)
+	return rawMetrics, nil
 }
 
 func metricsURL(podIP string) string {

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -21,9 +21,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"iter"
 	"math"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -206,6 +208,115 @@ var _ = ginkgo.When("checking metrics", ginkgo.Serial, ginkgo.Label("metrics"), 
 				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse baseline allocation metrics")
 				expectBasicMetricProperties(g, snapshot)
 				g.Expect(snapshot).To(gomega.Equal(allocBaseline))
+			}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.Context("NRI specific", func() {
+		ginkgo.It("reconciles metrics across driver restart and workload deletion", func(ctx context.Context) {
+			rawMetrics, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch baseline NRI metrics")
+			baseline, err := parseNRIMetricSnapshot(rawMetrics)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse baseline NRI metrics")
+			expectBasicNRIMetricPropertiesNow(baseline)
+
+			claimTemplate := resourcev1.ResourceClaimTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cpu-claim-metrics",
+				},
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: claimSpec,
+				},
+			}
+			createdClaimTemplate, err := metricsFxt.K8SClientset.ResourceV1().ResourceClaimTemplates(metricsFxt.Namespace.Name).Create(ctx, &claimTemplate, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			testerPod := makeTesterPodWithExclusiveCPUClaim(metricsFxt.Namespace.Name, dracpuTesterImage, createdClaimTemplate.Name, 1, targetNode.Name, getDriverConfig(ctx, metricsFxt.K8SClientset).PublishNodeAllocatableResourceMapping)
+			createdPod, err := e2epod.CreateSync(ctx, metricsFxt.K8SClientset, testerPod)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			ginkgo.By("verifying NRI metrics reflect the new claim")
+			gomega.Eventually(func(g gomega.Gomega) {
+				rawMetrics, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch raw NRI metrics snapshot")
+				snapshot, err := parseNRIMetricSnapshot(rawMetrics)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse raw NRI metrics snapshot")
+				expectBasicNRIMetricProperties(g, snapshot)
+				for key := range expectedNRIMetricKeys() {
+					if key.Name != "dra_cpu_nri_create_container_duration_seconds" {
+						continue
+					}
+					var delta uint64
+					if key.Result == "success" && key.CPUAllocationMode == "exclusive" {
+						delta = 1
+					}
+					expectNRIChange(g, baseline, snapshot, delta, key)
+				}
+			}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
+
+			ginkgo.DeferCleanup(func(ctx context.Context) {
+				restoreDriverDaemonSet(ctx, metricsFxt.K8SClientset, orgDaemonSet)
+			})
+
+			ginkgo.By("stopping the driver on the target node")
+			excludeNodeFromDriverDaemonSet(ctx, metricsFxt.K8SClientset, targetNode.Name)
+			waitForDriverPodTerminationOnNode(ctx, metricsFxt.K8SClientset, targetNode.Name)
+
+			ginkgo.By("restoring the driver on the target node")
+			restoreDriverDaemonSet(ctx, metricsFxt.K8SClientset, orgDaemonSet)
+			waitForDriverPodReadyOnNode(ctx, metricsFxt.K8SClientset, targetNode.Name)
+
+			rawMetricsRestarted, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch baseline NRI metrics post driver restart")
+			baselineRestarted, err := parseNRIMetricSnapshot(rawMetricsRestarted)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse baseline NRI metrics post driver restart")
+			expectBasicNRIMetricPropertiesNow(baselineRestarted)
+
+			ginkgo.By("verifying NRI metrics correctly reflect synchronization on restart")
+			gomega.Eventually(func(g gomega.Gomega) {
+				rawMetrics, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch raw NRI metrics snapshot")
+				snapshot, err := parseNRIMetricSnapshot(rawMetrics)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse raw NRI metrics snapshot")
+				expectBasicNRIMetricProperties(g, snapshot)
+
+				for result, expectedCount := range map[string]uint64{
+					"success": 1,
+					"error":   0,
+					"unknown": 0,
+				} {
+					key := nriMetricKey{Name: "dra_cpu_nri_synchronize_duration_seconds", Result: result}
+					syncHist, ok := snapshot.Histograms[key]
+					g.Expect(ok).To(gomega.BeTrue(), "missing metric for %s synchronize", result)
+					g.Expect(syncHist.Count).To(gomega.Equal(expectedCount), "unexpected synchronize %s count %d", result, syncHist.Count)
+				}
+			}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
+
+			ginkgo.By("deleting the workload and verifying NRI metrics update accordingly")
+			gomega.Expect(e2epod.DeleteSync(ctx, metricsFxt.K8SClientset, createdPod)).To(gomega.Succeed(), "cannot delete tester pod %s", e2epod.Identify(createdPod))
+			gomega.Eventually(func(g gomega.Gomega) {
+				rawMetrics, err := getDriverRawMetrics(ctx, metricsFxt, targetNode.Name)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot fetch raw NRI metrics snapshot")
+				snapshot, err := parseNRIMetricSnapshot(rawMetrics)
+				g.Expect(err).ToNot(gomega.HaveOccurred(), "cannot parse raw NRI metrics snapshot")
+				expectBasicNRIMetricProperties(g, snapshot)
+				for key := range expectedNRIMetricKeys() {
+					if key.Name != "dra_cpu_nri_stop_container_duration_seconds" {
+						continue
+					}
+					var delta uint64
+					if key.Result == "success" && key.CPUAllocationMode == "exclusive" {
+						delta = 1
+					}
+					expectNRIChange(g, baselineRestarted, snapshot, delta, key)
+				}
+				for key := range expectedNRIMetricKeys() {
+					if key.Name != "dra_cpu_nri_remove_container_duration_seconds" {
+						continue
+					}
+					delta := uint64(0)
+					expectNRIChange(g, baselineRestarted, snapshot, delta, key)
+				}
 			}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed())
 		})
 	})
@@ -439,4 +550,186 @@ func waitForDriverPodReadyOnNode(ctx context.Context, cs kubernetes.Interface, n
 		}
 		g.Expect(ready).To(gomega.BeTrue(), "driver pod on node %q is not ready", nodeName)
 	}).WithTimeout(driverPodPollTimeout).WithPolling(driverPodPollInterval).Should(gomega.Succeed(), "timed out waiting for pod to become ready")
+}
+
+type nriMetricKey struct {
+	Name              string
+	Result            string
+	CPUAllocationMode string
+}
+
+type nriHistogramSnapshot struct {
+	Count   uint64
+	Sum     float64
+	Buckets map[float64]uint64
+}
+
+type nriMetricSnapshot struct {
+	Histograms map[nriMetricKey]nriHistogramSnapshot
+}
+
+func expectNRIChange(g gomega.Gomega, prev, cur nriMetricSnapshot, delta uint64, key nriMetricKey) {
+	prevHist, ok := prev.Histograms[key]
+	g.Expect(ok).To(gomega.BeTrue(), "missing previous sample for %q", key)
+	curHist, ok := cur.Histograms[key]
+	g.Expect(ok).To(gomega.BeTrue(), "missing current sample for %q", key)
+	dt := curHist.Count - prevHist.Count
+	g.Expect(dt).To(gomega.Equal(delta), "computed delta %d different from expected delta %d", dt, delta)
+}
+
+func expectBasicNRIMetricPropertiesNow(snapshot nriMetricSnapshot) {
+	ginkgo.GinkgoHelper()
+	for key := range expectedNRIMetricKeys() {
+		hist, ok := snapshot.Histograms[key]
+		gomega.Expect(ok).To(gomega.BeTrue(), "missing expected key %q", key)
+		gomega.Expect(hist.Sum).To(gomega.BeNumerically(">=", 0), "sum for key %q must be non-negative", key)
+		gomega.Expect(hist.Buckets).ToNot(gomega.BeEmpty(), "histogram for key %q has no buckets", key)
+
+		upperBounds := make([]float64, 0, len(hist.Buckets))
+		for upperBound := range hist.Buckets {
+			upperBounds = append(upperBounds, upperBound)
+		}
+		sort.Float64s(upperBounds)
+
+		var previousCount uint64
+		for _, upperBound := range upperBounds {
+			count := hist.Buckets[upperBound]
+			// Prometheus histogram buckets are cumulative: each bucket includes all
+			// observations in the preceding buckets, and cannot exceed the total count.
+			gomega.Expect(count).To(gomega.BeNumerically("<=", hist.Count), "bucket %v for key %q exceeds the total count", upperBound, key)
+			gomega.Expect(count).To(gomega.BeNumerically(">=", previousCount), "bucket counts for key %q must be cumulative", key)
+			previousCount = count
+		}
+	}
+}
+
+func expectBasicNRIMetricProperties(g gomega.Gomega, snapshot nriMetricSnapshot) {
+	ginkgo.GinkgoHelper()
+	for key := range expectedNRIMetricKeys() {
+		hist, ok := snapshot.Histograms[key]
+		g.Expect(ok).To(gomega.BeTrue(), "missing expected key %q", key)
+		g.Expect(hist.Sum).To(gomega.BeNumerically(">=", 0), "sum for key %q must be non-negative", key)
+		g.Expect(hist.Buckets).ToNot(gomega.BeEmpty(), "histogram for key %q has no buckets", key)
+
+		upperBounds := make([]float64, 0, len(hist.Buckets))
+		for upperBound := range hist.Buckets {
+			upperBounds = append(upperBounds, upperBound)
+		}
+		sort.Float64s(upperBounds)
+
+		var previousCount uint64
+		for _, upperBound := range upperBounds {
+			count := hist.Buckets[upperBound]
+			// Prometheus histogram buckets are cumulative: each bucket includes all
+			// observations in the preceding buckets, and cannot exceed the total count.
+			g.Expect(count).To(gomega.BeNumerically("<=", hist.Count), "bucket %v for key %q exceeds the total count", upperBound, key)
+			g.Expect(count).To(gomega.BeNumerically(">=", previousCount), "bucket counts for key %q must be cumulative", key)
+			previousCount = count
+		}
+	}
+}
+
+func parseNRIMetricSnapshot(rawMetrics string) (nriMetricSnapshot, error) {
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(rawMetrics))
+	if err != nil {
+		return nriMetricSnapshot{}, err
+	}
+
+	expectedLabels := map[string]map[string]bool{
+		"dra_cpu_nri_synchronize_duration_seconds":      {"result": true},
+		"dra_cpu_nri_create_container_duration_seconds": {"result": true, "cpu_allocation_mode": true},
+		"dra_cpu_nri_stop_container_duration_seconds":   {"result": true, "cpu_allocation_mode": true},
+		"dra_cpu_nri_remove_container_duration_seconds": {"result": true, "cpu_allocation_mode": true},
+	}
+
+	snapshot := nriMetricSnapshot{Histograms: make(map[nriMetricKey]nriHistogramSnapshot)}
+	for metricName, labels := range expectedLabels {
+		family, ok := families[metricName]
+		if !ok {
+			return nriMetricSnapshot{}, fmt.Errorf("metric %q not found", metricName)
+		}
+		if family.GetType() != dto.MetricType_HISTOGRAM {
+			return nriMetricSnapshot{}, fmt.Errorf("metric %q has unexpected type %q", metricName, family.GetType())
+		}
+
+		for _, metric := range family.Metric {
+			metricLabels := make(map[string]string, len(metric.Label))
+			for _, label := range metric.Label {
+				labelName := label.GetName()
+				if !labels[labelName] {
+					return nriMetricSnapshot{}, fmt.Errorf("metric %q has unexpected label %q", metricName, labelName)
+				}
+				if _, duplicate := metricLabels[labelName]; duplicate {
+					return nriMetricSnapshot{}, fmt.Errorf("metric %q has duplicate label %q", metricName, labelName)
+				}
+				metricLabels[labelName] = label.GetValue()
+			}
+			for labelName := range labels {
+				if _, found := metricLabels[labelName]; !found {
+					return nriMetricSnapshot{}, fmt.Errorf("metric %q is missing label %q", metricName, labelName)
+				}
+			}
+
+			histogram := metric.GetHistogram()
+			if histogram == nil {
+				return nriMetricSnapshot{}, fmt.Errorf("metric %q has no histogram value", metricName)
+			}
+			key := nriMetricKey{
+				Name:              metricName,
+				Result:            metricLabels["result"],
+				CPUAllocationMode: metricLabels["cpu_allocation_mode"],
+			}
+			if _, duplicate := snapshot.Histograms[key]; duplicate {
+				return nriMetricSnapshot{}, fmt.Errorf("metric %q has duplicate series for result=%q, cpu_allocation_mode=%q", metricName, key.Result, key.CPUAllocationMode)
+			}
+
+			buckets := make(map[float64]uint64, len(histogram.Bucket))
+			for _, bucket := range histogram.Bucket {
+				upperBound := bucket.GetUpperBound()
+				if _, duplicate := buckets[upperBound]; duplicate {
+					return nriMetricSnapshot{}, fmt.Errorf("metric %q has duplicate bucket with upper bound %v", metricName, upperBound)
+				}
+				buckets[upperBound] = bucket.GetCumulativeCount()
+			}
+			snapshot.Histograms[key] = nriHistogramSnapshot{
+				Count:   histogram.GetSampleCount(),
+				Sum:     histogram.GetSampleSum(),
+				Buckets: buckets,
+			}
+		}
+	}
+
+	return snapshot, nil
+}
+
+func expectedNRIMetricKeys() iter.Seq[nriMetricKey] {
+	return func(yield func(nriMetricKey) bool) {
+		for _, result := range []string{"success", "error", "unknown"} {
+			if !yield(nriMetricKey{
+				Name:   "dra_cpu_nri_synchronize_duration_seconds",
+				Result: result,
+			}) {
+				return
+			}
+		}
+
+		for _, metricName := range []string{
+			"dra_cpu_nri_create_container_duration_seconds",
+			"dra_cpu_nri_stop_container_duration_seconds",
+			"dra_cpu_nri_remove_container_duration_seconds",
+		} {
+			for _, result := range []string{"success", "error", "unknown"} {
+				for _, allocationMode := range []string{"shared", "exclusive"} {
+					if !yield(nriMetricKey{
+						Name:              metricName,
+						Result:            result,
+						CPUAllocationMode: allocationMode,
+					}) {
+						return
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Spawned of after a concern emerged in https://github.com/kubernetes-sigs/dra-driver-cpu/pull/270#discussion_r3692378266 . We want to have a way to monitor performance in CI (or in general be able to do performance assessment), but this is yet to materialize and a non-trivial effort. A complementary and cheaper improvement is to export metrics about the NRI callback duration, so we can have visibility about how we are doing, and at least some data to work with.
We can probably build the performance measurement/tests on top of these metrics in the future, but this is yet to be decided.

#### Which issue(s) this PR is related to

N/A

#### Special notes for reviewers

AI usage disclosure: I use AI to accelerate the initial refactoring, but under close supervision.
I use AI to accelerate the writing of e2e test *utilities*. The e2e flow and expectations were written by a human

#### Release note

```release-note
Add prometheus metrics for NRI callbacks duration
```

#### Documentation updates

- user documentation